### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/Halleck45/ast-metrics/security/code-scanning/1](https://github.com/Halleck45/ast-metrics/security/code-scanning/1)

To fix the issue, an explicit `permissions` block should be added to the workflow to limit the `GITHUB_TOKEN` scope to the minimal required. In this case, placing `permissions: contents: read` at the top level is safest and sufficient for the shown steps. This should be added after the `name` and before the `on` block (anywhere before `jobs:`), or directly within each job if different jobs require different levels. In this workflow, add:

```yaml
permissions:
  contents: read
```

immediately after the `name: CI` line. No changes to methods, variables, or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
