### PR TITLE
Added the `--report-openmetrics` option, allowing OpenMetrics reports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/bsm/openmetrics v0.3.1 // indirect
 	github.com/containerd/console v1.0.4 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/bsm/openmetrics v0.3.1 h1:nhR6QgaKaDmnbnvVP9R0JyPExt8Qa+n1cJk/ouGC4FY=
+github.com/bsm/openmetrics v0.3.1/go.mod h1:tabLMhjVjhdhFuwm9YenEVx0s54uvu56faEwYgD6L2g=
 github.com/charmbracelet/bubbles v0.18.0 h1:PYv1A036luoBGroX6VWjQIE9Syf2Wby2oOl/39KLfy0=
 github.com/charmbracelet/bubbles v0.18.0/go.mod h1:08qhZhtIwzgrtBjAcJnij1t1H0ZRjwHyGsy6AL11PSw=
 github.com/charmbracelet/bubbletea v0.25.0 h1:bAfwk7jRz7FKFl9RzlIULPkStffg5k6pNt5dywy4TcM=

--- a/main.go
+++ b/main.go
@@ -88,6 +88,13 @@ func main() {
 						Usage:    "Generate a report in JSON format",
 						Category: "Report",
 					},
+					// OpenMetrics report
+					// https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md
+					&cli.StringFlag{
+						Name:     "report-openmetrics",
+						Usage:    "Generate a report in OpenMetrics format",
+						Category: "Report",
+					},
 					// Watch mode
 					&cli.BoolFlag{
 						Name:     "watch",
@@ -192,6 +199,9 @@ func main() {
 					if cCtx.String("report-json") != "" {
 						configuration.Reports.Json = cCtx.String("report-json")
 					}
+					if cCtx.String("report-openmetrics") != "" {
+						configuration.Reports.OpenMetrics = cCtx.String("report-openmetrics")
+					}
 
 					// CI mode
 					if cCtx.Bool("ci") {
@@ -203,6 +213,11 @@ func main() {
 						}
 						if configuration.Reports.Json == "" {
 							configuration.Reports.Json = "ast-metrics-report.json"
+						}
+						if configuration.Reports.OpenMetrics == "" {
+							// we don't prefix the file with ast-metrics- because "metrics.txt" is a common filename for CI
+							// @see https://docs.gitlab.com/ee/ci/testing/metrics_reports.html
+							configuration.Reports.OpenMetrics = "metrics.txt"
 						}
 					}
 

--- a/src/Command/AnalyzeCommand.go
+++ b/src/Command/AnalyzeCommand.go
@@ -16,6 +16,7 @@ import (
 	Html "github.com/halleck45/ast-metrics/src/Report/Html"
 	Json "github.com/halleck45/ast-metrics/src/Report/Json"
 	Markdown "github.com/halleck45/ast-metrics/src/Report/Markdown"
+	OpenMetrics "github.com/halleck45/ast-metrics/src/Report/OpenMetrics"
 	"github.com/halleck45/ast-metrics/src/Storage"
 	"github.com/inancgumus/screen"
 	"github.com/pterm/pterm"
@@ -186,6 +187,9 @@ func (v *AnalyzeCommand) Execute() error {
 		}
 		if v.configuration.Reports.Json != "" {
 			reporters = append(reporters, Json.NewJsonReportGenerator(v.configuration.Reports.Json))
+		}
+		if v.configuration.Reports.OpenMetrics != "" {
+			reporters = append(reporters, OpenMetrics.NewOpenMetricsReportGenerator(v.configuration.Reports.OpenMetrics))
 		}
 
 		// Generate reports

--- a/src/Configuration/Configuration.go
+++ b/src/Configuration/Configuration.go
@@ -32,9 +32,10 @@ type Configuration struct {
 }
 
 type ConfigurationReport struct {
-	Html     string `yaml:"html"`
-	Markdown string `yaml:"markdown"`
-	Json     string `yaml:"json"`
+	Html        string `yaml:"html"`
+	Markdown    string `yaml:"markdown"`
+	Json        string `yaml:"json"`
+	OpenMetrics string `yaml:"openmetrics"`
 }
 
 // function HasReports() bool {
@@ -66,12 +67,12 @@ type ConfigurationDefaultRule struct {
 
 func NewConfiguration() *Configuration {
 	return &Configuration{
-		SourcesToAnalyzePath: []string{},
-		ExcludePatterns:      []string{"/vendor/", "/node_modules/", "/.git/", "/.idea/", "/tests/", "/Tests/", "/test/", "/Test/", "/spec/", "/Spec/"},
-		Watching:             false,
-		CompareWith:          "",
-		Storage:              Storage.Default(),
-		IsComingFromConfigFile:   false,
+		SourcesToAnalyzePath:   []string{},
+		ExcludePatterns:        []string{"/vendor/", "/node_modules/", "/.git/", "/.idea/", "/tests/", "/Tests/", "/test/", "/Test/", "/spec/", "/Spec/"},
+		Watching:               false,
+		CompareWith:            "",
+		Storage:                Storage.Default(),
+		IsComingFromConfigFile: false,
 	}
 }
 

--- a/src/Report/OpenMetrics/OpenMetricsGenerator.go
+++ b/src/Report/OpenMetrics/OpenMetricsGenerator.go
@@ -1,0 +1,148 @@
+package Report
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"time"
+
+	"github.com/bsm/openmetrics"
+	"github.com/halleck45/ast-metrics/src/Analyzer"
+	"github.com/halleck45/ast-metrics/src/Engine"
+	pb "github.com/halleck45/ast-metrics/src/NodeType"
+	"github.com/halleck45/ast-metrics/src/Report"
+)
+
+type OpenMetricsReportGenerator struct {
+	// The path where the report will be generated
+	ReportPath string
+}
+
+func NewOpenMetricsReportGenerator(reportPath string) Report.Reporter {
+	return &OpenMetricsReportGenerator{
+		ReportPath: reportPath,
+	}
+}
+
+func (v *OpenMetricsReportGenerator) Generate(files []*pb.File, projectAggregated Analyzer.ProjectAggregated) ([]Report.GeneratedReport, error) {
+
+	if v.ReportPath == "" {
+		return nil, nil
+	}
+
+	reg := openmetrics.NewConsistentRegistry(func() time.Time {
+		return time.Now()
+	})
+
+	// Prepare series
+	ccn := reg.Gauge(openmetrics.Desc{
+		Name:   "cyclomatic_complexity",
+		Help:   "Cyclomatic complexity of the code",
+		Labels: []string{"path"},
+	})
+	loc := reg.Gauge(openmetrics.Desc{
+		Name:   "lines_of_code",
+		Help:   "Lines of code",
+		Labels: []string{"path"},
+	})
+	lloc := reg.Gauge(openmetrics.Desc{
+		Name:   "logical_lines_of_code",
+		Help:   "Logical lines of code",
+		Labels: []string{"path"},
+	})
+	cloc := reg.Gauge(openmetrics.Desc{
+		Name:   "comment_lines_of_code",
+		Help:   "Comment lines of code",
+		Labels: []string{"path"},
+	})
+	maintanability := reg.Gauge(openmetrics.Desc{
+		Name:   "maintainability",
+		Help:   "Maintainability index",
+		Labels: []string{"path"},
+	})
+	maintanabilityWithoutComments := reg.Gauge(openmetrics.Desc{
+		Name:   "maintainability_without_comments",
+		Help:   "Maintainability index without comments",
+		Labels: []string{"path"},
+	})
+	numberOfFunctions := reg.Gauge(openmetrics.Desc{
+		Name:   "number_of_functions",
+		Help:   "Number of functions",
+		Labels: []string{"path"},
+	})
+	numberOfClasses := reg.Gauge(openmetrics.Desc{
+		Name:   "number_of_classes",
+		Help:   "Number of classes",
+		Labels: []string{"path"},
+	})
+	afferentCoupling := reg.Gauge(openmetrics.Desc{
+		Name:   "afferent_coupling",
+		Help:   "Afferent coupling",
+		Labels: []string{"path"},
+	})
+	efferentCoupling := reg.Gauge(openmetrics.Desc{
+		Name:   "efferent_coupling",
+		Help:   "Efferent coupling",
+		Labels: []string{"path"},
+	})
+
+	// Add data to the series
+	for _, file := range files {
+		if file.Stmts == nil || file.Stmts.Analyze == nil {
+			continue
+		}
+
+		if file.Stmts.Analyze.Complexity != nil {
+			ccn.With(file.Path).Set(float64(*file.Stmts.Analyze.Complexity.Cyclomatic))
+		}
+
+		if file.Stmts.Analyze.Volume != nil {
+			loc.With(file.Path).Set(float64(*file.Stmts.Analyze.Volume.Loc))
+			lloc.With(file.Path).Set(float64(*file.Stmts.Analyze.Volume.Lloc))
+			cloc.With(file.Path).Set(float64(*file.Stmts.Analyze.Volume.Cloc))
+		}
+
+		if file.Stmts.Analyze.Maintainability != nil && file.Stmts.Analyze.Maintainability.MaintainabilityIndex != nil {
+			maintanability.With(file.Path).Set(float64(*file.Stmts.Analyze.Maintainability.MaintainabilityIndex))
+			if file.Stmts.Analyze.Maintainability.MaintainabilityIndexWithoutComments != nil {
+				maintanabilityWithoutComments.With(file.Path).Set(float64(*file.Stmts.Analyze.Maintainability.MaintainabilityIndexWithoutComments))
+			}
+		}
+
+		numberOfFunctions.With(file.Path).Set(float64(len(Engine.GetFunctionsInFile(file))))
+		numberOfClasses.With(file.Path).Set(float64(len(Engine.GetClassesInFile(file))))
+
+		if file.Stmts.Analyze.Coupling != nil {
+			afferentCoupling.With(file.Path).Set(float64(file.Stmts.Analyze.Coupling.Afferent))
+			efferentCoupling.With(file.Path).Set(float64(file.Stmts.Analyze.Coupling.Efferent))
+		}
+	}
+
+	// Write the report
+	var buf bytes.Buffer
+	if _, err := reg.WriteTo(&buf); err != nil {
+		panic(err)
+	}
+	file, err := os.Create(v.ReportPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the created report, in order to inform the user
+	reports := []Report.GeneratedReport{
+		{
+			Path:        v.ReportPath,
+			Type:        "file",
+			Description: "The openmetrics report allows to monitor the project with prometheus, or with specific tools that can read openmetrics format (like Gitlab CI).",
+			Icon:        "📄",
+		},
+	}
+	return reports, nil
+
+}

--- a/src/Report/OpenMetrics/OpenMetricsGenerator_test.go
+++ b/src/Report/OpenMetrics/OpenMetricsGenerator_test.go
@@ -1,0 +1,91 @@
+package Report
+
+import (
+	"testing"
+
+	pb "github.com/halleck45/ast-metrics/src/NodeType"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/halleck45/ast-metrics/src/Analyzer"
+)
+
+func TestGenerate_ReportPathEmpty(t *testing.T) {
+	v := &OpenMetricsReportGenerator{ReportPath: ""}
+	files := []*pb.File{}
+	projectAggregated := Analyzer.ProjectAggregated{}
+
+	reports, err := v.Generate(files, projectAggregated)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if reports != nil {
+		t.Fatalf("expected nil reports, got %v", reports)
+	}
+}
+
+func TestGenerate_EmptyFiles(t *testing.T) {
+	v := &OpenMetricsReportGenerator{ReportPath: "test_report"}
+	files := []*pb.File{}
+	projectAggregated := Analyzer.ProjectAggregated{}
+
+	reports, err := v.Generate(files, projectAggregated)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(reports))
+	}
+	if reports[0].Path != "test_report" {
+		t.Fatalf("expected report path 'test_report', got %s", reports[0].Path)
+	}
+}
+
+func TestGenerate_ValidFiles(t *testing.T) {
+	v := &OpenMetricsReportGenerator{ReportPath: "test_report"}
+	files := []*pb.File{
+		{
+			Path: "file1",
+			Stmts: &pb.Stmts{
+				Analyze: &pb.Analyze{
+					Complexity: &pb.Complexity{Cyclomatic: proto.Int32(10)},
+					Volume: &pb.Volume{
+						Loc:  proto.Int32(100),
+						Lloc: proto.Int32(80),
+						Cloc: proto.Int32(20),
+					},
+					Maintainability: &pb.Maintainability{
+						MaintainabilityIndex:                proto.Float32(75.5),
+						MaintainabilityIndexWithoutComments: proto.Float32(70.0),
+					},
+					Coupling: &pb.Coupling{
+						Afferent: *proto.Int32(5),
+						Efferent: *proto.Int32(3),
+					},
+				},
+			},
+		},
+	}
+	projectAggregated := Analyzer.ProjectAggregated{}
+
+	reports, err := v.Generate(files, projectAggregated)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(reports))
+	}
+	if reports[0].Path != "test_report" {
+		t.Fatalf("expected report path 'test_report', got %s", reports[0].Path)
+	}
+}
+
+func TestGenerate_CreateFileError(t *testing.T) {
+	v := &OpenMetricsReportGenerator{ReportPath: "/invalid_path/test_report"}
+	files := []*pb.File{}
+	projectAggregated := Analyzer.ProjectAggregated{}
+
+	_, err := v.Generate(files, projectAggregated)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}


### PR DESCRIPTION
When the `--report-openmetrics=report.txt`  option is used, it generates a file with something like:

```
# TYPE cyclomatic_complexity gauge
# HELP cyclomatic_complexity Cyclomatic complexity of the code
cyclomatic_complexity{path="file1"} 10
# TYPE lines_of_code gauge
# HELP lines_of_code Lines of code
lines_of_code{path="file1"} 100
# TYPE logical_lines_of_code gauge
# HELP logical_lines_of_code Logical lines of code
logical_lines_of_code{path="file1"} 80
# TYPE comment_lines_of_code gauge
# HELP comment_lines_of_code Comment lines of code
comment_lines_of_code{path="file1"} 20
# TYPE maintainability gauge
# HELP maintainability Maintainability index
maintainability{path="file1"} 75.5
# TYPE maintainability_without_comments gauge
# HELP maintainability_without_comments Maintainability index without comments
maintainability_without_comments{path="file1"} 70
# TYPE number_of_functions gauge
# HELP number_of_functions Number of functions
number_of_functions{path="file1"} 0
# TYPE number_of_classes gauge
# HELP number_of_classes Number of classes
number_of_classes{path="file1"} 0
# TYPE afferent_coupling gauge
# HELP afferent_coupling Afferent coupling
afferent_coupling{path="file1"} 5
# TYPE efferent_coupling gauge
# HELP efferent_coupling Efferent coupling
efferent_coupling{path="file1"} 3
# EOF
```