### PR TITLE
fix: LCOM4 semantics (closes #126)

### DIFF
--- a/internal/analyzer/aggregator.go
+++ b/internal/analyzer/aggregator.go
@@ -681,7 +681,8 @@ func (r *Aggregator) mapSums(file *pb.File, specificAggregation Aggregated) Aggr
 		}
 
 		// LCOM
-		if class.Stmts.Analyze.ClassCohesion != nil && class.Stmts.Analyze.ClassCohesion.Lcom4 != nil {
+		// LCOM4 = 0 means the class has no method to measure cohesion on: it is not aggregated
+		if class.Stmts.Analyze.ClassCohesion != nil && class.Stmts.Analyze.ClassCohesion.Lcom4 != nil && *class.Stmts.Analyze.ClassCohesion.Lcom4 > 0 {
 			// want a float64, got a int32
 			lcom4 := float64(*class.Stmts.Analyze.ClassCohesion.Lcom4)
 			result.Lcom4PerClass.Sum += lcom4

--- a/internal/analyzer/ast_analyzer.go
+++ b/internal/analyzer/ast_analyzer.go
@@ -77,7 +77,7 @@ func AnalyzeFile(file *pb.File) {
 	halsteadVisitor := &Volume.HalsteadMetricsVisitor{}
 	root.Accept(halsteadVisitor)
 
-	lcomVisitor := &Component.LackOfCohesionOfMethodsVisitor{}
+	lcomVisitor := &Component.LackOfCohesionOfMethodsVisitor{Language: file.ProgrammingLanguage}
 	root.Accept(lcomVisitor)
 
 	maintainabilityIndexVisitor := &Component.MaintainabilityIndexVisitor{}

--- a/internal/analyzer/component/lcom_visitor.go
+++ b/internal/analyzer/component/lcom_visitor.go
@@ -7,6 +7,58 @@ import (
 )
 
 type LackOfCohesionOfMethodsVisitor struct {
+	// Language is the programming language of the file being visited. It uses the
+	// same values as pb.File.ProgrammingLanguage ("PHP", "Java", ...) and drives the
+	// detection of lifecycle methods, which are excluded from the LCOM4 graph.
+	// When left empty, a generic policy is applied (see genericLifecycleMethods).
+	Language string
+}
+
+// lifecycleMethodsByLanguage lists, per language, the methods excluded from the LCOM4
+// graph. A constructor or a destructor usually touches every attribute of the class:
+// keeping it in the graph connects all the other methods together and hides the real
+// lack of cohesion. See https://www.aivosto.com/project/help/pm-oo-cohesion.html
+var lifecycleMethodsByLanguage = map[string][]string{
+	"PHP":        {"__construct", "__destruct"},
+	"Python":     {"__init__", "__new__", "__del__"},
+	"TypeScript": {"constructor"},
+	"Java":       {"finalize"},
+	"C#":         {"Finalize"},
+	"Rust":       {"new", "drop"},
+	"Golang":     {},
+}
+
+// genericLifecycleMethods is used when the language is unknown. It only contains the
+// names that cannot be mistaken for a regular method in any supported language.
+var genericLifecycleMethods = []string{
+	"__construct", "__destruct",
+	"__init__", "__new__", "__del__",
+	"constructor",
+	"finalize", "Finalize",
+}
+
+// languagesWithConstructorNamedAfterClass lists the languages where the constructor
+// bears the name of the class. It also covers destructors in these languages, since
+// parsers expose "~Foo" as "Foo".
+var languagesWithConstructorNamedAfterClass = map[string]bool{
+	"Java": true,
+	"C#":   true,
+	"PHP":  true, // PHP 4 style constructors
+}
+
+// qualifiedNameSeparators lists the separators used by the parsers to build a
+// qualified name, from the outermost to the innermost scope.
+var qualifiedNameSeparators = []string{"\\", "::", "."}
+
+// receiverKeywords lists the identifiers designating the current instance. Some
+// parsers report them as plain operands ("self" in Python and Rust): they are not
+// attributes, and keeping them would connect every method of the class together.
+var receiverKeywords = map[string]bool{
+	"this":  true,
+	"self":  true,
+	"Self":  true,
+	"cls":   true,
+	"super": true,
 }
 
 func (v *LackOfCohesionOfMethodsVisitor) Visit(stmts *pb.Stmts, parents *pb.Stmts) {
@@ -41,11 +93,31 @@ func (v *LackOfCohesionOfMethodsVisitor) Calculate(stmts *pb.Stmts) {
 
 	classes = append(classes, stmts.StmtClass...)
 	for _, namespace := range stmts.StmtNamespace {
+		if namespace == nil || namespace.Stmts == nil {
+			continue
+		}
 		classes = append(classes, namespace.Stmts.StmtClass...)
 	}
 
 	for _, class := range classes {
-		if class == nil || class.Stmts.StmtFunction == nil || len(class.Stmts.StmtFunction) == 0 {
+		if class == nil || class.Stmts == nil {
+			continue
+		}
+		if class.Stmts.Analyze == nil {
+			class.Stmts.Analyze = &pb.Analyze{}
+		}
+		if class.Stmts.Analyze.ClassCohesion == nil {
+			class.Stmts.Analyze.ClassCohesion = &pb.ClassCohesion{}
+		}
+
+		// Only the methods carrying a responsibility take part in the graph
+		methods := v.methodsInGraph(class)
+
+		// A class without any of them (no method at all, or only constructors,
+		// destructors and empty stubs) has no cohesion to measure: LCOM4 = 0
+		if len(methods) == 0 {
+			none := int32(0)
+			class.Stmts.Analyze.ClassCohesion.Lcom4 = &none
 			continue
 		}
 
@@ -55,7 +127,7 @@ func (v *LackOfCohesionOfMethodsVisitor) Calculate(stmts *pb.Stmts) {
 		// initialize matrix
 		matrix := map[string]map[string]bool{}
 
-		for _, method := range class.Stmts.StmtFunction {
+		for _, method := range methods {
 
 			operandsInMethods := []string{}
 			for _, operand := range method.Operands {
@@ -64,6 +136,9 @@ func (v *LackOfCohesionOfMethodsVisitor) Calculate(stmts *pb.Stmts) {
 				// if name contains more than one dot => skip it. It's probably a dynamic attribute ($this->$foo->$bar item)
 				name := strings.TrimPrefix(operand.Name, "this.")
 				if strings.Count(name, ".") != 0 {
+					continue
+				}
+				if receiverKeywords[name] {
 					continue
 				}
 
@@ -98,12 +173,86 @@ func (v *LackOfCohesionOfMethodsVisitor) Calculate(stmts *pb.Stmts) {
 			}
 		}
 
-		l4 := int32(v.lcom4(matrix, class))
-		if class.Stmts.Analyze.ClassCohesion == nil {
-			class.Stmts.Analyze.ClassCohesion = &pb.ClassCohesion{}
-		}
+		l4 := int32(v.lcom4(matrix, methods))
 		class.Stmts.Analyze.ClassCohesion.Lcom4 = &l4
 	}
+}
+
+// methodsInGraph returns the methods of the class that are relevant for LCOM4.
+//
+// Two families of methods are left out:
+//   - lifecycle methods (constructors, destructors), which access most of the
+//     attributes and would therefore connect unrelated responsibilities;
+//   - empty methods (stubs, unimplemented interface methods), which have no edge
+//     at all and would each be counted as an extra component.
+func (v *LackOfCohesionOfMethodsVisitor) methodsInGraph(class *pb.StmtClass) []*pb.StmtFunction {
+	methods := make([]*pb.StmtFunction, 0, len(class.Stmts.StmtFunction))
+	for _, method := range class.Stmts.StmtFunction {
+		if method == nil || method.Name == nil {
+			continue
+		}
+		if v.isLifecycleMethod(class, method) {
+			continue
+		}
+		if isEmptyMethod(method) {
+			continue
+		}
+		methods = append(methods, method)
+	}
+	return methods
+}
+
+// isLifecycleMethod tells whether the method is a constructor or a destructor of the class.
+func (v *LackOfCohesionOfMethodsVisitor) isLifecycleMethod(class *pb.StmtClass, method *pb.StmtFunction) bool {
+	name := shortName(method.Name)
+	if name == "" {
+		return false
+	}
+
+	lifecycleMethods, isKnownLanguage := lifecycleMethodsByLanguage[v.Language]
+	if !isKnownLanguage {
+		lifecycleMethods = genericLifecycleMethods
+	}
+	for _, lifecycleMethod := range lifecycleMethods {
+		if name == lifecycleMethod {
+			return true
+		}
+	}
+
+	// A method named after its class is a constructor (or a destructor, parsers
+	// dropping the leading "~") in Java, C# and legacy PHP.
+	if isKnownLanguage && !languagesWithConstructorNamedAfterClass[v.Language] {
+		return false
+	}
+	if class.Name == nil {
+		return false
+	}
+	className := shortName(class.Name)
+
+	return className != "" && name == className
+}
+
+// isEmptyMethod tells whether the method body holds no statement.
+func isEmptyMethod(method *pb.StmtFunction) bool {
+	return method.LinesOfCode != nil && method.LinesOfCode.LogicalLinesOfCode == 0
+}
+
+// shortName returns the name of a symbol, without the scope it belongs to.
+func shortName(name *pb.Name) string {
+	if name == nil {
+		return ""
+	}
+	if name.Short != "" {
+		return name.Short
+	}
+
+	short := name.Qualified
+	for _, separator := range qualifiedNameSeparators {
+		if index := strings.LastIndex(short, separator); index != -1 {
+			short = short[index+len(separator):]
+		}
+	}
+	return short
 }
 
 // LCOM_HS (Henderson-Sellers) algorithm
@@ -174,16 +323,13 @@ func (v *LackOfCohesionOfMethodsVisitor) lcom1(matrix map[string]map[string]bool
 }
 
 // LCOM4 (Hitz & Montazeri) : nb de composantes connexes
-func (v *LackOfCohesionOfMethodsVisitor) lcom4(matrix map[string]map[string]bool, class *pb.StmtClass) int {
+func (v *LackOfCohesionOfMethodsVisitor) lcom4(matrix map[string]map[string]bool, methodsInGraph []*pb.StmtFunction) int {
 	// 1) Index simple -> qualifié pour résoudre "foo()" -> "Class::foo"
+	//    Seules les méthodes du graphe y figurent: un appel vers un constructeur
+	//    ou vers un stub vide ne doit pas créer d'arête.
 	nameIndex := map[string]string{}
-	for _, m := range class.Stmts.StmtFunction {
-		if m == nil || m.Name == nil {
-			continue
-		}
-		q := m.Name.Qualified
-		simple := m.Name.Short
-		nameIndex[simple] = q
+	for _, m := range methodsInGraph {
+		nameIndex[shortName(m.Name)] = m.Name.Qualified
 	}
 
 	// 2) Liste des méthodes (nœuds du graphe)
@@ -294,6 +440,6 @@ func (v *LackOfCohesionOfMethodsVisitor) lcom4(matrix map[string]map[string]bool
 		}
 	}
 
-	// fmt.Printf("%s LCOM4=%d\n", class.Name.Qualified, components)
+	// fmt.Printf("LCOM4=%d\n", components)
 	return components
 }

--- a/internal/analyzer/component/lcom_visitor_lifecycle_test.go
+++ b/internal/analyzer/component/lcom_visitor_lifecycle_test.go
@@ -1,0 +1,224 @@
+package analyzer
+
+import (
+	"testing"
+
+	pb "github.com/halleck45/ast-metrics/pb"
+)
+
+// method builds a method using the given attributes, in a way that is close to what
+// the parsers produce (operands prefixed with "this.").
+func method(class string, name string, attributes ...string) *pb.StmtFunction {
+	operands := make([]*pb.StmtOperand, 0, len(attributes))
+	for _, attribute := range attributes {
+		operands = append(operands, &pb.StmtOperand{Name: "this." + attribute})
+	}
+
+	lloc := int32(len(attributes))
+	return &pb.StmtFunction{
+		Name:        &pb.Name{Short: name, Qualified: class + "::" + name},
+		Operands:    operands,
+		LinesOfCode: &pb.LinesOfCode{LogicalLinesOfCode: lloc},
+	}
+}
+
+func classWith(name string, methods ...*pb.StmtFunction) *pb.Stmts {
+	return &pb.Stmts{
+		StmtClass: []*pb.StmtClass{
+			{
+				Name: &pb.Name{Short: name, Qualified: name},
+				Stmts: &pb.Stmts{
+					StmtFunction: methods,
+					Analyze:      &pb.Analyze{},
+				},
+			},
+		},
+		Analyze: &pb.Analyze{},
+	}
+}
+
+func lcom4Of(t *testing.T, stmts *pb.Stmts) int32 {
+	t.Helper()
+
+	cohesion := stmts.StmtClass[0].Stmts.Analyze.ClassCohesion
+	if cohesion == nil || cohesion.Lcom4 == nil {
+		t.Fatal("LCOM4 has not been measured")
+	}
+	return *cohesion.Lcom4
+}
+
+func TestLifecycleMethodsAreExcludedPerLanguage(t *testing.T) {
+	// In each case, useA and useB are two independent responsibilities, and the
+	// lifecycle method touches both attributes.
+	cases := []struct {
+		language  string
+		lifecycle string
+	}{
+		{"PHP", "__construct"},
+		{"PHP", "__destruct"},
+		{"PHP", "Example"}, // PHP 4 style constructor
+		{"Python", "__init__"},
+		{"Python", "__new__"},
+		{"Python", "__del__"},
+		{"TypeScript", "constructor"},
+		{"Java", "Example"},
+		{"Java", "finalize"},
+		{"C#", "Example"}, // constructor, and destructor "~Example"
+		{"C#", "Finalize"},
+		{"Rust", "new"},
+		{"Rust", "drop"},
+		{"", "__construct"}, // unknown language: generic policy
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.language+"/"+testCase.lifecycle, func(t *testing.T) {
+			visitor := &LackOfCohesionOfMethodsVisitor{Language: testCase.language}
+			stmts := classWith("Example",
+				method("Example", testCase.lifecycle, "a", "b"),
+				method("Example", "useA", "a"),
+				method("Example", "useB", "b"),
+			)
+
+			visitor.Calculate(stmts)
+
+			if got := lcom4Of(t, stmts); got != 2 {
+				t.Errorf("Expected LCOM4=2, got %d", got)
+			}
+		})
+	}
+}
+
+func TestALifecycleNameOfAnotherLanguageIsARegularMethod(t *testing.T) {
+	// "new" is a constructor in Rust only: in PHP it is a method like any other,
+	// and it does connect useA and useB.
+	visitor := &LackOfCohesionOfMethodsVisitor{Language: "PHP"}
+	stmts := classWith("Example",
+		method("Example", "new", "a", "b"),
+		method("Example", "useA", "a"),
+		method("Example", "useB", "b"),
+	)
+
+	visitor.Calculate(stmts)
+
+	if got := lcom4Of(t, stmts); got != 1 {
+		t.Errorf("Expected LCOM4=1, got %d", got)
+	}
+}
+
+func TestAMethodNamedAfterItsClassIsARegularMethodInGolang(t *testing.T) {
+	visitor := &LackOfCohesionOfMethodsVisitor{Language: "Golang"}
+	stmts := classWith("Example",
+		method("Example", "Example", "a", "b"),
+		method("Example", "useA", "a"),
+		method("Example", "useB", "b"),
+	)
+
+	visitor.Calculate(stmts)
+
+	if got := lcom4Of(t, stmts); got != 1 {
+		t.Errorf("Expected LCOM4=1, got %d", got)
+	}
+}
+
+func TestAClassWithoutMethodHasNoCohesionToMeasure(t *testing.T) {
+	visitor := &LackOfCohesionOfMethodsVisitor{Language: "PHP"}
+	stmts := classWith("Example")
+
+	visitor.Calculate(stmts)
+
+	if got := lcom4Of(t, stmts); got != 0 {
+		t.Errorf("Expected LCOM4=0, got %d", got)
+	}
+}
+
+func TestEmptyMethodsAreNotCountedAsComponents(t *testing.T) {
+	visitor := &LackOfCohesionOfMethodsVisitor{Language: "PHP"}
+	stmts := classWith("Example",
+		method("Example", "useA", "a"),
+		method("Example", "alsoUseA", "a"),
+		method("Example", "stub"), // no attribute, no statement
+	)
+
+	visitor.Calculate(stmts)
+
+	if got := lcom4Of(t, stmts); got != 1 {
+		t.Errorf("Expected LCOM4=1, got %d", got)
+	}
+}
+
+func TestAMethodWithoutMeasuredLinesOfCodeIsNotConsideredEmpty(t *testing.T) {
+	// Parsers not filling LinesOfCode must not see all their methods dropped
+	visitor := &LackOfCohesionOfMethodsVisitor{Language: "PHP"}
+	useA := method("Example", "useA", "a")
+	useA.LinesOfCode = nil
+	useB := method("Example", "useB", "b")
+	useB.LinesOfCode = nil
+	stmts := classWith("Example", useA, useB)
+
+	visitor.Calculate(stmts)
+
+	if got := lcom4Of(t, stmts); got != 2 {
+		t.Errorf("Expected LCOM4=2, got %d", got)
+	}
+}
+
+func TestCallingAnExcludedMethodDoesNotConnectComponents(t *testing.T) {
+	visitor := &LackOfCohesionOfMethodsVisitor{Language: "PHP"}
+	useA := method("Example", "useA", "a")
+	useA.MethodCalls = []*pb.StmtMethodCall{{Name: "this.stub"}}
+	useB := method("Example", "useB", "b")
+	useB.MethodCalls = []*pb.StmtMethodCall{{Name: "this.stub"}}
+	stmts := classWith("Example", useA, useB, method("Example", "stub"))
+
+	visitor.Calculate(stmts)
+
+	if got := lcom4Of(t, stmts); got != 2 {
+		t.Errorf("Expected LCOM4=2, got %d", got)
+	}
+}
+
+func TestInternalCallsStillConnectComponents(t *testing.T) {
+	visitor := &LackOfCohesionOfMethodsVisitor{Language: "PHP"}
+	useA := method("Example", "useA", "a")
+	useA.MethodCalls = []*pb.StmtMethodCall{{Name: "this.useB"}}
+	stmts := classWith("Example", useA, method("Example", "useB", "b"))
+
+	visitor.Calculate(stmts)
+
+	if got := lcom4Of(t, stmts); got != 1 {
+		t.Errorf("Expected LCOM4=1, got %d", got)
+	}
+}
+
+func TestTheReceiverIsNotAnAttribute(t *testing.T) {
+	// Some parsers report "self" / "this" as an operand: it must not be seen as an
+	// attribute shared by every method of the class.
+	visitor := &LackOfCohesionOfMethodsVisitor{Language: "Python"}
+	stmts := classWith("Example",
+		method("Example", "useA", "self", "a"),
+		method("Example", "useB", "self", "b"),
+	)
+
+	visitor.Calculate(stmts)
+
+	if got := lcom4Of(t, stmts); got != 2 {
+		t.Errorf("Expected LCOM4=2, got %d", got)
+	}
+}
+
+func TestShortNameFallsBackOnTheQualifiedName(t *testing.T) {
+	cases := map[string]string{
+		"Example::__construct":       "__construct",
+		"App\\Example.constructor":   "constructor",
+		"module\\Example::use_a":     "use_a",
+		"Example.Example":            "Example",
+		"withoutAnyScope":            "withoutAnyScope",
+		"App\\Domain\\Example::useA": "useA",
+	}
+
+	for qualified, expected := range cases {
+		if got := shortName(&pb.Name{Qualified: qualified}); got != expected {
+			t.Errorf("shortName(%q) = %q, expected %q", qualified, got, expected)
+		}
+	}
+}

--- a/internal/engine/java/java_lcom_test.go
+++ b/internal/engine/java/java_lcom_test.go
@@ -1,0 +1,51 @@
+package java
+
+import (
+	"testing"
+
+	"github.com/halleck45/ast-metrics/internal/analyzer"
+	"github.com/halleck45/ast-metrics/internal/engine"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJavaConstructorDoesNotArtificiallyCreateCohesion(t *testing.T) {
+	src := `
+public class Example {
+    private int a;
+    private int b;
+
+    public Example() {
+        this.a = 1;
+        this.b = 2;
+    }
+
+    public int useA() {
+        return this.a;
+    }
+
+    public int useB() {
+        return this.b;
+    }
+}`
+	r := &JavaRunner{}
+	file, _ := engine.CreateTestFileWithCode(r, src)
+	analyzer.AnalyzeFile(file)
+
+	class := file.Stmts.StmtClass[0]
+	assert.NotNil(t, class.Stmts.Analyze.ClassCohesion.Lcom4)
+	assert.Equal(t, int32(2), *class.Stmts.Analyze.ClassCohesion.Lcom4)
+}
+
+func TestJavaClassWithoutMethodHasLCOM4OfZero(t *testing.T) {
+	src := `
+public class Example {
+    private int a;
+}`
+	r := &JavaRunner{}
+	file, _ := engine.CreateTestFileWithCode(r, src)
+	analyzer.AnalyzeFile(file)
+
+	class := file.Stmts.StmtClass[0]
+	assert.NotNil(t, class.Stmts.Analyze.ClassCohesion.Lcom4)
+	assert.Equal(t, int32(0), *class.Stmts.Analyze.ClassCohesion.Lcom4)
+}

--- a/internal/engine/php/php_lcom_test.go
+++ b/internal/engine/php/php_lcom_test.go
@@ -7,6 +7,22 @@ import (
 	"github.com/halleck45/ast-metrics/internal/engine"
 )
 
+func assertLcom4(t *testing.T, src string, expected int32) {
+	t.Helper()
+
+	r := &PhpRunner{}
+	file, _ := engine.CreateTestFileWithCode(r, src)
+	analyzer.AnalyzeFile(file)
+
+	class1 := file.Stmts.StmtClass[0]
+	if class1.Stmts.Analyze.ClassCohesion == nil || class1.Stmts.Analyze.ClassCohesion.Lcom4 == nil {
+		t.Fatalf("Expected LCOM4=%d, got no measure at all", expected)
+	}
+	if *class1.Stmts.Analyze.ClassCohesion.Lcom4 != expected {
+		t.Errorf("Expected LCOM4=%d, got %d", expected, *class1.Stmts.Analyze.ClassCohesion.Lcom4)
+	}
+}
+
 func Test_Real_Code_Has_Lack_Of_Cohesion(t *testing.T) {
 
 	src := `
@@ -34,13 +50,151 @@ class Example {
         echo 'ok';
     }
 }`
-	r := &PhpRunner{}
-	file, _ := engine.CreateTestFileWithCode(r, src)
-	analyzer.AnalyzeFile(file)
+	assertLcom4(t, src, 2)
+}
 
-	class1 := file.Stmts.StmtClass[0]
-	expected := int32(2)
-	if *class1.Stmts.Analyze.ClassCohesion.Lcom4 != expected {
-		t.Errorf("Expected LCOM4=%d, got %d", expected, *class1.Stmts.Analyze.ClassCohesion.Lcom4)
-	}
+func TestAClassWithoutMethodsHasLCOM4OfZero(t *testing.T) {
+
+	src := `
+<?php
+class Example {
+    private $a;
+    private $b;
+}`
+	assertLcom4(t, src, 0)
+}
+
+func TestConstructorDoesNotArtificiallyCreateCohesion(t *testing.T) {
+
+	src := `
+<?php
+class Example {
+    private $a;
+    private $b;
+
+    public function __construct() {
+        $this->a = 1;
+        $this->b = 2;
+    }
+
+    public function useA() {
+        return $this->a;
+    }
+
+    public function useB() {
+        return $this->b;
+    }
+}`
+	assertLcom4(t, src, 2)
+}
+
+func TestDestructorDoesNotArtificiallyCreateCohesion(t *testing.T) {
+
+	src := `
+<?php
+class Example {
+    private $a;
+    private $b;
+
+    public function __destruct() {
+        unset($this->a);
+        unset($this->b);
+    }
+
+    public function useA() {
+        return $this->a;
+    }
+
+    public function useB() {
+        return $this->b;
+    }
+}`
+	assertLcom4(t, src, 2)
+}
+
+func TestEmptyMethodsDoNotIncreaseLCOM4Components(t *testing.T) {
+
+	src := `
+<?php
+class Example {
+    private $a;
+
+    public function useA() {
+        return $this->a;
+    }
+
+    public function alsoUseA() {
+        $this->a = 2;
+    }
+
+    public function notImplementedYet() {}
+}`
+	assertLcom4(t, src, 1)
+}
+
+func TestAClassWithOnlyLifecycleAndEmptyMethodsHasLCOM4OfZero(t *testing.T) {
+
+	src := `
+<?php
+class Example {
+    private $a;
+
+    public function __construct() {
+        $this->a = 1;
+    }
+
+    public function __destruct() {
+        unset($this->a);
+    }
+
+    public function notImplementedYet() {}
+}`
+	assertLcom4(t, src, 0)
+}
+
+func TestCallingAnEmptyMethodDoesNotConnectComponents(t *testing.T) {
+
+	src := `
+<?php
+class Example {
+    private $a;
+    private $b;
+
+    public function useA() {
+        $this->a = 1;
+        $this->hook();
+    }
+
+    public function useB() {
+        $this->b = 2;
+        $this->hook();
+    }
+
+    public function hook() {}
+}`
+	assertLcom4(t, src, 2)
+}
+
+func TestPhp4StyleConstructorDoesNotArtificiallyCreateCohesion(t *testing.T) {
+
+	src := `
+<?php
+class Example {
+    private $a;
+    private $b;
+
+    public function Example() {
+        $this->a = 1;
+        $this->b = 2;
+    }
+
+    public function useA() {
+        return $this->a;
+    }
+
+    public function useB() {
+        return $this->b;
+    }
+}`
+	assertLcom4(t, src, 2)
 }

--- a/internal/engine/python/python_lcom_test.go
+++ b/internal/engine/python/python_lcom_test.go
@@ -1,0 +1,31 @@
+package python
+
+import (
+	"testing"
+
+	"github.com/halleck45/ast-metrics/internal/analyzer"
+	"github.com/halleck45/ast-metrics/internal/engine"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPythonInitDoesNotArtificiallyCreateCohesion(t *testing.T) {
+	src := `
+class Example:
+    def __init__(self):
+        self.a = 1
+        self.b = 2
+
+    def use_a(self):
+        return self.a
+
+    def use_b(self):
+        return self.b
+`
+	r := &PythonRunner{}
+	file, _ := engine.CreateTestFileWithCode(r, src)
+	analyzer.AnalyzeFile(file)
+
+	class := file.Stmts.StmtClass[0]
+	assert.NotNil(t, class.Stmts.Analyze.ClassCohesion.Lcom4)
+	assert.Equal(t, int32(2), *class.Stmts.Analyze.ClassCohesion.Lcom4)
+}

--- a/internal/engine/rust/rust_lcom_test.go
+++ b/internal/engine/rust/rust_lcom_test.go
@@ -1,0 +1,44 @@
+package rust
+
+import (
+	"testing"
+
+	"github.com/halleck45/ast-metrics/internal/analyzer"
+	"github.com/halleck45/ast-metrics/internal/engine"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRustNewDoesNotArtificiallyCreateCohesion(t *testing.T) {
+	src := `
+struct Example { a: i32, b: i32 }
+
+impl Example {
+    fn new() -> Example {
+        Example { a: 1, b: 2 }
+    }
+
+    fn use_a(&self) -> i32 {
+        self.a
+    }
+
+    fn use_b(&self) -> i32 {
+        self.b
+    }
+}
+`
+	r := &RustRunner{}
+	file, _ := engine.CreateTestFileWithCode(r, src)
+	analyzer.AnalyzeFile(file)
+
+	// the impl block carries the methods
+	var measured *int32
+	for _, class := range file.Stmts.StmtClass {
+		if len(class.Stmts.StmtFunction) == 0 {
+			continue
+		}
+		measured = class.Stmts.Analyze.ClassCohesion.Lcom4
+	}
+
+	assert.NotNil(t, measured)
+	assert.Equal(t, int32(2), *measured)
+}

--- a/internal/report/templates/html/explorer.html
+++ b/internal/report/templates/html/explorer.html
@@ -692,7 +692,8 @@ AST Metrics - Explorer
           .map(m => m?.stmts?.analyze?.complexity?.cyclomatic)
           .filter(x => typeof x === 'number');
         this.avgMethodCyclomatic = methodCyclo.length ? (methodCyclo.reduce((a, b) => a + b, 0) / methodCyclo.length) : 0;
-        const lcom = classes.map(c => c?.stmts?.analyze?.classCohesion?.lcom4).filter(x => typeof x === 'number');
+        // lcom4 = 0 means the class has no method to measure cohesion on: it is not averaged
+        const lcom = classes.map(c => c?.stmts?.analyze?.classCohesion?.lcom4).filter(x => typeof x === 'number' && x > 0);
         this.avgLCOM4Display = lcom.length ? (lcom.reduce((a, b) => a + b, 0) / lcom.length).toFixed(2) : '-';
         const vol = f?.stmts?.analyze?.volume;
         const fileLLOC = (vol && typeof vol.lloc === 'number') ? vol.lloc : null;

--- a/internal/ui/component_barchart_lcom_repartition.go
+++ b/internal/ui/component_barchart_lcom_repartition.go
@@ -52,6 +52,10 @@ func (c *ComponentBarchartLcomRepartition) GetData() *orderedmap.OrderedMap[stri
 				continue
 			}
 			mesured := *class.Stmts.Analyze.ClassCohesion.Lcom4
+			if mesured == 0 {
+				// no method to measure cohesion on: nothing to plot
+				continue
+			}
 
 			// map measured to bucket
 			// special case for exactly 1


### PR DESCRIPTION
Exclude constructors, destructors and empty methods from the LCOM4 graph, and report LCOM4=0 for classes without measurable methods.

Cf. #126 