### PR TITLE
Update number of commiters

### DIFF
--- a/src/Analyzer/Activity/BusFactor.go
+++ b/src/Analyzer/Activity/BusFactor.go
@@ -71,7 +71,7 @@ func (busFactor *BusFactor) Calculate(aggregate *Analyzer.Aggregated) {
 		}
 	}
 
-	// keep only top 3 committers
+	// keep only top 4 committers
 	aggregate.TopCommitters = make([]Analyzer.TopCommitter, 0)
 	for i, kv := range ss {
 		if i > 3 {


### PR DESCRIPTION
Since the condition is `if i > 3` it actually loops 4 times, so the correct number of kept committers is 4, not 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Adjusted analysis metrics to now display the top four committers, offering users an enhanced overview of key contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->