### PR TITLE
Speedup Git analysis

### DIFF
--- a/src/Scm/Commit.go
+++ b/src/Scm/Commit.go
@@ -1,0 +1,8 @@
+package Scm
+
+type Commit struct {
+	Hash   string
+	Author string
+	Timestamp   int
+	Files  []string
+}


### PR DESCRIPTION
Change the complexity (and execution time) of Git analysis from `O = n²` to `O = n`  (where n is the number of files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Scm` package with a `Commit` struct for better representation of commit data.
	- Enhanced `ListAllCommitsSince` method to return structured commit information including hash, author, timestamp, and associated files.

- **Bug Fixes**
	- Improved error handling and logging for invalid timestamps and incomplete output in commit retrieval.

- **Refactor**
	- Transitioned from asynchronous to synchronous processing for fetching git log data, simplifying commit processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->