### PR TITLE
feat: new --watch option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,9 +35,11 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/gookit/color v1.5.4 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
+	github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -57,6 +59,7 @@ require (
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
 	github.com/yuin/goldmark v1.7.0 // indirect
 	github.com/yuin/goldmark-emoji v1.0.2 // indirect
+	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/evandro-slv/go-cli-charts v0.0.0-20191022204244-4ef8459d5f4d h1:6//xY
 github.com/evandro-slv/go-cli-charts v0.0.0-20191022204244-4ef8459d5f4d/go.mod h1:KqPtENPp5GIJlV5oaDkDbakg3lXDUD1VVB9mJDReRLM=
 github.com/flosch/pongo2/v5 v5.0.0 h1:ZauMp+iPZzh2aI1QM2UwRb0lXD4BoFcvBuWqefkIuq0=
 github.com/flosch/pongo2/v5 v5.0.0/go.mod h1:6ysKu++8ANFXmc3x6uA6iVaS+PKUoDfdX3yPcv8TIzY=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-python/gpython v0.2.0 h1:MW7m7pFnbpzHL88vhAdIhT1pgG1QUZ0Q5jcF94z5MBI=
 github.com/go-python/gpython v0.2.0/go.mod h1:fUN4z1X+GFaOwPOoHOAM8MOPnh1NJatWo/cDqGlZDEI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -83,6 +85,8 @@ github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
+github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3 h1:fO9A67/izFYFYky7l1pDP5Dr0BTCRkaQJUG6Jm5ehsk=
+github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3/go.mod h1:Ey4uAp+LvIl+s5jRbOHLcZpUDnkjLBROl15fZLwPlTM=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.10/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
@@ -195,6 +199,8 @@ github.com/yuin/goldmark-emoji v1.0.2 h1:c/RgTShNgHTtc6xdz2KKI74jJr6rWi7FPgnP9GA
 github.com/yuin/goldmark-emoji v1.0.2/go.mod h1:RhP/RWpexdp+KHs7ghKnifRoIs/Bq4nDS7tRbCkOwKY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
+golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/halleck45/ast-metrics/src/Engine/Golang"
 	"github.com/halleck45/ast-metrics/src/Engine/Php"
 	"github.com/halleck45/ast-metrics/src/Engine/Python"
+	"github.com/halleck45/ast-metrics/src/Watcher"
 	"github.com/pterm/pterm"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -68,6 +69,12 @@ func main() {
 						Name:     "report-markdown",
 						Usage:    "Generate an Markdown report file",
 						Category: "Report",
+					},
+					// Watch mode
+					&cli.BoolFlag{
+						Name:     "watch",
+						Usage:    "Re-run the analysis when files change",
+						Category: "Global options",
 					},
 				},
 				Action: func(cCtx *cli.Context) error {
@@ -130,6 +137,15 @@ func main() {
 
 					// Run command
 					command := Command.NewAnalyzeCommand(configuration, outWriter, runners, isInteractive)
+
+					// Watch mode
+					configuration.Watching = cCtx.Bool("watch")
+					err = Watcher.NewCommandWatcher(configuration).Start(command)
+					if err != nil {
+						pterm.Error.Println("Cannot watch files: " + err.Error())
+					}
+
+					// Execute command
 					err = command.Execute()
 					if err != nil {
 						pterm.Error.Println(err.Error())

--- a/src/Analyzer/Activity/BusFactor.go
+++ b/src/Analyzer/Activity/BusFactor.go
@@ -20,6 +20,11 @@ func (busFactor *BusFactor) Calculate(aggregate *Analyzer.Aggregated) {
 	files := aggregate.ConcernedFiles
 	commits := make(map[string]int)
 	for _, file := range files {
+
+		if file.Commits == nil {
+			continue
+		}
+		
 		for _, commit := range file.Commits.Commits {
 
 			// Exclude commits with no author or from noreply@github.com

--- a/src/Cli/ComponentClassTable.go
+++ b/src/Cli/ComponentClassTable.go
@@ -22,15 +22,15 @@ type ComponentTableClass struct {
 
 // index of cols
 var cols = map[string]int{
-	"Name":              0,
-	"Commits":           1,
-	"Authors":           2,
-	"Methods":           3,
-	"LLoc":              4,
-	"Cyclomatic":        5,
-	"Halstead Length":   6,
-	"Halstead Volume":   7,
-	"Maintainability":   8,
+	"Name":            0,
+	"Commits":         1,
+	"Authors":         2,
+	"Methods":         3,
+	"LLoc":            4,
+	"Cyclomatic":      5,
+	"Halstead Length": 6,
+	"Halstead Volume": 7,
+	"Maintainability": 8,
 }
 
 func NewComponentTableClass(isInteractive bool, files []*pb.File) *ComponentTableClass {
@@ -245,6 +245,10 @@ func (v *ComponentTableClass) Update(msg tea.Msg) {
 		case "n":
 			v.SortByName()
 		}
+	case DoRefreshModel:
+		// refresh the model
+		v.files = msg.files
+		v.Init()
 	}
 
 	v.table, _ = v.table.Update(msg)

--- a/src/Cli/ComponentFileTable.go
+++ b/src/Cli/ComponentFileTable.go
@@ -52,7 +52,7 @@ func (v *ComponentFileTable) Render() string {
 func (v *ComponentFileTable) Init() {
 
 	columns := []table.Column{
-		{Title: "File", Width: 75},
+		{Title: "File", Width: 70},
 		{Title: "Commits", Width: 9},
 		{Title: "Authors", Width: 9},
 		{Title: "LOC", Width: 9},

--- a/src/Cli/Screen.go
+++ b/src/Cli/Screen.go
@@ -2,6 +2,8 @@ package Cli
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/halleck45/ast-metrics/src/Analyzer"
+	pb "github.com/halleck45/ast-metrics/src/NodeType"
 )
 
 type Screen interface {
@@ -11,4 +13,6 @@ type Screen interface {
 
 	// Returns the name of the screen
 	GetScreenName() string
+
+	Reset(files []*pb.File, projectAggregated Analyzer.ProjectAggregated)
 }

--- a/src/Cli/ScreenByProgrammingLangage.go
+++ b/src/Cli/ScreenByProgrammingLangage.go
@@ -35,6 +35,10 @@ func (m modelByProgrammingLanguage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q", "ctrl+c", "esc":
 			return NewScreenHome(true, m.files, m.projectAggregated).GetModel(), tea.ClearScreen
 		}
+	case DoRefreshModel:
+		// refresh the model
+		m.files = msg.files
+		m.projectAggregated = msg.projectAggregated
 	}
 
 	m.componentTableClass.Update(msg)
@@ -51,6 +55,11 @@ func (m modelByProgrammingLanguage) View() string {
 	return StyleScreen(StyleTitle(m.programmingLangageName+" overview").Render() +
 		header.Render() +
 		"\n\n" + m.componentTableClass.Render()).Render()
+}
+
+func (v *ScreenByProgrammingLanguage) Reset(files []*pb.File, projectAggregated Analyzer.ProjectAggregated) {
+	v.files = files
+	v.projectAggregated = projectAggregated
 }
 
 func (v ScreenByProgrammingLanguage) GetScreenName() string {

--- a/src/Cli/ScreenSummary.go
+++ b/src/Cli/ScreenSummary.go
@@ -43,6 +43,11 @@ func (m modelScreenSummary) Init() tea.Cmd {
 	return nil
 }
 
+func (m *ScreenSummary) Reset(files []*pb.File, projectAggregated Analyzer.ProjectAggregated) {
+	m.files = files
+	m.projectAggregated = projectAggregated
+}
+
 func (m modelScreenSummary) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -50,6 +55,11 @@ func (m modelScreenSummary) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q", "ctrl+c", "esc":
 			return NewScreenHome(true, m.files, m.projectAggregated).GetModel(), tea.ClearScreen
 		}
+	case DoRefreshModel:
+		// refresh the model
+		m.files = msg.files
+		m.projectAggregated = msg.projectAggregated
+		return m, nil
 	}
 	return m, nil
 }

--- a/src/Cli/ScreenTableClass.go
+++ b/src/Cli/ScreenTableClass.go
@@ -37,6 +37,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q", "ctrl+c", "esc":
 			return NewScreenHome(true, m.files, m.projectAggregated).GetModel(), tea.ClearScreen
 		}
+	case DoRefreshModel:
+		// refresh the model
+		m.files = msg.files
+		m.projectAggregated = msg.projectAggregated
 	}
 
 	m.table.Update(msg)
@@ -50,6 +54,11 @@ func (m model) View() string {
 
 func (v ScreenTableClass) GetScreenName() string {
 	return "Classes and object oriented statistics"
+}
+
+func (v *ScreenTableClass) Reset(files []*pb.File, projectAggregated Analyzer.ProjectAggregated) {
+	v.files = files
+	v.projectAggregated = projectAggregated
 }
 
 func (v ScreenTableClass) GetModel() tea.Model {

--- a/src/Configuration/Configuration.go
+++ b/src/Configuration/Configuration.go
@@ -15,12 +15,14 @@ type Configuration struct {
 	// Reports
 	HtmlReportPath string
 	MarkdownReportPath string
+	Watching bool
 }
 
 func NewConfiguration() *Configuration {
 	return &Configuration{
 		SourcesToAnalyzePath: []string{},
 		ExcludePatterns:      []string{"/vendor/", "/node_modules/", "/.git/", "/.idea/", "/tests/", "/Tests/", "/test/", "/Test/", "/spec/", "/Spec/"},
+		Watching: false,
 	}
 }
 

--- a/src/Engine/util.go
+++ b/src/Engine/util.go
@@ -3,6 +3,7 @@ package Engine
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -82,6 +83,27 @@ func DumpProtobuf(file *pb.File, binPath string) {
 	if err != nil {
 		log.Error(err)
 	}
+}
+
+func UnmarshalProtobuf(file string) (*pb.File, error) {
+	pbFile := &pb.File{}
+
+	// load AST via ProtoBuf (using NodeType package)
+	in, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	// if file is empty, return
+	if len(in) == 0 {
+		return nil, errors.New("File is empty: " + file)
+	}
+
+	if err := proto.Unmarshal(in, pbFile); err != nil {
+		return nil, err
+	}
+
+	return pbFile, nil
 }
 
 // FactoryStmts returns a new instance of Stmts

--- a/src/Watcher/CommandWatcher.go
+++ b/src/Watcher/CommandWatcher.go
@@ -1,0 +1,103 @@
+package Watcher
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/halleck45/ast-metrics/src/Command"
+	"github.com/halleck45/ast-metrics/src/Configuration"
+	"github.com/halleck45/ast-metrics/src/Storage"
+	log "github.com/sirupsen/logrus"
+)
+
+type CommandWatcher struct {
+	// The path to the sources to analyze
+	SourcesToAnalyzePath []string
+
+	// Configuration
+	Configuration *Configuration.Configuration
+}
+
+func NewCommandWatcher(configuration *Configuration.Configuration) *CommandWatcher {
+	return &CommandWatcher{
+		Configuration:        configuration,
+		SourcesToAnalyzePath: configuration.SourcesToAnalyzePath,
+	}
+}
+
+func (c *CommandWatcher) Start(command *Command.AnalyzeCommand) error {
+	if !c.Configuration.Watching {
+		return nil
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	command.FileWatcher = watcher
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get subdirectories in all sources
+	subdirectories := []string{}
+	for _, path := range c.SourcesToAnalyzePath {
+		// explore the directory
+		err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				subdirectories = append(subdirectories, path)
+			}
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Start listening for events.
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+
+				// Ignore swp files
+				if filepath.Ext(event.Name) == ".swp" {
+					continue
+				}
+				// when last character is ~, it's a backup file
+				if event.Name[len(event.Name)-1] == '~' {
+					continue
+				}
+
+				// get file concerned by the event, and remove it from cache
+				Storage.DeleteCache(event.Name)
+
+				// Re-execute analyze command
+				command.Execute()
+
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				fmt.Println("error:", err)
+			}
+		}
+	}()
+
+	// watch all subdirectories
+	for _, dir := range subdirectories {
+		err = watcher.Add(dir)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add a new ` --watch` option. When used, screen (and HTML report) is updated when file is updated.

[Screen recording 2024-03-23 16.50.40.webm](https://github.com/Halleck45/ast-metrics/assets/1076296/f5bedea5-f8a8-439f-b39d-52ff3a3db6f3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced watch mode to rerun analysis automatically when files change.
	- Added functionality to skip processing files with no commits in analysis.
	- Implemented screen refresh logic to update data in real-time during file changes.
- **Bug Fixes**
	- Corrected column width in file table display for better readability.
- **Refactor**
	- Enhanced command-line interface components with new methods for dynamic updates.
	- Updated configuration to support watch mode.
- **Chores**
	- Integrated new external packages for file watching and screen management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->