### PR TITLE
fix: compute LLOC from the AST instead of line arithmetic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ ai/training/classifier/models
 dataset
 classified_output
 *.plk
+.venv
+
+# AI Helpers
+.claude/
+.mcp.json
+CLAUDE.md

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/nsf/gocode v0.0.0-20260207060752-91e26af1d20f // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKt
 github.com/muesli/termenv v0.13.0/go.mod h1:sP1+uffeLaEYpyOTb8pLCUctGcGLnoFjSn4YJK5e2bc=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
+github.com/nsf/gocode v0.0.0-20260207060752-91e26af1d20f h1:M5AhFQGPNfQdqA0kFGR5pKiyhm+YOQ3PcoVgvFQh7VM=
+github.com/nsf/gocode v0.0.0-20260207060752-91e26af1d20f/go.mod h1:6Q8/OMaaKAgTX7/jt2bOXVDrm1eJhoNd+iwzghR7jvs=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/analyzer/volume/loc_visitor.go
+++ b/internal/analyzer/volume/loc_visitor.go
@@ -44,7 +44,7 @@ func (v *LocVisitor) Visit(stmts *pb.Stmts, parents *pb.Stmts) {
 				continue
 			}
 
-			v.consolidate(class.Stmts, class.LinesOfCode)
+			v.consolidate(class.Stmts, class.LinesOfCode, true)
 		}
 	}
 
@@ -59,7 +59,7 @@ func (v *LocVisitor) Visit(stmts *pb.Stmts, parents *pb.Stmts) {
 			continue
 		}
 
-		v.consolidate(class.Stmts, class.LinesOfCode)
+		v.consolidate(class.Stmts, class.LinesOfCode, true)
 	}
 
 	// Consolidate foreach method (if file is not a class)
@@ -74,7 +74,9 @@ func (v *LocVisitor) Visit(stmts *pb.Stmts, parents *pb.Stmts) {
 			if target == nil {
 				target = stmts
 			}
-			v.consolidate(target, function.LinesOfCode)
+			// loc belongs to a single function here, not to the target scope:
+			// only the per-function sums are meaningful
+			v.consolidate(target, function.LinesOfCode, false)
 		}
 	}
 
@@ -126,7 +128,10 @@ func (v *LocVisitor) LeaveNode(stmts *pb.Stmts) {
 
 }
 
-func (v *LocVisitor) consolidate(stmts *pb.Stmts, loc *pb.LinesOfCode) {
+// consolidate fills the scope's Volume from loc and from the functions it
+// contains. preferScopeLloc is set when loc describes the scope itself (e.g.
+// a class range): its AST-based LLOC then wins over the sum of function LLOCs.
+func (v *LocVisitor) consolidate(stmts *pb.Stmts, loc *pb.LinesOfCode, preferScopeLloc bool) {
 
 	if stmts == nil {
 		return
@@ -158,7 +163,11 @@ func (v *LocVisitor) consolidate(stmts *pb.Stmts, loc *pb.LinesOfCode) {
 		locVal = sumLoc
 	}
 	stmts.Analyze.Volume.Loc = &locVal
-	stmts.Analyze.Volume.Lloc = &lloc
+	if preferScopeLloc && loc.LogicalLinesOfCode > 0 {
+		stmts.Analyze.Volume.Lloc = &loc.LogicalLinesOfCode
+	} else {
+		stmts.Analyze.Volume.Lloc = &lloc
+	}
 	// Preserve pre-set CLOC (e.g., class body CLOC) if already provided
 	if stmts.Analyze.Volume.Cloc == nil || *stmts.Analyze.Volume.Cloc == 0 {
 		stmts.Analyze.Volume.Cloc = &cloc

--- a/internal/engine/csharp/tree_sitter_csharp_adapter.go
+++ b/internal/engine/csharp/tree_sitter_csharp_adapter.go
@@ -268,9 +268,6 @@ func (a *TreeSitterAdapter) Imports(n *sitter.Node) []Treesitter.ImportItem {
 // CountElseIfAsIf: treat else-if as if for complexity aggregation (consistent with Go/PHP/TS)
 func (a *TreeSitterAdapter) CountElseIfAsIf() bool { return true }
 
-// FileLlocOffset returns the offset to subtract when computing file-level LLOC.
-func (a *TreeSitterAdapter) FileLlocOffset() int { return 2 }
-
 // CountComments counts C# comment lines (//, /// and /* */) in the given range.
 func (a *TreeSitterAdapter) CountComments(lines []string, start, end int) int {
 	cnt := 0

--- a/internal/engine/golang/golang_complexity_test.go
+++ b/internal/engine/golang/golang_complexity_test.go
@@ -23,7 +23,8 @@ func Test_Cyclomatic_Complexity_Is_Correct(t *testing.T) {
 	if *file.Stmts.Analyze.Volume.Loc != int32(28) {
 		t.Fatalf("incorrect Loc on sampleGo file, got %d", *file.Stmts.Analyze.Volume.Loc)
 	}
-	if *file.Stmts.Analyze.Volume.Lloc != int32(20) {
+	// statement lines: if, 2x Println, for, switch, return x, return z * 2
+	if *file.Stmts.Analyze.Volume.Lloc != int32(7) {
 		t.Fatalf("incorrect logical Loc on sampleGo file, got %d", *file.Stmts.Analyze.Volume.Lloc)
 	}
 	if *file.Stmts.Analyze.Volume.Cloc != int32(3) {

--- a/internal/engine/golang/golang_maintainability_test.go
+++ b/internal/engine/golang/golang_maintainability_test.go
@@ -102,7 +102,8 @@ func Test_FileLevel_Loc_SampleGo(t *testing.T) {
 	if *file.Stmts.Analyze.Volume.Loc != int32(28) {
 		t.Fatalf("incorrect Loc on sampleGo file, got %d", *file.Stmts.Analyze.Volume.Loc)
 	}
-	if *file.Stmts.Analyze.Volume.Lloc != int32(20) {
+	// statement lines: if, 2x Println, for, switch, return x, return z * 2
+	if *file.Stmts.Analyze.Volume.Lloc != int32(7) {
 		t.Fatalf("incorrect logical Loc on sampleGo file, got %d", *file.Stmts.Analyze.Volume.Lloc)
 	}
 	if *file.Stmts.Analyze.Volume.Cloc != int32(3) {

--- a/internal/engine/golang/tree_sitter_go_adapter.go
+++ b/internal/engine/golang/tree_sitter_go_adapter.go
@@ -389,9 +389,16 @@ func (a *TreeSitterAdapter) CountElseIfAsIf() bool {
 	return true
 }
 
-// FileLlocOffset returns the offset to subtract when computing file-level LLOC.
-// Go tests expect not subtracting the historical constant 2 used elsewhere.
-func (a *TreeSitterAdapter) FileLlocOffset() int { return 0 }
+// IsLogicalNode reports whether a node begins a logical line. On top of the
+// default statement types, Go declares local variables with dedicated node
+// types that do not carry the "_statement" suffix.
+func (a *TreeSitterAdapter) IsLogicalNode(n *sitter.Node) bool {
+	switch n.Type() {
+	case "short_var_declaration", "var_declaration", "const_declaration":
+		return true
+	}
+	return Treesitter.IsDefaultLogicalNode(n.Type())
+}
 
 // CountComments counts Go comment lines (// and /* */) in the given range, ignoring markers inside strings
 func (a *TreeSitterAdapter) CountComments(lines []string, start, end int) int {

--- a/internal/engine/java/tree_sitter_java_adapter.go
+++ b/internal/engine/java/tree_sitter_java_adapter.go
@@ -247,8 +247,15 @@ func (a *TreeSitterAdapter) Imports(n *sitter.Node) []Treesitter.ImportItem {
 // CountElseIfAsIf: treat else-if as if for complexity aggregation (consistent with Go/PHP/TS)
 func (a *TreeSitterAdapter) CountElseIfAsIf() bool { return true }
 
-// FileLlocOffset returns the offset to subtract when computing file-level LLOC.
-func (a *TreeSitterAdapter) FileLlocOffset() int { return 2 }
+// IsLogicalNode reports whether a node begins a logical line. In Java, local
+// variable declarations are statements but their node type does not carry the
+// "_statement" suffix.
+func (a *TreeSitterAdapter) IsLogicalNode(n *sitter.Node) bool {
+	if n.Type() == "local_variable_declaration" {
+		return true
+	}
+	return Treesitter.IsDefaultLogicalNode(n.Type())
+}
 
 // CountComments counts Java comment lines (//, /* */ and /** */) in the given range.
 func (a *TreeSitterAdapter) CountComments(lines []string, start, end int) int {

--- a/internal/engine/php/php_runner_test.go
+++ b/internal/engine/php/php_runner_test.go
@@ -123,7 +123,8 @@ class calculatrice {
 	assert.Equal(t, int32(4), func1.LinesOfCode.CommentLinesOfCode, "Expected CLOC")
 	// Ensure LOC
 	assert.Equal(t, int32(12), func2.LinesOfCode.LinesOfCode, "Expected LOC")
-	assert.Equal(t, int32(7), func2.LinesOfCode.LogicalLinesOfCode, "Expected LLOC")
+	// 6 statement lines: if, throw, $d = ..., $d += 1, $e = ..., return
+	assert.Equal(t, int32(6), func2.LinesOfCode.LogicalLinesOfCode, "Expected LLOC")
 	assert.Equal(t, int32(0), func2.LinesOfCode.CommentLinesOfCode, "Expected CLOC")
 }
 
@@ -714,7 +715,9 @@ class Registry
 	class1 := file.Stmts.StmtClass[0]
 	assert.Equal(t, int32(20), *class1.Stmts.Analyze.Volume.Loc, "Incorrect number of lines of code")
 	assert.Equal(t, int32(6), *class1.Stmts.Analyze.Volume.Cloc, "Incorrect number of comment lines of code")
-	assert.Equal(t, int32(3), *class1.Stmts.Analyze.Volume.Lloc, "Incorrect number of logical lines of code")
+	// 2 statement lines in the class: the return of method2 (even though its
+	// line also carries comments) and the return of method3
+	assert.Equal(t, int32(2), *class1.Stmts.Analyze.Volume.Lloc, "Incorrect number of logical lines of code")
 
 	// Ensure methods
 	assert.Equal(t, 3, len(class1.Stmts.StmtFunction), "Incorrect number of methods")
@@ -723,13 +726,54 @@ class Registry
 	assert.Equal(t, int32(0), *class1.Stmts.StmtFunction[0].Stmts.Analyze.Volume.Cloc, "Incorrect number of comment lines of code")
 
 	assert.Equal(t, int32(6), *class1.Stmts.StmtFunction[1].Stmts.Analyze.Volume.Loc, "Incorrect number of lines of code")
-	assert.Equal(t, int32(2), *class1.Stmts.StmtFunction[1].Stmts.Analyze.Volume.Lloc, "Incorrect number of logical lines of code")
+	// the return statement counts even though its line also carries comments
+	assert.Equal(t, int32(1), *class1.Stmts.StmtFunction[1].Stmts.Analyze.Volume.Lloc, "Incorrect number of logical lines of code")
 	assert.Equal(t, int32(4), *class1.Stmts.StmtFunction[1].Stmts.Analyze.Volume.Cloc, "Incorrect number of comment lines of code")
 
 	assert.Equal(t, int32(5), *class1.Stmts.StmtFunction[2].Stmts.Analyze.Volume.Loc, "Incorrect number of lines of code")
 	assert.Equal(t, int32(1), *class1.Stmts.StmtFunction[2].Stmts.Analyze.Volume.Lloc, "Incorrect number of logical lines of code")
 	assert.Equal(t, int32(2), *class1.Stmts.StmtFunction[2].Stmts.Analyze.Volume.Cloc, "Incorrect number of comment lines of code")
 
+}
+
+// A multi-line PHPDoc docblock is entirely made of comment lines: the opener
+// "/**", the "*" body lines and the closing "*/" all count as CLOC, and none
+// of them counts as a logical line of code.
+func Test_Docblock_Does_Not_Count_As_Lloc(t *testing.T) {
+	src := `<?php
+
+namespace Foo;
+
+class Registry
+{
+    /**
+     * A well-formed docblock.
+     *
+     * @param int $a
+     * @param int $b
+     * @return int
+     */
+    public function add($a, $b)
+    {
+        return $a + $b;
+    }
+}`
+
+	file, err := engine.CreateTestFileWithCode(&PhpRunner{}, src)
+	assert.Nil(t, err)
+	analyzer.AnalyzeFile(file)
+
+	// 7 comment lines: "/**", 5 "*" body lines, "*/"
+	assert.Equal(t, int32(7), *file.Stmts.Analyze.Volume.Cloc, "Incorrect number of comment lines of code")
+	// a single statement line in the whole file: the return
+	assert.Equal(t, int32(1), *file.Stmts.Analyze.Volume.Lloc, "Incorrect number of logical lines of code")
+
+	// The method itself: body spans 3 lines ("{", "return", "}"), no comment
+	class := file.Stmts.StmtClass[0]
+	method := class.Stmts.StmtFunction[0]
+	assert.Equal(t, int32(3), *method.Stmts.Analyze.Volume.Loc, "Incorrect number of lines of code")
+	assert.Equal(t, int32(1), *method.Stmts.Analyze.Volume.Lloc, "Incorrect number of logical lines of code")
+	assert.Equal(t, int32(0), *method.Stmts.Analyze.Volume.Cloc, "Incorrect number of comment lines of code")
 }
 
 func Test_Fix_Empty_Maintainability(t *testing.T) {

--- a/internal/engine/php/tree_sitter_php_adapter.go
+++ b/internal/engine/php/tree_sitter_php_adapter.go
@@ -746,41 +746,20 @@ func (a *TreeSitterAdapter) CountComments(lines []string, start, end int) int {
 		clean := stripStrings(line)
 
 		if inBlock {
+			// Every line of a block comment is a comment line, including the
+			// closing "*/" delimiter line.
+			cnt++
 			if strings.Contains(clean, "*/") {
-				// closing delimiter on this line; do not count the delimiter line itself
-				// but if there is an inline comment after it (e.g., // ...), count that as one
-				after := strings.TrimSpace(clean[strings.Index(clean, "*/")+2:])
-				if strings.Contains(after, "//") || strings.HasPrefix(after, "#") || strings.Contains(after, "# ") {
-					cnt++
-				}
 				inBlock = false
-				continue
-			}
-			// count only interior lines that begin with '*'
-			if strings.HasPrefix(strings.TrimSpace(line), "*") {
-				cnt++
 			}
 			continue
 		}
 
 		if strings.HasPrefix(clean, "/*") {
-			// If it's a docblock opener "/**", count the opening line as a comment line
-			isDocblock := strings.HasPrefix(clean, "/**")
-			if strings.Contains(clean, "*/") {
-				// block opens and closes on the same line
-				if isDocblock {
-					cnt++ // count the opener line for docblock
-				}
-				// also count inline // or # after the closing delimiter
-				after := strings.TrimSpace(clean[strings.Index(clean, "*/")+2:])
-				if strings.Contains(after, "//") || strings.HasPrefix(after, "#") || strings.Contains(after, "# ") {
-					cnt++
-				}
-				// do not enter block since it closes here
-			} else {
-				if isDocblock {
-					cnt++ // count the opener line for docblock
-				}
+			// Opening line of a "/*" or "/**" block; a block closing on the
+			// same line stays a single comment line.
+			cnt++
+			if !strings.Contains(clean, "*/") {
 				inBlock = true
 			}
 			continue

--- a/internal/engine/python/python_runner_test.go
+++ b/internal/engine/python/python_runner_test.go
@@ -256,3 +256,38 @@ func TestPythonRunner_IsTest_NormalFile(t *testing.T) {
 		t.Fatalf("expected file NOT to be detected as test")
 	}
 }
+
+// "//" is the floor division operator in Python, not a comment: lines using
+// it count as logical lines of code.
+func TestPythonFloorDivisionIsNotAComment(t *testing.T) {
+	src := `def divide(a, b):
+    q = a // b
+    r = a - q * b
+    s = (a + b) // 2
+    t = q // 2 + s // 3
+    return q + r + s + t
+`
+	r := &PythonRunner{}
+	file, err := enginePkg.CreateTestFileWithCode(r, src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(file.Stmts.StmtNamespace) != 1 {
+		t.Fatalf("expected 1 namespace, got %d", len(file.Stmts.StmtNamespace))
+	}
+	ns := file.Stmts.StmtNamespace[0]
+	if len(ns.Stmts.StmtFunction) != 1 {
+		t.Fatalf("expected 1 function, got %d", len(ns.Stmts.StmtFunction))
+	}
+	fn := ns.Stmts.StmtFunction[0]
+	if fn.LinesOfCode == nil {
+		t.Fatalf("expected LinesOfCode on divide")
+	}
+	if fn.LinesOfCode.CommentLinesOfCode != 0 {
+		t.Errorf("expected 0 comment lines, got %d (floor division counted as comment)", fn.LinesOfCode.CommentLinesOfCode)
+	}
+	// 5 statement lines: the 4 assignments and the return
+	if fn.LinesOfCode.LogicalLinesOfCode != 5 {
+		t.Errorf("expected 5 logical lines, got %d", fn.LinesOfCode.LogicalLinesOfCode)
+	}
+}

--- a/internal/engine/python/tree_sitter_python_adapter.go
+++ b/internal/engine/python/tree_sitter_python_adapter.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/halleck45/ast-metrics/internal/engine"
 	Treesitter "github.com/halleck45/ast-metrics/internal/engine/treesitter"
 	sitter "github.com/smacker/go-tree-sitter"
 	tsPython "github.com/smacker/go-tree-sitter/python"
@@ -372,4 +373,26 @@ func dedup(in []Treesitter.ImportItem) []Treesitter.ImportItem {
 		out = append(out, it)
 	}
 	return out
+}
+
+// CountComments counts full-line "#" comments in the given 1-based inclusive
+// line range.
+func (a *TreeSitterAdapter) CountComments(lines []string, start, end int) int {
+	cnt := 0
+	for i := start - 1; i < end && i < len(lines); i++ {
+		ln := strings.TrimSpace(lines[i])
+		if ln == "" {
+			continue
+		}
+		if strings.HasPrefix(ln, "#") {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+// CommentMarkers declares Python comment tokens: only "#" starts a comment.
+// "//" is the floor division operator and "/* */" does not exist.
+func (a *TreeSitterAdapter) CommentMarkers() engine.CommentMarkers {
+	return engine.CommentMarkers{Hash: true}
 }

--- a/internal/engine/python/tree_sitter_python_adapter_test.go
+++ b/internal/engine/python/tree_sitter_python_adapter_test.go
@@ -62,3 +62,27 @@ func TestTreeSitterAdapter_NodeBody_NilNode(t *testing.T) {
 		t.Error("expected nil body for nil node")
 	}
 }
+
+func TestTreeSitterAdapter_CountComments(t *testing.T) {
+	adapter := NewTreeSitterAdapter(nil)
+
+	lines := []string{
+		"# module comment",
+		"#!shebang-like comment",
+		"def divide(a, b):",
+		"    # inner comment",
+		"    return a // b  # floor division, line has code: not counted",
+		"",
+	}
+
+	cnt := adapter.CountComments(lines, 1, len(lines))
+	if cnt != 3 {
+		t.Errorf("expected 3 comment lines, got %d", cnt)
+	}
+
+	// "//" is floor division in Python, never a comment
+	floorDiv := []string{"x = a // b"}
+	if got := adapter.CountComments(floorDiv, 1, 1); got != 0 {
+		t.Errorf("expected 0 comment lines for floor division, got %d", got)
+	}
+}

--- a/internal/engine/rust/rust_runner_test.go
+++ b/internal/engine/rust/rust_runner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/halleck45/ast-metrics/internal/configuration"
+	pb "github.com/halleck45/ast-metrics/pb"
 )
 
 func TestRustRunner_Name(t *testing.T) {
@@ -164,5 +165,59 @@ func TestRustRunner_IsTest_NormalFile(t *testing.T) {
 	}
 	if file.IsTest {
 		t.Fatalf("expected file NOT to be detected as test")
+	}
+}
+
+// "#[...]" introduces an attribute in Rust, not a comment: attribute lines
+// are not counted as comment lines, and being metadata rather than
+// statements they are not logical lines either.
+func TestRustAttributesAreNotComments(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "attrs.rs")
+
+	rustCode := `fn compute(a: i32) -> i32 {
+    #[cfg(debug_assertions)]
+    let _dbg = true;
+    #[allow(unused)]
+    let _unused = 0;
+    a + 1
+}`
+
+	if err := os.WriteFile(tmpFile, []byte(rustCode), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	runner := RustRunner{}
+	file, err := runner.Parse(tmpFile)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var fn *pb.StmtFunction
+	all := file.Stmts.StmtFunction
+	for _, ns := range file.Stmts.StmtNamespace {
+		if ns != nil && ns.Stmts != nil {
+			all = append(all, ns.Stmts.StmtFunction...)
+		}
+	}
+	for _, f := range all {
+		if f != nil && f.Name != nil && f.Name.Short == "compute" {
+			fn = f
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatalf("function compute not found")
+	}
+	if fn.LinesOfCode == nil {
+		t.Fatalf("expected LinesOfCode on compute")
+	}
+	if fn.LinesOfCode.CommentLinesOfCode != 0 {
+		t.Errorf("expected 0 comment lines, got %d (attributes counted as comments)", fn.LinesOfCode.CommentLinesOfCode)
+	}
+	// 3 statement lines: the two "let" bindings and the "a + 1" tail
+	// expression; attribute lines are neither comments nor statements
+	if fn.LinesOfCode.LogicalLinesOfCode != 3 {
+		t.Errorf("expected 3 logical lines, got %d", fn.LinesOfCode.LogicalLinesOfCode)
 	}
 }

--- a/internal/engine/rust/tree_sitter_rust_adapter.go
+++ b/internal/engine/rust/tree_sitter_rust_adapter.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/halleck45/ast-metrics/internal/engine"
 	Treesitter "github.com/halleck45/ast-metrics/internal/engine/treesitter"
 	sitter "github.com/smacker/go-tree-sitter"
 	tsRust "github.com/smacker/go-tree-sitter/rust"
@@ -323,4 +324,93 @@ func dedup(in []Treesitter.ImportItem) []Treesitter.ImportItem {
 		out = append(out, it)
 	}
 	return out
+}
+
+// CountComments counts Rust comment lines (//, ///, //! and /* ... */ blocks)
+// in the given 1-based inclusive line range. Block delimiter lines are
+// comment lines.
+func (a *TreeSitterAdapter) CountComments(lines []string, start, end int) int {
+	cnt := 0
+	inBlock := false
+	for i := start - 1; i < end && i < len(lines); i++ {
+		ln := strings.TrimSpace(lines[i])
+		if ln == "" {
+			continue
+		}
+		clean := stripRustStrings(ln)
+		if inBlock {
+			cnt++
+			if strings.Contains(clean, "*/") {
+				inBlock = false
+			}
+			continue
+		}
+		if strings.HasPrefix(clean, "//") {
+			cnt++
+			continue
+		}
+		if strings.HasPrefix(clean, "/*") {
+			cnt++
+			if !strings.Contains(clean, "*/") {
+				inBlock = true
+			}
+			continue
+		}
+	}
+	return cnt
+}
+
+// IsLogicalNode reports whether a node begins a logical line. Rust is
+// expression-oriented: on top of the default statement types, "let" bindings
+// and match arms count, as does the tail expression of a block (a direct
+// block child with no wrapping statement node).
+func (a *TreeSitterAdapter) IsLogicalNode(n *sitter.Node) bool {
+	t := n.Type()
+	switch t {
+	case "let_declaration", "match_arm":
+		return true
+	case "attribute_item", "inner_attribute_item", "line_comment", "block_comment", "block":
+		return false
+	}
+	if Treesitter.IsDefaultLogicalNode(t) {
+		return true
+	}
+	// tail expression of a block
+	if parent := n.Parent(); parent != nil && parent.Type() == "block" && n.IsNamed() {
+		return true
+	}
+	return false
+}
+
+// CommentMarkers declares Rust comment tokens: "//" and "/* */" only.
+// "#" introduces attributes (#[derive(...)]), which are code, not comments.
+func (a *TreeSitterAdapter) CommentMarkers() engine.CommentMarkers {
+	return engine.CommentMarkers{SlashSlash: true, SlashStar: true}
+}
+
+// stripRustStrings removes content inside double-quoted strings so comment
+// markers embedded in literals (e.g. URLs) are not miscounted. Single quotes
+// are left untouched: in Rust they also introduce lifetimes ('a), which have
+// no closing quote and would corrupt the scan.
+func stripRustStrings(s string) string {
+	out := make([]rune, 0, len(s))
+	inDq := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\\' { // escape
+			if i+1 < len(s) {
+				i++
+			}
+			continue
+		}
+		if c == '"' {
+			inDq = !inDq
+			continue
+		}
+		if inDq {
+			continue
+		}
+		out = append(out, rune(c))
+	}
+	return string(out)
 }

--- a/internal/engine/rust/tree_sitter_rust_adapter_test.go
+++ b/internal/engine/rust/tree_sitter_rust_adapter_test.go
@@ -54,3 +54,39 @@ func TestTreeSitterAdapter_NodeName_NilSource(t *testing.T) {
 		t.Errorf("expected empty name for nil source, got %s", name)
 	}
 }
+
+func TestTreeSitterAdapter_CountComments(t *testing.T) {
+	adapter := NewTreeSitterAdapter(nil)
+
+	lines := []string{
+		"//! Module doc",
+		"/// Item doc",
+		"// plain comment",
+		"/*",
+		" block body",
+		"*/",
+		"fn add(a: i32, b: i32) -> i32 {",
+		"    let url = \"http://example.com\"; // not stripped away wrongly",
+		"    a + b",
+		"}",
+	}
+
+	cnt := adapter.CountComments(lines, 1, len(lines))
+	// 3 line comments + 3 block lines (opener, body, closer); the trailing
+	// "//" after code is not counted (full-line comments only)
+	if cnt != 6 {
+		t.Errorf("expected 6 comment lines, got %d", cnt)
+	}
+
+	// A "//" inside a string literal must not be counted
+	inString := []string{"let s = \"//not-a-comment\";"}
+	if got := adapter.CountComments(inString, 1, 1); got != 0 {
+		t.Errorf("expected 0 comment lines for string content, got %d", got)
+	}
+
+	// Lifetimes must not corrupt the scan
+	lifetime := []string{"fn f<'a>(x: &'a str) -> &'a str {", "// comment", "}"}
+	if got := adapter.CountComments(lifetime, 1, 3); got != 1 {
+		t.Errorf("expected 1 comment line with lifetimes present, got %d", got)
+	}
+}

--- a/internal/engine/treesitter/visitor.go
+++ b/internal/engine/treesitter/visitor.go
@@ -17,6 +17,57 @@ type Visitor struct {
 
 	classStk []*pb.StmtClass
 	funcStk  []*pb.StmtFunction
+
+	// logicalLines holds the 1-based line numbers on which a statement starts.
+	// LLOC at every level (file, class, function) is the number of such lines
+	// in the scope's range.
+	logicalLines map[int]bool
+}
+
+// IsDefaultLogicalNode reports whether a tree-sitter node type is a statement
+// for LLOC purposes. Statements and local declarations count; pure structure
+// (blocks), member declarations (classes, functions, fields) and imports do
+// not. Adapters can refine this per grammar by implementing
+// IsLogicalNode(*sitter.Node) bool.
+func IsDefaultLogicalNode(nodeType string) bool {
+	switch nodeType {
+	case "compound_statement", "statement_block", "empty_statement",
+		"import_statement", "import_from_statement", "future_import_statement",
+		"export_statement":
+		return false
+	}
+	return strings.HasSuffix(nodeType, "_statement")
+}
+
+// collectLogicalLines walks the whole tree once and records the lines on
+// which a statement starts.
+func (v *Visitor) collectLogicalLines(node *sitter.Node) {
+	isLogical := func(n *sitter.Node) bool { return IsDefaultLogicalNode(n.Type()) }
+	if la, ok := v.ad.(interface{ IsLogicalNode(*sitter.Node) bool }); ok {
+		isLogical = la.IsLogicalNode
+	}
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if isLogical(n) {
+			v.logicalLines[int(n.StartPoint().Row)+1] = true
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(node)
+}
+
+// countLogicalLines returns the number of logical lines within the 1-based
+// inclusive line range.
+func (v *Visitor) countLogicalLines(start, end int) int {
+	cnt := 0
+	for line := range v.logicalLines {
+		if line >= start && line <= end {
+			cnt++
+		}
+	}
+	return cnt
 }
 
 func (v *Visitor) curStmts() *pb.Stmts {
@@ -41,6 +92,15 @@ func NewVisitor(ad LangAdapter, path string, src []byte) *Visitor {
 	}
 }
 
+// commentMarkers returns the comment tokens declared by the adapter, or every
+// marker when the adapter does not declare any.
+func (v *Visitor) commentMarkers() engine.CommentMarkers {
+	if cm, ok := v.ad.(interface{ CommentMarkers() engine.CommentMarkers }); ok {
+		return cm.CommentMarkers()
+	}
+	return engine.AllCommentMarkers()
+}
+
 func (v *Visitor) Result() *pb.File {
 	if len(v.file.Stmts.StmtNamespace) == 0 {
 		v.file.Stmts.StmtNamespace = append(v.file.Stmts.StmtNamespace, v.ns)
@@ -50,27 +110,11 @@ func (v *Visitor) Result() *pb.File {
 	if cc, ok := v.ad.(interface{ CountComments([]string, int, int) int }); ok {
 		newC := int32(cc.CountComments(v.lines, 1, len(v.lines)))
 		v.file.LinesOfCode.CommentLinesOfCode = newC
-		// also recompute LLOC and NCLOC at file-level using blank lines and updated CLOC
-		blank := 0
-		for _, ln := range v.lines {
-			if strings.TrimSpace(ln) == "" {
-				blank++
-			}
-		}
-		loc := int(v.file.LinesOfCode.LinesOfCode)
-		cloc := int(v.file.LinesOfCode.CommentLinesOfCode)
-		offset := 2
-		if tun, ok := v.ad.(interface{ FileLlocOffset() int }); ok {
-			offset = tun.FileLlocOffset()
-		}
-		lloc := loc - (cloc + blank + offset)
-		if lloc < 0 {
-			lloc = 0
-		}
-		ncloc := loc - cloc
-		v.file.LinesOfCode.LogicalLinesOfCode = int32(lloc)
-		v.file.LinesOfCode.NonCommentLinesOfCode = int32(ncloc)
+		v.file.LinesOfCode.NonCommentLinesOfCode = v.file.LinesOfCode.LinesOfCode - newC
 	}
+
+	// LLOC counts the lines on which a statement starts
+	v.file.LinesOfCode.LogicalLinesOfCode = int32(len(v.logicalLines))
 
 	return v.file
 }
@@ -148,6 +192,13 @@ func (v *Visitor) namespaceSeparator() string {
 }
 
 func (v *Visitor) Visit(node *sitter.Node) {
+	// The first call receives the root node: collect logical lines for the
+	// whole file before descending.
+	if v.logicalLines == nil {
+		v.logicalLines = map[int]bool{}
+		v.collectLogicalLines(node)
+	}
+
 	switch {
 	case v.ad.IsModule(node):
 		for i := 0; i < int(node.ChildCount()); i++ {
@@ -203,12 +254,13 @@ func (v *Visitor) Visit(node *sitter.Node) {
 			// body.EndPoint().Row points at the '}' line; do not add +1 here to avoid counting the next line.
 			end = max(start, int(body.EndPoint().Row))
 		}
-		c.LinesOfCode = engine.GetLocPositionFromSource(v.lines, start, end)
+		c.LinesOfCode = engine.GetLocPositionFromSourceWithMarkers(v.lines, start, end, v.commentMarkers())
 		// If adapter can count comments precisely (e.g., PHP docblocks), override class CLOC using adapter for class span
 		if cc, ok := v.ad.(interface{ CountComments([]string, int, int) int }); ok {
 			newC := int32(cc.CountComments(v.lines, start, end))
 			c.LinesOfCode.CommentLinesOfCode = newC
 		}
+		c.LinesOfCode.LogicalLinesOfCode = int32(v.countLogicalLines(start, end))
 
 		// Pre-initialize class-level CLOC from class body to preserve expected semantics in tests
 		if c.Stmts == nil {
@@ -287,7 +339,7 @@ func (v *Visitor) Visit(node *sitter.Node) {
 			locStart = int(body.StartPoint().Row) + 1
 			locEnd = int(body.EndPoint().Row) + 1
 		}
-		fn.LinesOfCode = engine.GetLocPositionFromSource(v.lines, locStart, locEnd)
+		fn.LinesOfCode = engine.GetLocPositionFromSourceWithMarkers(v.lines, locStart, locEnd, v.commentMarkers())
 
 		// allow adapter to provide a better comment count
 		if cc, ok := v.ad.(interface{ CountComments([]string, int, int) int }); ok {
@@ -296,6 +348,7 @@ func (v *Visitor) Visit(node *sitter.Node) {
 			newC := int32(cc.CountComments(v.lines, cs, ce))
 			fn.LinesOfCode.CommentLinesOfCode = newC
 		}
+		fn.LinesOfCode.LogicalLinesOfCode = int32(v.countLogicalLines(nodeStart, nodeEnd))
 
 		v.attachFunction(fn)
 		v.pushFunc(fn)

--- a/internal/engine/typescript/tree_sitter_typescript_adapter.go
+++ b/internal/engine/typescript/tree_sitter_typescript_adapter.go
@@ -289,8 +289,16 @@ func (a *TreeSitterAdapter) Imports(n *sitter.Node) []Treesitter.ImportItem {
 // CountElseIfAsIf: treat else-if as if for complexity aggregation (consistent with Go/PHP)
 func (a *TreeSitterAdapter) CountElseIfAsIf() bool { return true }
 
-// FileLlocOffset returns the offset to subtract when computing file-level LLOC.
-func (a *TreeSitterAdapter) FileLlocOffset() int { return 2 }
+// IsLogicalNode reports whether a node begins a logical line. In TypeScript,
+// "const"/"let"/"var" declarations are statements but their node types do not
+// carry the "_statement" suffix.
+func (a *TreeSitterAdapter) IsLogicalNode(n *sitter.Node) bool {
+	switch n.Type() {
+	case "lexical_declaration", "variable_declaration":
+		return true
+	}
+	return Treesitter.IsDefaultLogicalNode(n.Type())
+}
 
 // CountComments counts TypeScript comment lines (// and /* */ and /** */) in the given range.
 func (a *TreeSitterAdapter) CountComments(lines []string, start, end int) int {

--- a/internal/engine/util.go
+++ b/internal/engine/util.go
@@ -14,7 +14,26 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// CommentMarkers describes which comment tokens exist in a language, so the
+// generic line scanner does not misclassify code as comments (e.g. "//" is
+// floor division in Python, "#[...]" is an attribute in Rust).
+type CommentMarkers struct {
+	SlashSlash bool // "//" line comments
+	Hash       bool // "#" line comments
+	SlashStar  bool // "/* ... */" block comments
+}
+
+// AllCommentMarkers is the default used when a language declares nothing:
+// every marker is honored.
+func AllCommentMarkers() CommentMarkers {
+	return CommentMarkers{SlashSlash: true, Hash: true, SlashStar: true}
+}
+
 func GetLocPositionFromSource(sourceCode []string, start int, end int) *pb.LinesOfCode {
+	return GetLocPositionFromSourceWithMarkers(sourceCode, start, end, AllCommentMarkers())
+}
+
+func GetLocPositionFromSourceWithMarkers(sourceCode []string, start int, end int, markers CommentMarkers) *pb.LinesOfCode {
 	// Normalize boundaries
 	if start < 1 {
 		start = 1
@@ -42,34 +61,29 @@ func GetLocPositionFromSource(sourceCode []string, start int, end int) *pb.Lines
 		clean := stripQuotes(line)
 
 		if inBlock {
-			// Inside a block comment: count only interior lines that begin with '*'
-			// Do not count the opening or closing delimiter lines.
+			// Every line of a block comment is a comment line, including the
+			// closing "*/" delimiter line.
+			cloc++
 			if strings.Contains(clean, "*/") {
 				inBlock = false
-				continue
-			}
-			if strings.HasPrefix(strings.TrimSpace(line), "*") {
-				cloc++
 			}
 			continue
 		}
 
 		// line comments: count if present anywhere on the line (after stripping strings)
-		if strings.Contains(clean, "//") || strings.HasPrefix(clean, "#") || strings.Contains(clean, "# ") {
+		if markers.SlashSlash && strings.Contains(clean, "//") {
 			cloc++
 			continue
 		}
-		if strings.HasPrefix(clean, "/*") {
-			// If block opens and closes on the same line, count it as one comment line if there is any comment content before */
-			if strings.Contains(clean, "*/") {
-				idx := strings.Index(clean, "*/")
-				commentContent := strings.TrimSpace(strings.TrimPrefix(clean[:idx], "/*"))
-				if commentContent != "" {
-					cloc++
-				}
-				// block closes on same line; do not enter inBlock
-			} else {
-				// Do not count the opening delimiter line; count only inner lines
+		if markers.Hash && (strings.HasPrefix(clean, "#") || strings.Contains(clean, "# ")) {
+			cloc++
+			continue
+		}
+		if markers.SlashStar && strings.HasPrefix(clean, "/*") {
+			// Opening line of a block comment; a block closing on the same
+			// line stays a single comment line.
+			cloc++
+			if !strings.Contains(clean, "*/") {
 				inBlock = true
 			}
 			continue
@@ -77,8 +91,9 @@ func GetLocPositionFromSource(sourceCode []string, start int, end int) *pb.Lines
 		// not a comment line here
 	}
 
-	// Keep historical behavior for logical lines to match existing tests:
-	// LLOC = LOC - (CLOC + BLANK + 2)
+	// Line-based LLOC approximation. Callers with an AST at hand (the
+	// tree-sitter visitor) override this value with the number of lines on
+	// which a statement starts.
 	ncloc := loc - cloc
 	lloc := loc - (cloc + blank + 2)
 	if lloc < 0 {

--- a/internal/engine/util_test.go
+++ b/internal/engine/util_test.go
@@ -338,3 +338,40 @@ func TestNamespacesParsing(t *testing.T) {
 	})
 
 }
+
+func TestGetLocPositionFromSourceWithMarkers(t *testing.T) {
+	// Python: "//" is floor division, "#" is a comment
+	pySource := []string{
+		"def divide(a, b):",
+		"    # a real comment",
+		"    return a // b",
+	}
+	loc := GetLocPositionFromSourceWithMarkers(pySource, 1, 3, CommentMarkers{Hash: true})
+	if loc.CommentLinesOfCode != 1 {
+		t.Errorf("python: expected 1 comment line, got %d", loc.CommentLinesOfCode)
+	}
+	if loc.LogicalLinesOfCode != 0 { // 3 - (1 + 0 + 2)
+		t.Errorf("python: expected 0 logical lines, got %d", loc.LogicalLinesOfCode)
+	}
+	// With every marker active, any line containing "//" counts as a comment
+	locAll := GetLocPositionFromSourceWithMarkers(pySource, 1, 3, AllCommentMarkers())
+	if locAll.CommentLinesOfCode != 2 {
+		t.Errorf("all markers: expected 2 comment lines, got %d", locAll.CommentLinesOfCode)
+	}
+
+	// Rust: "#[...]" is an attribute, "//" is a comment
+	rsSource := []string{
+		"fn f() {",
+		"    // a real comment",
+		"    #[allow(unused)]",
+		"    let x = 1;",
+		"}",
+	}
+	loc = GetLocPositionFromSourceWithMarkers(rsSource, 1, 5, CommentMarkers{SlashSlash: true, SlashStar: true})
+	if loc.CommentLinesOfCode != 1 {
+		t.Errorf("rust: expected 1 comment line, got %d", loc.CommentLinesOfCode)
+	}
+	if loc.LogicalLinesOfCode != 2 { // 5 - (1 + 0 + 2)
+		t.Errorf("rust: expected 2 logical lines, got %d", loc.LogicalLinesOfCode)
+	}
+}


### PR DESCRIPTION
**Why this PR?**

In PhpMetrics I chose to compute LLOC arithmetically (total lines minus blank and comment lines), and I carried that approach over into AST Metrics. 

But it creates inconsistencies (statements spanning multiple lines, multiple statements per line, continuations and multi-line literals) and, more importantly, it is not the state of the art. 

Modern analyzers count statements directly from the syntax tree: SonarQube does this across all its languages, radon does it for Python via the ast module, and PMD/Checkstyle and Lizard do it for Java and other languages. 

**This PR aligns AST Metrics with that AST-based method, for stable values that are comparable from one language to another**

## Impacts for Maintainability index

**Overview** (98 files compared across 7 projects)

| Project | Mean MI | Δ | 🔴 red | 🟡 yellow | 🟢 green |
|---|---|---|---|---|---|
| collections (PHP) | 79.9 → 81.2 | +1.2 | 0 → 0 | 0 → 0 | 4 → 4 |
| cobra (Go) | 65.1 → 68.9 | +3.8 | 21 → 13 | 6 → 14 | 8 → 8 |
| gson (Java) | 72.5 → 73.2 | +0.7 | 0 → 0 | 0 → 0 | 11 → 11 |
| dotnet/core (C#) | 60.3 → 60.8 | +0.5 | 6 → 4 | 8 → 4 | 2 → 8 |
| excalidraw/math (TS) | 64.7 → 72.2 | +7.5 | 12 → 7 | 3 → 7 | 4 → 5 |
| requests (Python) | 8.7 → 8.7 | 0 | unchanged | | |
| serde (Rust) | 3.7 → 3.7 | 0 | unchanged | | |