### PR TITLE
Make the download script compatible with sh

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,84 +1,89 @@
-#!/bin/bash
+#!/bin/sh
 
 # Function to get the version of the latest release
-function get_latest_release() {
-  curl --silent "https://api.github.com/repos/Halleck45/ast-metrics/releases/latest" |  # Get latest release from GitHub API
-  grep '"tag_name":' |  # Get tag line
-  sed -E 's/.*"([^"]+)".*/\1/'  # Pluck JSON value
+get_latest_release() {
+  # Get latest release from GitHub API
+  curl --silent "https://api.github.com/repos/Halleck45/ast-metrics/releases/latest" | \
+  # Get tag line
+  grep '"tag_name":' | \
+  # Pluck JSON value
+  sed -E 's/.*"([^"]+)".*/\1/'
 }
 
 # Function to check OS and architecture
-function get_os_arch() {
+get_os_arch() {
   os=$(uname -s)
   arch=$(uname -m)
-  
-  if [[ "$os" == "Linux" ]]; then
-    if [[ "$arch" == "i686" || "$arch" == "i386" ]]; then
-      echo "Linux_i386"
-    elif [[ "$arch" == "x86_64" ]]; then
-      echo "Linux_x86_64"
-    elif [[ "$arch" == "aarch64" ]]; then
-      echo "Linux_arm64"
-    else
-      echo "Unsupported Linux architecture"
-    fi
-  elif [[ "$os" == "Darwin" ]]; then
-    if [[ "$arch" == "x86_64" ]]; then
-      echo "Darwin_x86_64"
-    elif [[ "$arch" == "arm64" ]]; then
-      echo "Darwin_arm64"
-    else
-      echo "Unsupported macOS architecture"
-    fi
-  elif [[ "$os" == "MINGW32" || "$os" == "MSYS" ]]; then
-    echo "Windows_i386.exe"  # Assuming 32-bit executable for MSYS/MINGW32
-  elif [[ "$os" == "CYGWIN" ]]; then
-    # Cygwin can run both 32-bit and 64-bit applications, check further
-    if [[ "$(uname -m)" == "x86_64" ]]; then
-      echo "Windows_x86_64.exe"
-    else
+
+  case "$os" in
+    Linux)
+      case "$arch" in
+        i686|i386) echo "Linux_i386" ;;
+        x86_64) echo "Linux_x86_64" ;;
+        aarch64) echo "Linux_arm64" ;;
+        *) echo "Unsupported Linux architecture" ;;
+      esac
+      ;;
+    Darwin)
+      case "$arch" in
+        x86_64) echo "Darwin_x86_64" ;;
+        arm64) echo "Darwin_arm64" ;;
+        *) echo "Unsupported macOS architecture" ;;
+      esac
+      ;;
+    MINGW32*|MSYS*)
+      # Assuming 32-bit executable for MSYS/MINGW32
       echo "Windows_i386.exe"
-    fi
-  elif [[ "$os" == "Windows_NT" ]]; then
-    # Check for 64-bit Windows directly
-    if [[ $(wmic os get Caption | findstr /i "WOW64") == "" ]]; then  # Not running under WOW64 (32-bit compatibility layer)
-      echo "Windows_x86_64.exe"
-    else
-      echo "Windows_i386.exe"
-    fi
-  else
-    echo "Unsupported OS"
-  fi
+      ;;
+    MINGW64*|CYGWIN*)
+      if [ "$arch" = "x86_64" ]; then
+        echo "Windows_x86_64.exe"
+      else
+        echo "Windows_i386.exe"
+      fi
+      ;;
+    Windows_NT)
+      if echo "$PROCESSOR_ARCHITECTURE" | grep -q "64"; then
+        echo "Windows_x86_64.exe"
+      else
+        echo "Windows_i386.exe"
+      fi
+      ;;
+    *)
+      echo "Unsupported OS"
+      ;;
+  esac
 }
 
-# Get OS and architecture
 os_arch=$(get_os_arch)
-version=$(get_latest_release)
 
-# Download based on OS and architecture
-download_url=""
-if [[ "$os_arch" == *"Linux"* ]]; then
-  download_url="https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_$os_arch"
-  destination="ast-metrics"
-elif [[ "$os_arch" == *"Darwin"* ]]; then
-  download_url="https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_$os_arch"
-  destination="ast-metrics"
-elif [[ "$os_arch" == *"Windows"* ]]; then
-  download_url="https://github.com/Halleck45/ast-metrics/releases/download/$version/$os_arch"
-  destination="ast-metrics.exe"
-else
+if echo "$os_arch" | grep -q "Unsupported"; then
   echo "No download available for your system: $os_arch"
   exit 1
 fi
 
-if [[ "$download_url" != "" ]]; then
+version=$(get_latest_release)
+
+download_url=""
+destination="ast-metrics"
+if echo "$os_arch" | grep -q "Linux\|Darwin"; then
+  download_url="https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_$os_arch"
+elif echo "$os_arch" | grep -q "Windows"; then
+  download_url="https://github.com/Halleck45/ast-metrics/releases/download/$version/$os_arch"
+  destination="ast-metrics.exe"
+fi
+
+if [ -n "$download_url" ]; then
   echo "📦 Downloading $download_url"
-  curl -L -o $destination $download_url
+  curl -L -o "$destination" "$download_url"
+else
+  echo "Failed to construct the download URL."
+  exit 1
 fi
 
 # permissions
-if [[ "$os_arch" == *"Linux"* || "$os_arch" == *"Darwin"* ]]; then
-  chmod +x $destination
+if echo "$os_arch" | grep -q "Linux\|Darwin"; then
+  chmod +x "$destination"
 fi
 
 echo
@@ -86,11 +91,11 @@ echo "📁 File downloaded: $destination"
 echo
 echo "You can move the executable to a directory in your PATH to make it easier to run."
 echo
-if [[ "$os_arch" == *"Windows"* ]]; then
+if echo "$os_arch" | grep -q "Windows"; then
   echo "    Example: "
   echo "    mv $destination C:\\Windows\\System32"
 fi
-if [[ "$os_arch" == *"Linux"* || "$os_arch" == *"Darwin"* ]]; then
+if echo "$os_arch" | grep -q "Linux\|Darwin"; then
   echo "    Example: "
   echo
   echo "    mv $destination /usr/local/bin"


### PR DESCRIPTION
I think it would be nice to make the script compatible with sh and not Bash, for instance to support Alpine Docker images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced script structure for better readability and maintainability.
	- Improved error handling for download URL construction.
	- Streamlined logic for determining OS and architecture.
	- Ensured executable permissions are set appropriately based on OS type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->