### PR TITLE
Supporting PHP 8.5 pipe operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ jobs:
 + ✅ **Golang** `any version`
 + ✅ **Python** `Python 2, Python 3`
 + ✅ **Rust** `any version`
-+ ✅ **PHP** `<= PHP 8.4`
++ ✅ **PHP** `<= PHP 8.5`
 + 🕛 **TypeScript**
 + 🕛 **Flutter**
 + 🕛 **Java**

--- a/internal/engine/php/tree_sitter_php_adapter.go
+++ b/internal/engine/php/tree_sitter_php_adapter.go
@@ -546,7 +546,7 @@ func (a *TreeSitterAdapter) ExtractOperatorsOperands(src []byte, startLine, endL
 	oprnds := []string{}
 	addOp := func(op string) { ops = append(ops, op) }
 	// tokens ordered longest-first to avoid partial matches
-	tokens := []string{"<<=", ">>=", "**=", "===", "!==", "<=>", "??=", "<=", ">=", "<<", ">>", "&&", "||", "??", "&=", "|=", "^=", "+=", "-=", "*=", "/=", "%=", ".=", "==", "**", "+", "-", "*", "/", "%", ".", "&", "|", "^", "<", ">"}
+	tokens := []string{"<<=", ">>=", "**=", "===", "!==", "<=>", "??=", "<=", ">=", "<<", ">>", "&&", "||", "??", "&=", "|=", "^=", "+=", "-=", "*=", "/=", "%=", ".=", "==", "**", "|>", "+", "-", "*", "/", "%", ".", "&", "|", "^", "<", ">"}
 	addOperand := func(name string) { oprnds = append(oprnds, normalizePhpOperand(name)) }
 	// very naive scan in order
 	for i := startLine - 1; i < endLine && i < len(lines); i++ {


### PR DESCRIPTION
Supporting [PHP 8.5 pipe operators](https://www.php.net/releases/8.5/en.php#pipe-operator)

```php
function test() {
	$result = 'Hello World'
		|> strtoupper(...)
		|> str_shuffle(...)
		|> trim(...);
	
	return $result;
}
```