### PR TITLE
Fix Docker Build Issues by Updating Go Version and Build Process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 #
 # docker build . -t Halleck45/ast-metrics:latest
 # docker run -it --rm Halleck45/ast-metrics:latest sh
-# docker run -it -v .:/src  --rm Halleck45/ast-metrics:latest ast-metrics analyze --report-html=/src/repport /src
+# docker run -it -v .:/src  --rm Halleck45/ast-metrics:latest ast-metrics analyze --report-html=/src/report /src
 #
-FROM golang:1.22-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 # Install packages
 RUN apk --update --no-cache add \
@@ -23,19 +23,9 @@ FROM alpine:latest
 
 WORKDIR /
 
-COPY --from=builder /usr/app/dist/ast-metrics_linux_amd64_v1 /usr/app/dist/ast-metrics_linux_amd64_v1
-COPY --from=builder /usr/app/dist/ast-metrics_linux_arm64 /usr/app/dist/ast-metrics_linux_arm64
-
-RUN arch=$(uname -m) \
-  && echo "ARCH=$arch" \
-  && case "$arch" in \
-    x86_64) \
-      cp /usr/app/dist/ast-metrics_linux_amd64_v1/ast-metrics /usr/local/bin/ast-metrics ;; \
-    aarch64) \
-      cp /usr/app/dist/ast-metrics_linux_arm64/ast-metrics /usr/local/bin/ast-metrics ;; \
-    *) \
-      echo "Architecture inconnue: $arch" && exit 1 ;; \
-  esac
+COPY --from=builder /usr/app/bin/ast-metrics /usr/local/bin/ast-metrics
 
 RUN chmod +x /usr/local/bin/ast-metrics
 RUN rm -rf /usr/app
+
+CMD ["ast-metrics", "--version"]

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-release:
 	go install github.com/goreleaser/goreleaser@latest
 	GOPATH=$(HOME)/go PATH=$$PATH:$(HOME)/go/bin goreleaser build --snapshot
 	@echo "\e[34m\033[1mDONE \033[0m\e[39m\n"
-build: build-protobuff build-release
+build: build-protobuff build-go
 	@echo "\n\e[42m  BUILD FINISHED  \e[49m\n"
 
 test:


### PR DESCRIPTION
This pull request addresses the issues related to `docker build`, ensuring it functions correctly with the latest updates.

```sh
15.46 make: *** [Makefile:15: bin/protoc] Error 1
------
Dockerfile:21
--------------------
  19 |     COPY . /usr/app
  20 |
  21 | >>> RUN make build
  22 |     FROM alpine:latest
  23 |
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c make build" did not complete successfully: exit code: 2
```

#### Changes:
- **Dockerfile**:
  - Corrected a typo in comments and updated the Go version from 1.22 to 1.23 to meet the project requirements.
  - Simplified the architecture-specific binary handling by directly copying from `/usr/app/bin/ast-metrics`.

- **Makefile**:
  - Updated the build target to call `build-go` instead of relying on `goreleaser`, which was causing issues with finding the main function.

#### Context:
- Since the project release process is handled by GitHub Actions, it seems that the Dockerfile isn't used for releases. That's why we updated the Makefile to skip using `goreleaser` in the `make build` process.

Please feel free to close this pull request if it does not fit with the ongoing changes to the project's release flow.