### PR TITLE
fix: match exclude patterns relative to the project root, not each analyzed source

### DIFF
--- a/internal/file/finder.go
+++ b/internal/file/finder.go
@@ -46,6 +46,24 @@ type Finder struct {
 	// Discovery is an optional shared cache for multi-extension search.
 	// When set, Search() will check it before doing a full glob.
 	Discovery *FileDiscovery
+	// projectRoot overrides the directory used as the reference for exclude
+	// pattern matching. Empty means "use the working directory"; only tests
+	// set it.
+	projectRoot string
+}
+
+// resolveProjectRoot returns the directory exclude patterns are matched
+// against: the working directory (where the configuration file lives),
+// unless overridden for tests.
+func (r Finder) resolveProjectRoot() string {
+	if r.projectRoot != "" {
+		return r.projectRoot
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return wd
 }
 
 func (r Finder) Search(fileExtension string) FileList {
@@ -74,6 +92,8 @@ func (r Finder) Search(fileExtension string) FileList {
 		}
 	}
 
+	projectRoot := r.resolveProjectRoot()
+
 	// Search for files in each directory
 	for _, path := range r.Configuration.SourcesToAnalyzePath {
 
@@ -87,7 +107,7 @@ func (r Finder) Search(fileExtension string) FileList {
 
 		// deal with excluded files
 		for _, file := range matches {
-			if isExcluded(file, path, compiledExcludes) {
+			if isExcluded(file, projectRoot, path, compiledExcludes) {
 				continue
 			}
 
@@ -131,6 +151,8 @@ func (r Finder) SearchMultiple(extensions []string) map[string]FileList {
 		}
 	}
 
+	projectRoot := r.resolveProjectRoot()
+
 	for _, srcPath := range r.Configuration.SourcesToAnalyzePath {
 		srcPath = strings.TrimRight(srcPath, "/")
 
@@ -142,7 +164,7 @@ func (r Finder) SearchMultiple(extensions []string) map[string]FileList {
 		if !info.IsDir() {
 			ext := filepath.Ext(srcPath)
 			if extSet[ext] {
-				if !isExcluded(srcPath, srcPath, compiledExcludes) {
+				if !isExcluded(srcPath, projectRoot, srcPath, compiledExcludes) {
 					fl := results[ext]
 					fl.Files = append(fl.Files, srcPath)
 					fl.FilesByDirectory[srcPath] = append(fl.FilesByDirectory[srcPath], srcPath)
@@ -161,7 +183,7 @@ func (r Finder) SearchMultiple(extensions []string) map[string]FileList {
 			if !extSet[ext] {
 				return nil
 			}
-			if isExcluded(path, srcPath, compiledExcludes) {
+			if isExcluded(path, projectRoot, srcPath, compiledExcludes) {
 				return nil
 			}
 			fl := results[ext]
@@ -190,17 +212,24 @@ func MergeFileLists(lists ...FileList) FileList {
 }
 
 // isExcluded reports whether a discovered file must be skipped. Exclude
-// patterns are matched against the file path relative to the analyzed root
-// (with a leading "/" and forward slashes), so that a directory named e.g.
-// "vendor" or "var" *inside* the project is excluded, while the absolute
-// location of the project itself never causes a false match (for instance a
-// macOS temp directory under /var/folders, or a project served from /var/www).
-// If the relative path cannot be computed, the absolute path is used as a
-// conservative fallback.
-func isExcluded(file, root string, compiledExcludes []*regexp.Regexp) bool {
-	target := file
-	if rel, err := filepath.Rel(root, file); err == nil {
-		target = "/" + filepath.ToSlash(rel)
+// patterns are matched against the file path relative to the project root
+// (the working directory, where the configuration file lives), with a
+// leading "/" and forward slashes. This keeps two properties at once:
+//   - the absolute location of the project never causes a false match (a
+//     project served from /var/www, or a macOS temp directory under
+//     /var/folders, is not emptied out by the default "/var/" pattern);
+//   - with several sources (e.g. "./a" and "./b"), a pattern can target one
+//     of them ("/b/file") because the source prefix is preserved.
+//
+// When the file lies outside the project root, the path relative to the
+// analyzed source root is used instead, and as a last resort the absolute
+// path.
+func isExcluded(file, projectRoot, sourceRoot string, compiledExcludes []*regexp.Regexp) bool {
+	target, ok := relativeTo(projectRoot, file)
+	if !ok {
+		if target, ok = relativeTo(sourceRoot, file); !ok {
+			target = file
+		}
 	}
 	for _, re := range compiledExcludes {
 		if re.MatchString(target) {
@@ -208,4 +237,17 @@ func isExcluded(file, root string, compiledExcludes []*regexp.Regexp) bool {
 		}
 	}
 	return false
+}
+
+// relativeTo returns file relative to root, with a leading "/" and forward
+// slashes. ok is false when root is empty or file is not located under root.
+func relativeTo(root, file string) (target string, ok bool) {
+	if root == "" {
+		return "", false
+	}
+	rel, err := filepath.Rel(root, file)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return "/" + filepath.ToSlash(rel), true
 }

--- a/internal/file/finder_test.go
+++ b/internal/file/finder_test.go
@@ -91,11 +91,13 @@ func TestFinder_SearchRootLevelFiles(t *testing.T) {
 }
 
 func TestFinder_ExcludeRelativeToRoot(t *testing.T) {
-	// Exclude patterns must be matched relative to the analyzed root, not
-	// against the absolute path. Otherwise a project whose absolute location
-	// happens to contain an excluded segment (e.g. a macOS temp dir under
-	// /var/folders, or a project served from /var/www) would be wrongly
-	// emptied out by the default "/var/" pattern.
+	// Exclude patterns must never be matched against the absolute path.
+	// Otherwise a project whose absolute location happens to contain an
+	// excluded segment (e.g. a macOS temp dir under /var/folders, or a
+	// project served from /var/www) would be wrongly emptied out by the
+	// default "/var/" pattern. Here the sources live outside the project
+	// root (the working directory), so matching falls back to the path
+	// relative to the analyzed source root.
 	t.Run("does not exclude files because of the root's absolute path", func(t *testing.T) {
 		// A root that itself sits under a "/var/" path.
 		base := filepath.Join(t.TempDir(), "var", "www", "app")
@@ -134,6 +136,82 @@ func TestFinder_ExcludeRelativeToRoot(t *testing.T) {
 		}
 		if filepath.Base(result.Files[0]) != "Main.cs" {
 			t.Errorf("Expected Main.cs to be the only kept file, got %s", result.Files[0])
+		}
+	})
+}
+
+func TestFinder_ExcludeRelativeToProjectRoot(t *testing.T) {
+	// https://github.com/Halleck45/ast-metrics/issues/147
+	// With several sources, patterns are matched relative to the project
+	// root (not to each analyzed root), so a pattern can target a file in
+	// one source without touching its sibling in another source.
+	setup := func(t *testing.T) (root, dirA, dirB string) {
+		root = t.TempDir()
+		dirA = filepath.Join(root, "a")
+		dirB = filepath.Join(root, "b")
+		_ = os.MkdirAll(dirA, 0o777)
+		_ = os.MkdirAll(dirB, 0o777)
+		_ = os.WriteFile(filepath.Join(dirA, "file.php"), []byte("<?php\n"), 0o644)
+		_ = os.WriteFile(filepath.Join(dirB, "file.php"), []byte("<?php\n"), 0o644)
+		return root, dirA, dirB
+	}
+
+	t.Run("Search can exclude a file in one source only", func(t *testing.T) {
+		root, dirA, dirB := setup(t)
+		finder := Finder{
+			Configuration: configuration.Configuration{
+				SourcesToAnalyzePath: []string{dirA, dirB},
+				ExcludePatterns:      []string{"/b/file"},
+			},
+			projectRoot: root,
+		}
+		result := finder.Search(".php")
+
+		if len(result.Files) != 1 {
+			t.Fatalf("Expected only a/file.php to remain, got %d files (%v)", len(result.Files), result.Files)
+		}
+		if result.Files[0] != filepath.Join(dirA, "file.php") {
+			t.Errorf("Expected a/file.php to be kept, got %s", result.Files[0])
+		}
+	})
+
+	t.Run("SearchMultiple can exclude a file in one source only", func(t *testing.T) {
+		root, dirA, dirB := setup(t)
+		finder := Finder{
+			Configuration: configuration.Configuration{
+				SourcesToAnalyzePath: []string{dirA, dirB},
+				ExcludePatterns:      []string{"/b/file"},
+			},
+			projectRoot: root,
+		}
+		results := finder.SearchMultiple([]string{".php"})
+
+		files := results[".php"].Files
+		if len(files) != 1 {
+			t.Fatalf("Expected only a/file.php to remain, got %d files (%v)", len(files), files)
+		}
+		if files[0] != filepath.Join(dirA, "file.php") {
+			t.Errorf("Expected a/file.php to be kept, got %s", files[0])
+		}
+	})
+
+	t.Run("project location under /var/ still never matches", func(t *testing.T) {
+		root := filepath.Join(t.TempDir(), "var", "www", "app")
+		src := filepath.Join(root, "src")
+		_ = os.MkdirAll(src, 0o777)
+		_ = os.WriteFile(filepath.Join(src, "Service.php"), []byte("<?php\n"), 0o644)
+
+		finder := Finder{
+			Configuration: configuration.Configuration{
+				SourcesToAnalyzePath: []string{src},
+				ExcludePatterns:      []string{"/var/", "/vendor/"},
+			},
+			projectRoot: root,
+		}
+		result := finder.Search(".php")
+
+		if len(result.Files) != 1 {
+			t.Fatalf("Expected 1 file (project path under /var/ must not be excluded), got %d (%v)", len(result.Files), result.Files)
 		}
 	})
 }


### PR DESCRIPTION
Fixes #147