### PR TITLE
docs: Adapt links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 AST Metrics is a blazing-fast static code analyzer. It provides metrics about your code, and helps you to identify potential problems early on. 
 
-[Documentation](https://phpmetrics.github.io/website/) | [Twitter](https://twitter.com/Halleck45) | [Contributing](https://github.com/phpmetrics/PhpMetrics/blob/master/doc/contributing.md)
+[Documentation](https://halleck45.github.io/ast-metrics/) | [Twitter](https://twitter.com/Halleck45)
 
 <br/><br/>
 <br/><br/>


### PR DESCRIPTION
They seem to have been copy/pasted from PhpMetrics' README. I removed the link to the contributing guide because I could not find an equivalent.