### PR TITLE
fix: attach Go receiver methods to their struct and extract Halstead operands from the AST

### DIFF
--- a/internal/engine/golang/golang_complexity_test.go
+++ b/internal/engine/golang/golang_complexity_test.go
@@ -31,14 +31,18 @@ func Test_Cyclomatic_Complexity_Is_Correct(t *testing.T) {
 		t.Fatalf("incorrect comment Loc on sampleGo file, got %d", *file.Stmts.Analyze.Volume.Cloc)
 	}
 
-	if len(file.Stmts.StmtFunction) != 2 {
-		t.Fatal("functions not found in gofile")
+	// M has a receiver: it is a method of the struct C, not a function of the file
+	if len(file.Stmts.StmtFunction) != 1 {
+		t.Fatal("expected the top-level function F in gofile")
 	}
-	function1 := file.Stmts.StmtFunction[0]
-	assert.Equal(t, "M", function1.Name.Short)
+	if len(file.Stmts.StmtClass) != 1 || len(file.Stmts.StmtClass[0].Stmts.StmtFunction) != 1 {
+		t.Fatal("method M not attached to the struct C")
+	}
+	method := file.Stmts.StmtClass[0].Stmts.StmtFunction[0]
+	assert.Equal(t, "M", method.Name.Short)
 	expected := int32(1)
-	if *function1.Stmts.Analyze.Volume.Cloc != expected {
-		t.Fatalf("incorrect comment lines of code for function, got %d", *function1.Stmts.Analyze.Volume.Cloc)
+	if *method.Stmts.Analyze.Volume.Cloc != expected {
+		t.Fatalf("incorrect comment lines of code for method, got %d", *method.Stmts.Analyze.Volume.Cloc)
 	}
 
 }

--- a/internal/engine/golang/golang_lcom_test.go
+++ b/internal/engine/golang/golang_lcom_test.go
@@ -1,0 +1,166 @@
+package golang
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/halleck45/ast-metrics/internal/analyzer"
+	"github.com/halleck45/ast-metrics/internal/engine"
+	pb "github.com/halleck45/ast-metrics/pb"
+)
+
+const sampleGoStruct = `package main
+
+type Example struct {
+	counter int
+	label   string
+}
+
+func (e *Example) Increment() {
+	e.counter = e.counter + 1
+}
+
+func (e *Example) Counter() int {
+	return e.counter
+}
+
+func (e *Example) Rename(label string) {
+	e.label = label
+}
+
+func (e *Example) Reset() {
+	e.Increment()
+}
+`
+
+func Test_Go_Struct_Methods_Are_Attached_To_The_Struct(t *testing.T) {
+	file, err := engine.CreateTestFileWithCode(&GolangRunner{}, sampleGoStruct)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	analyzer.AnalyzeFile(file)
+
+	if len(file.Stmts.StmtClass) != 1 {
+		t.Fatalf("expected 1 struct, got %d", len(file.Stmts.StmtClass))
+	}
+	class := file.Stmts.StmtClass[0]
+	if len(class.Stmts.StmtFunction) != 4 {
+		t.Fatalf("expected the 4 methods of Example to be attached to it, got %d", len(class.Stmts.StmtFunction))
+	}
+	// methods with a receiver are not functions of the file
+	if len(file.Stmts.StmtFunction) != 0 {
+		t.Fatalf("expected no top-level function, got %d", len(file.Stmts.StmtFunction))
+	}
+
+	var rename *pb.StmtFunction
+	for _, method := range class.Stmts.StmtFunction {
+		// the receiver qualifies the method: two structs of a file may declare
+		// the same method name
+		if method.Name.Qualified != "main\\Example."+method.Name.Short {
+			t.Fatalf("expected the method to be qualified with its struct, got %q", method.Name.Qualified)
+		}
+		if method.Name.Short == "Rename" {
+			rename = method
+		}
+	}
+	if rename == nil {
+		t.Fatalf("method Rename not found")
+	}
+	// the receiver is not a parameter
+	if len(rename.Parameters) != 1 || rename.Parameters[0].Name != "label" {
+		t.Fatalf("expected Rename to declare the single parameter label, got %+v", rename.Parameters)
+	}
+}
+
+func Test_Go_Method_Declared_Before_Its_Struct_Is_Attached(t *testing.T) {
+	src := `package main
+
+func (e *Later) Value() int {
+	return e.value
+}
+
+type Later struct {
+	value int
+}
+`
+	file, err := engine.CreateTestFileWithCode(&GolangRunner{}, src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	if len(file.Stmts.StmtClass) != 1 || len(file.Stmts.StmtClass[0].Stmts.StmtFunction) != 1 {
+		t.Fatalf("expected Value to be attached to Later, even though it is declared first")
+	}
+}
+
+func Test_Go_Struct_Has_Lack_Of_Cohesion(t *testing.T) {
+	file, err := engine.CreateTestFileWithCode(&GolangRunner{}, sampleGoStruct)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	analyzer.AnalyzeFile(file)
+
+	class := file.Stmts.StmtClass[0]
+	if class.Stmts.Analyze.ClassCohesion == nil || class.Stmts.Analyze.ClassCohesion.Lcom4 == nil {
+		t.Fatalf("expected LCOM4 to be computed on the struct Example")
+	}
+	// Increment and Counter share the attribute counter, Reset calls Increment:
+	// they form one component. Rename only touches label.
+	expected := int32(2)
+	if *class.Stmts.Analyze.ClassCohesion.Lcom4 != expected {
+		t.Fatalf("expected LCOM4=%d, got %d", expected, *class.Stmts.Analyze.ClassCohesion.Lcom4)
+	}
+}
+
+func Test_Go_Multiline_Signature_Does_Not_Leak_Types(t *testing.T) {
+	src := []byte(`package main
+
+type Wide struct {
+	total int
+}
+
+func (w *Wide) Add(
+	amount int,
+	factor int,
+) int {
+	return w.total + amount*factor
+}
+`)
+	adapter := NewTreeSitterAdapter(src)
+	_, operands := adapter.ExtractOperatorsOperands(src, 7, 12)
+
+	for _, expected := range []string{"Add", "amount", "factor", "this.total"} {
+		if !slices.Contains(operands, expected) {
+			t.Errorf("expected the operand %q, got %v", expected, operands)
+		}
+	}
+	for _, leaked := range []string{"int", "Wide", "w", "w.total"} {
+		if slices.Contains(operands, leaked) {
+			t.Errorf("%q leaked into the operands: %v", leaked, operands)
+		}
+	}
+}
+
+func Test_Go_Receiver_Accesses_Are_Reported_As_Attributes(t *testing.T) {
+	adapter := NewTreeSitterAdapter([]byte(sampleGoStruct))
+	src := []byte(sampleGoStruct)
+
+	// `func (e *Example) Increment() {` ... on lines 8 to 10
+	_, operands := adapter.ExtractOperatorsOperands(src, 8, 10)
+	if !slices.Contains(operands, "this.counter") {
+		t.Fatalf("expected the receiver access to be normalized as this.counter, got %v", operands)
+	}
+	if slices.Contains(operands, "e.counter") || slices.Contains(operands, "e") || slices.Contains(operands, "Example") {
+		t.Fatalf("expected the receiver and its type to be normalized, got %v", operands)
+	}
+
+	// `func (e *Example) Reset() { e.Increment() }` on lines 20 to 22
+	calls := adapter.ExtractMethodCalls(src, 20, 22)
+	if len(calls) != 1 || calls[0] != "this.Increment" {
+		t.Fatalf("expected the call on the receiver to be reported as this.Increment, got %v", calls)
+	}
+	_, operands = adapter.ExtractOperatorsOperands(src, 20, 22)
+	if slices.Contains(operands, "this.Increment") {
+		t.Fatalf("a call on the receiver is not an operand, got %v", operands)
+	}
+}

--- a/internal/engine/golang/golang_maintainability_test.go
+++ b/internal/engine/golang/golang_maintainability_test.go
@@ -63,7 +63,8 @@ func Test_FileLevel_Maintainability_SampleGo(t *testing.T) {
 	if file.Stmts.Analyze.Volume == nil {
 		t.Fatalf("missing Volume on sampleGo file")
 	}
-	if *file.Stmts.Analyze.Volume.HalsteadVocabulary != int32(15) {
+	// average of the struct C (its method M) and of the top-level function F
+	if *file.Stmts.Analyze.Volume.HalsteadVocabulary != int32(7) {
 		t.Fatalf("incorrect halstead volume on file, got %d", *file.Stmts.Analyze.Volume.HalsteadVocabulary)
 	}
 	if file.Stmts.Analyze.Volume.Loc == nil || file.Stmts.Analyze.Volume.Lloc == nil || file.Stmts.Analyze.Volume.Cloc == nil {
@@ -110,14 +111,18 @@ func Test_FileLevel_Loc_SampleGo(t *testing.T) {
 		t.Fatalf("incorrect comment Loc on sampleGo file, got %d", *file.Stmts.Analyze.Volume.Cloc)
 	}
 
-	if len(file.Stmts.StmtFunction) != 2 {
-		t.Fatal("functions not found in gofile")
+	// M has a receiver: it is a method of the struct C, not a function of the file
+	if len(file.Stmts.StmtFunction) != 1 {
+		t.Fatal("expected the top-level function F in gofile")
 	}
-	function1 := file.Stmts.StmtFunction[0]
-	assert.Equal(t, "M", function1.Name.Short)
+	if len(file.Stmts.StmtClass) != 1 || len(file.Stmts.StmtClass[0].Stmts.StmtFunction) != 1 {
+		t.Fatal("method M not attached to the struct C")
+	}
+	method := file.Stmts.StmtClass[0].Stmts.StmtFunction[0]
+	assert.Equal(t, "M", method.Name.Short)
 	expected := int32(1)
-	if *function1.Stmts.Analyze.Volume.Cloc != expected {
-		t.Fatalf("incorrect comment lines of code for function, got %d", *function1.Stmts.Analyze.Volume.Cloc)
+	if *method.Stmts.Analyze.Volume.Cloc != expected {
+		t.Fatalf("incorrect comment lines of code for method, got %d", *method.Stmts.Analyze.Volume.Cloc)
 	}
 
 }

--- a/internal/engine/golang/golang_operators_test.go
+++ b/internal/engine/golang/golang_operators_test.go
@@ -52,10 +52,13 @@ func calc(a, b int) int {
 		t.Fatalf("expected some operands, got 0")
 	}
 
-	if len(fn.Operators) != 50 {
-		t.Fatalf("expected 50 operators, got %d", len(fn.Operators))
+	// "foo.bar" is a single operand: its "." is not an operator
+	if len(fn.Operators) != 49 {
+		t.Fatalf("expected 49 operators, got %d", len(fn.Operators))
 	}
-	if len(fn.Operands) != 69 {
-		t.Fatalf("expected 69 operands, got %d", len(fn.Operands))
+	// the declaration line contributes "calc", "a" and "b": the types of the
+	// parameters and of the result are not operands
+	if len(fn.Operands) != 67 {
+		t.Fatalf("expected 67 operands, got %d", len(fn.Operands))
 	}
 }

--- a/internal/engine/golang/tree_sitter_go_adapter.go
+++ b/internal/engine/golang/tree_sitter_go_adapter.go
@@ -11,12 +11,33 @@ import (
 )
 
 type TreeSitterAdapter struct {
-	src []byte
+	src  []byte
+	root *sitter.Node
 }
 
-func NewTreeSitterAdapter(src []byte) *TreeSitterAdapter { return &TreeSitterAdapter{src: src} }
-func (a *TreeSitterAdapter) SetSource(src []byte)        { a.src = src }
-func (a *TreeSitterAdapter) Language() *sitter.Language  { return tsGo.GetLanguage() }
+func NewTreeSitterAdapter(src []byte) *TreeSitterAdapter   { return &TreeSitterAdapter{src: src} }
+func (a *TreeSitterAdapter) SetSource(src []byte)          { a.src = src }
+func (a *TreeSitterAdapter) SetRootNode(root *sitter.Node) { a.root = root }
+func (a *TreeSitterAdapter) Language() *sitter.Language    { return tsGo.GetLanguage() }
+
+// ensureRoot returns the tree shared by the runner, parsing the source when
+// the adapter is used on its own (tests).
+func (a *TreeSitterAdapter) ensureRoot(src []byte) (*sitter.Node, []byte) {
+	source := a.src
+	if source == nil {
+		source = src
+	}
+	if a.root != nil {
+		return a.root, source
+	}
+	if source == nil {
+		return nil, nil
+	}
+	parser := sitter.NewParser()
+	parser.SetLanguage(a.Language())
+	a.root = parser.Parse(nil, source).RootNode()
+	return a.root, source
+}
 
 func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return n.Type() == "source_file" }
 func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool {
@@ -59,9 +80,31 @@ func (a *TreeSitterAdapter) NodeBody(n *sitter.Node) *sitter.Node {
 func (a *TreeSitterAdapter) NodeParams(n *sitter.Node) *sitter.Node {
 	switch n.Type() {
 	case "function_declaration", "method_declaration":
+		// on a method, the first parameter_list child holds the receiver, not the
+		// parameters: rely on the field name to get the real ones
+		if p := n.ChildByFieldName("parameters"); p != nil {
+			return p
+		}
 		return firstChildOfType(n, "parameter_list")
 	}
 	return nil
+}
+
+// ReceiverTypeName returns the type a method is bound to: "Counter" for
+// `func (c *Counter) Add(n int)`. It is empty for a plain function. The visitor
+// uses it to attach the method to its struct, which Go declares separately.
+func (a *TreeSitterAdapter) ReceiverTypeName(n *sitter.Node) string {
+	if n == nil || n.Type() != "method_declaration" {
+		return ""
+	}
+	receiver := n.ChildByFieldName("receiver")
+	if receiver == nil {
+		return ""
+	}
+	if t := firstDescendantOfType(receiver, "type_identifier"); t != nil {
+		return text(a.src, t)
+	}
+	return ""
 }
 
 func (a *TreeSitterAdapter) EachParamIdent(params *sitter.Node, yield func(string)) {
@@ -266,123 +309,124 @@ func eachDescendantOfType(n *sitter.Node, t string, yield func(*sitter.Node)) {
 	}
 }
 
-// Provide simplistic operators/operands extraction for Go
+// goOperatorTokens lists the anonymous token types counted as Halstead
+// operators: arithmetic, comparison, logical, bitwise, assignments and
+// channel operations.
+var goOperatorTokens = map[string]bool{
+	"+": true, "-": true, "*": true, "/": true, "%": true,
+	"==": true, "!=": true, "<": true, ">": true, "<=": true, ">=": true,
+	"&&": true, "||": true, "!": true,
+	"&": true, "|": true, "^": true, "<<": true, ">>": true, "&^": true,
+	"=": true, ":=": true, "+=": true, "-=": true, "*=": true, "/=": true, "%=": true,
+	"&=": true, "|=": true, "^=": true, "<<=": true, ">>=": true, "&^=": true,
+	"++": true, "--": true, "<-": true,
+}
+
+// goOperandTypes lists the named node types counted as Halstead operands.
+// Literals are left out on purpose: the cohesion metrics read the operands,
+// and two methods sharing the literal 0 are not cohesive.
+var goOperandTypes = map[string]bool{
+	"identifier": true, "field_identifier": true,
+}
+
+// goPruneTypes lists the node types never walked: a type is not an operand,
+// and two methods sharing the type "int" are not cohesive.
+var goPruneTypes = map[string]bool{
+	"type_identifier": true, "qualified_type": true, "pointer_type": true,
+	"slice_type": true, "array_type": true, "map_type": true, "channel_type": true,
+	"function_type": true, "struct_type": true, "interface_type": true,
+	"generic_type": true, "type_arguments": true, "type_parameter_list": true,
+	"type_declaration": true,
+}
+
+// goPruneFields lists the children never walked, by field name: the receiver
+// and the result of a method hold types, not operands.
+var goPruneFields = map[string]bool{
+	"receiver": true, "result": true,
+}
+
+var goChainTypes = map[string]bool{"selector_expression": true}
+
+func (a *TreeSitterAdapter) operandSpec(root *sitter.Node, src []byte, startLine int) Treesitter.OperandSpec {
+	return Treesitter.OperandSpec{
+		OperatorTokens: goOperatorTokens,
+		OperandTypes:   goOperandTypes,
+		PruneTypes:     goPruneTypes,
+		PruneFields:    goPruneFields,
+		ChainTypes:     goChainTypes,
+		// the receiver of the method is the Go equivalent of "this":
+		// normalizing it is what lets the cohesion metrics tell an attribute
+		// access from a local variable
+		Receiver: goReceiverIdent(root, src, startLine),
+	}
+}
+
+// ExtractOperatorsOperands collects Halstead operators and operands from the
+// AST within the given 1-based inclusive line range.
 func (a *TreeSitterAdapter) ExtractOperatorsOperands(src []byte, startLine, endLine int) ([]string, []string) {
-	if src == nil || startLine <= 0 || endLine <= 0 || endLine < startLine {
+	root, source := a.ensureRoot(src)
+	if root == nil {
 		return nil, nil
 	}
-	// token list ordered longest-first to avoid partial matches
-	tokens := []string{
-		">>=", "<<=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "&^=",
-		"==", "!=", "<=", ">=", "&&", "||", "++", "--", ":=",
-		"<<", ">>", "&^",
-		"+", "-", "*", "/", "%", "&", "|", "^", "!", "<", ">", "=",
-		".", // selector used as operator in Halstead sense
+	return a.operandSpec(root, source, startLine).Extract(root, source, startLine, endLine)
+}
+
+// ExtractMethodCalls returns the methods called on the receiver of the method
+// declared at startLine, normalized as "this.Name": `e.reset()` gives
+// "this.reset". Calls made on another variable or on a package say nothing
+// about the cohesion of the struct and are not reported.
+func (a *TreeSitterAdapter) ExtractMethodCalls(src []byte, startLine, endLine int) []string {
+	root, source := a.ensureRoot(src)
+	if root == nil {
+		return nil
 	}
-	// Prepare lines and a helper to strip strings and comments
-	lines := strings.Split(string(src), "\n")
-	strip := func(s string) string {
-		out := make([]rune, 0, len(s))
-		inBack := false
-		inDq := false
-		inSq := false
-		for i := 0; i < len(s); i++ {
-			c := s[i]
-			if c == '\\' { // escape
-				if i+1 < len(s) {
-					i++
-				}
-				continue
-			}
-			if !inDq && !inSq && c == '`' {
-				inBack = !inBack
-				continue
-			}
-			if !inBack && !inSq && c == '"' {
-				inDq = !inDq
-				continue
-			}
-			if !inBack && !inDq && c == '\'' {
-				inSq = !inSq
-				continue
-			}
-			if inBack || inDq || inSq {
-				continue
-			}
-			out = append(out, rune(c))
-		}
-		return string(out)
+	spec := a.operandSpec(root, source, startLine)
+	if spec.Receiver == "" {
+		return nil
 	}
-	ops := []string{}
-	opr := []string{}
-	addOp := func(op string) { ops = append(ops, op) }
-	addOperand := func(name string) { opr = append(opr, name) }
+	return spec.MethodCalls(root, source, startLine, endLine)
+}
 
-	for i := startLine - 1; i < endLine && i < len(lines); i++ {
-		raw := strings.TrimSpace(lines[i])
-		if raw == "" {
-			continue
-		}
-		// remove line comments
-		line := raw
-		if idx := strings.Index(line, "//"); idx >= 0 {
-			line = line[:idx]
-		}
-		line = strip(line)
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
+// goReceiverIdent returns the name of the receiver of the method declared at
+// startLine: "e" for `func (e *Example) Increment()`. It is empty for a plain
+// function, or for a method that does not name its receiver.
+func goReceiverIdent(root *sitter.Node, src []byte, startLine int) string {
+	method := goMethodAtLine(root, startLine)
+	if method == nil {
+		return ""
+	}
+	receiver := method.ChildByFieldName("receiver")
+	if receiver == nil {
+		return ""
+	}
+	decl := firstChildOfType(receiver, "parameter_declaration")
+	if decl == nil {
+		return ""
+	}
+	name := decl.ChildByFieldName("name")
+	if name == nil || name.Type() != "identifier" {
+		return ""
+	}
+	if ident := text(src, name); ident != "_" {
+		return ident
+	}
+	return ""
+}
 
-		// scan operators in order by searching earliest occurrence repeatedly
-		rest := line
-		for {
-			found := false
-			minPos := len(rest)
-			minTok := ""
-			for _, tok := range tokens {
-				if p := strings.Index(rest, tok); p >= 0 {
-					if p < minPos {
-						minPos = p
-						minTok = tok
-						found = true
-					}
-				}
-			}
-			if !found {
-				break
-			}
-			addOp(minTok)
-			rest = rest[minPos+len(minTok):]
-		}
-
-		// operands: identifiers and selectors a.b (without keywords)
-		cleaned := line
-		// replace delimiters with space
-		replacers := []string{",", ";", "(", ")", "[", "]", "{", "}", "*", "&", "|", "^", "/", "+", "-", "%", ":", "<", ">", "=", "!"}
-		for _, r := range replacers {
-			cleaned = strings.ReplaceAll(cleaned, r, " ")
-		}
-		fields := strings.Fields(cleaned)
-		isKeyword := func(s string) bool {
-			switch s {
-			case "package", "import", "func", "type", "var", "const", "return", "if", "else", "for", "range", "switch", "case", "default", "break", "continue", "go", "defer", "select", "struct", "interface", "map", "chan", "fallthrough":
-				return true
-			}
-			return false
-		}
-		for _, f := range fields {
-			if f == "" || isKeyword(f) {
-				continue
-			}
-			// retain simple identifiers and dotted selectors
-			// drop numeric literals
-			if f[0] >= '0' && f[0] <= '9' {
-				continue
-			}
-			addOperand(f)
+// goMethodAtLine returns the method declared on the given 1-based line, or nil.
+func goMethodAtLine(n *sitter.Node, line int) *sitter.Node {
+	if int(n.EndPoint().Row)+1 < line || int(n.StartPoint().Row)+1 > line {
+		return nil
+	}
+	if n.Type() == "method_declaration" && int(n.StartPoint().Row)+1 == line {
+		return n
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if found := goMethodAtLine(n.Child(i), line); found != nil {
+			return found
 		}
 	}
-	return ops, opr
+	return nil
 }
 
 // Align with PHP counting: treat else-if as if for complexity aggregation

--- a/internal/engine/treesitter/operands.go
+++ b/internal/engine/treesitter/operands.go
@@ -1,0 +1,194 @@
+package treesitter
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// OperandSpec drives the AST-based extraction of Halstead operators and
+// operands for languages whose objects carry attributes. On top of the plain
+// token walk of ExtractOperatorsOperandsFromAST, it prunes type positions (a
+// type annotation is not an operand), keeps member access chains whole
+// ("a.b.c" is one operand, not three) and normalizes accesses made through the
+// current object as "this.attr", the form the cohesion metrics (LCOM4) expect.
+type OperandSpec struct {
+	// OperatorTokens lists the anonymous leaf token types counted as operators.
+	OperatorTokens map[string]bool
+	// OperandTypes lists the named node types counted as operands.
+	OperandTypes map[string]bool
+	// PruneTypes lists the node types whose whole subtree yields nothing:
+	// type annotations, type arguments, type declarations.
+	PruneTypes map[string]bool
+	// PruneFields lists the field names whose child is skipped, for children
+	// that hold no operand but have no dedicated node type (the "receiver" and
+	// "result" of a Go method).
+	PruneFields map[string]bool
+	// ChainTypes lists the member access node types ("selector_expression" in
+	// Go, "member_expression" in TypeScript).
+	ChainTypes map[string]bool
+	// Receiver names the variable standing for the current object (the
+	// receiver of a Go method). Languages where the object is a keyword
+	// ("this", "super") leave it empty.
+	Receiver string
+}
+
+// Extract walks the AST between startLine and endLine (1-based, inclusive) and
+// returns the Halstead operators and operands found there. Strings and
+// comments never produce tokens, so they are excluded by construction.
+func (s OperandSpec) Extract(root *sitter.Node, src []byte, startLine, endLine int) ([]string, []string) {
+	if root == nil || src == nil || startLine <= 0 || endLine < startLine {
+		return nil, nil
+	}
+	ops := []string{}
+	operands := []string{}
+
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if outsideLines(n, startLine, endLine) {
+			return
+		}
+		t := n.Type()
+		if s.PruneTypes[t] {
+			return
+		}
+		if s.ChainTypes[t] {
+			if operand, ok := s.chainOperand(n, src); ok {
+				if operand != "" {
+					operands = append(operands, operand)
+				}
+				return
+			}
+			// not a plain chain ("foo().bar"): its property names nothing on
+			// its own, only the object is worth walking
+			if object := n.NamedChild(0); object != nil {
+				walk(object)
+			}
+			return
+		}
+		if n.IsNamed() && s.OperandTypes[t] {
+			// the object alone ("return e") names no attribute
+			if txt := nodeText(src, n); s.Receiver == "" || txt != s.Receiver {
+				operands = append(operands, txt)
+			}
+			return
+		}
+		if !n.IsNamed() && n.ChildCount() == 0 && s.OperatorTokens[t] {
+			ops = append(ops, t)
+			return
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			if s.PruneFields[n.FieldNameForChild(i)] {
+				continue
+			}
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	return ops, operands
+}
+
+// MethodCalls returns the methods called on the current object between
+// startLine and endLine, normalized as "this.name" ("super.name" for a call on
+// the parent class). Calls made on another variable or on a package say
+// nothing about the cohesion of the class and are not reported.
+func (s OperandSpec) MethodCalls(root *sitter.Node, src []byte, startLine, endLine int) []string {
+	if root == nil || src == nil || startLine <= 0 || endLine < startLine {
+		return nil
+	}
+	var calls []string
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if outsideLines(n, startLine, endLine) {
+			return
+		}
+		if n.Type() == "call_expression" {
+			if fn := n.ChildByFieldName("function"); fn != nil && s.ChainTypes[fn.Type()] {
+				if segments, ok := s.flatten(fn, src); ok && len(segments) == 2 {
+					if object := s.normalizeObject(segments[0]); object != "" {
+						calls = append(calls, object+"."+segments[1])
+					}
+				}
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	return calls
+}
+
+// chainOperand renders a member access chain as a single operand. An access
+// through the current object reads an attribute, whatever is done with it
+// afterwards: "this.items", "this.items.length" and "this.items.push()" all
+// read "this.items" (Go receivers are normalized the same way: "e.counter"
+// gives "this.counter"). A direct call on the object ("this.load()") reads no
+// attribute at all: it is a method call, reported by MethodCalls. ok is false
+// when the chain is not a plain chain of identifiers ("foo().bar").
+func (s OperandSpec) chainOperand(n *sitter.Node, src []byte) (operand string, ok bool) {
+	segments, ok := s.flatten(n, src)
+	if !ok {
+		return "", false
+	}
+	if object := s.normalizeObject(segments[0]); object != "" {
+		if len(segments) == 2 && isCallee(n) {
+			return "", true
+		}
+		return object + "." + segments[1], true
+	}
+	return strings.Join(segments, "."), true
+}
+
+// normalizeObject returns "this" for the current object ("this", the Go
+// receiver), "super" for the parent class, and "" for anything else.
+func (s OperandSpec) normalizeObject(root string) string {
+	if s.Receiver != "" && root == s.Receiver {
+		return "this"
+	}
+	if root == "this" || root == "super" {
+		return root
+	}
+	return ""
+}
+
+// flatten splits a member access chain into its segments: `this.items.length`
+// gives ["this", "items", "length"]. ok is false when a link is not a plain
+// identifier (a call, an index, a literal).
+func (s OperandSpec) flatten(n *sitter.Node, src []byte) ([]string, bool) {
+	if s.ChainTypes[n.Type()] {
+		if n.NamedChildCount() != 2 {
+			return nil, false
+		}
+		left, ok := s.flatten(n.NamedChild(0), src)
+		if !ok {
+			return nil, false
+		}
+		return append(left, nodeText(src, n.NamedChild(1))), true
+	}
+	if n.NamedChildCount() == 0 && !strings.HasSuffix(n.Type(), "literal") {
+		return []string{nodeText(src, n)}, true
+	}
+	return nil, false
+}
+
+// isCallee reports whether the node is the function of a call expression.
+func isCallee(n *sitter.Node) bool {
+	parent := n.Parent()
+	if parent == nil || parent.Type() != "call_expression" {
+		return false
+	}
+	fn := parent.ChildByFieldName("function")
+	return fn != nil && fn.StartByte() == n.StartByte() && fn.EndByte() == n.EndByte()
+}
+
+func outsideLines(n *sitter.Node, startLine, endLine int) bool {
+	return int(n.EndPoint().Row)+1 < startLine || int(n.StartPoint().Row)+1 > endLine
+}
+
+func nodeText(src []byte, n *sitter.Node) string {
+	if int(n.EndByte()) > len(src) {
+		return ""
+	}
+	return string(src[n.StartByte():n.EndByte()])
+}

--- a/internal/engine/treesitter/visitor.go
+++ b/internal/engine/treesitter/visitor.go
@@ -18,10 +18,22 @@ type Visitor struct {
 	classStk []*pb.StmtClass
 	funcStk  []*pb.StmtFunction
 
+	// receiverMethods holds the methods declared outside of the class they
+	// belong to (Go receivers). They are attached to their class once the whole
+	// file has been visited, because a method may be declared before its type.
+	receiverMethods []receiverMethod
+
 	// logicalLines holds the 1-based line numbers on which a statement starts.
 	// LLOC at every level (file, class, function) is the number of such lines
 	// in the scope's range.
 	logicalLines map[int]bool
+}
+
+// receiverMethod is a method waiting to be attached to the class of its
+// receiver.
+type receiverMethod struct {
+	fn       *pb.StmtFunction
+	receiver string
 }
 
 // IsDefaultLogicalNode reports whether a tree-sitter node type is a statement
@@ -102,6 +114,10 @@ func (v *Visitor) commentMarkers() engine.CommentMarkers {
 }
 
 func (v *Visitor) Result() *pb.File {
+	// methods declared outside of their class (Go receivers) are attached now
+	// that every class of the file is known
+	v.bindReceiverMethods()
+
 	if len(v.file.Stmts.StmtNamespace) == 0 {
 		v.file.Stmts.StmtNamespace = append(v.file.Stmts.StmtNamespace, v.ns)
 	}
@@ -179,6 +195,62 @@ func (v *Visitor) attachFunction(fn *pb.StmtFunction) {
 // An adapter can implement this to let Visitor create StmtInterface nodes.
 type InterfaceAware interface {
 	IsInterface(*sitter.Node) bool
+}
+
+// ReceiverAware lets an adapter tell that a function node is a method bound to a
+// type declared elsewhere in the file. Go declares its methods at the top level,
+// outside of the struct they belong to: without this, a struct would hold no
+// method at all and every class-level metric (cohesion, number of methods)
+// would ignore them.
+type ReceiverAware interface {
+	// ReceiverTypeName returns the short name of the type the method is bound
+	// to, or an empty string when the node is a plain function.
+	ReceiverTypeName(*sitter.Node) string
+}
+
+// bindReceiverMethods moves the methods declared with a receiver into the class
+// of that receiver. The method is moved and not copied, so that it stays
+// reachable exactly once from the file.
+func (v *Visitor) bindReceiverMethods() {
+	if len(v.receiverMethods) == 0 {
+		return
+	}
+
+	classes := map[string]*pb.StmtClass{}
+	for _, c := range v.ns.Stmts.StmtClass {
+		if c != nil && c.Name != nil {
+			classes[c.Name.Short] = c
+		}
+	}
+
+	for _, rm := range v.receiverMethods {
+		class, ok := classes[rm.receiver]
+		if !ok {
+			// the receiver type is declared in another file of the package: the
+			// method stays where it is
+			continue
+		}
+		if class.Stmts == nil {
+			class.Stmts = engine.FactoryStmts()
+		}
+		class.Stmts.StmtFunction = append(class.Stmts.StmtFunction, rm.fn)
+		v.file.Stmts.StmtFunction = removeFunction(v.file.Stmts.StmtFunction, rm.fn)
+		if rm.fn.Name != nil {
+			// qualify with the receiver: two structs of the same file may
+			// declare a method with the same name
+			rm.fn.Name.Qualified = v.ad.AttachQualified(class.Name.Qualified, rm.fn.Name.Short)
+		}
+	}
+	v.receiverMethods = nil
+}
+
+func removeFunction(list []*pb.StmtFunction, fn *pb.StmtFunction) []*pb.StmtFunction {
+	for i, item := range list {
+		if item == fn {
+			return append(list[:i], list[i+1:]...)
+		}
+	}
+	return list
 }
 
 // namespaceSeparator returns the separator used between a namespace and a
@@ -351,6 +423,11 @@ func (v *Visitor) Visit(node *sitter.Node) {
 		fn.LinesOfCode.LogicalLinesOfCode = int32(v.countLogicalLines(nodeStart, nodeEnd))
 
 		v.attachFunction(fn)
+		if ra, ok := v.ad.(ReceiverAware); ok && v.curClass() == nil {
+			if receiver := ra.ReceiverTypeName(node); receiver != "" {
+				v.receiverMethods = append(v.receiverMethods, receiverMethod{fn: fn, receiver: receiver})
+			}
+		}
 		v.pushFunc(fn)
 		v.ad.EachChildBody(body, func(ch *sitter.Node) { v.Visit(ch) })
 		// optional: extract operators/operands from source per adapter

--- a/internal/engine/typescript/tree_sitter_typescript_adapter.go
+++ b/internal/engine/typescript/tree_sitter_typescript_adapter.go
@@ -11,12 +11,33 @@ import (
 )
 
 type TreeSitterAdapter struct {
-	src []byte
+	src  []byte
+	root *sitter.Node
 }
 
-func NewTreeSitterAdapter(src []byte) *TreeSitterAdapter { return &TreeSitterAdapter{src: src} }
-func (a *TreeSitterAdapter) SetSource(src []byte)        { a.src = src }
-func (a *TreeSitterAdapter) Language() *sitter.Language  { return tsTsx.GetLanguage() }
+func NewTreeSitterAdapter(src []byte) *TreeSitterAdapter   { return &TreeSitterAdapter{src: src} }
+func (a *TreeSitterAdapter) SetSource(src []byte)          { a.src = src }
+func (a *TreeSitterAdapter) SetRootNode(root *sitter.Node) { a.root = root }
+func (a *TreeSitterAdapter) Language() *sitter.Language    { return tsTsx.GetLanguage() }
+
+// ensureRoot returns the tree shared by the runner, parsing the source when
+// the adapter is used on its own (tests).
+func (a *TreeSitterAdapter) ensureRoot(src []byte) (*sitter.Node, []byte) {
+	source := a.src
+	if source == nil {
+		source = src
+	}
+	if a.root != nil {
+		return a.root, source
+	}
+	if source == nil {
+		return nil, nil
+	}
+	parser := sitter.NewParser()
+	parser.SetLanguage(a.Language())
+	a.root = parser.Parse(nil, source).RootNode()
+	return a.root, source
+}
 
 func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return n.Type() == "program" }
 
@@ -339,119 +360,84 @@ func (a *TreeSitterAdapter) CountComments(lines []string, start, end int) int {
 	return cnt
 }
 
-// ExtractOperatorsOperands extracts Halstead operators and operands from TypeScript source.
-func (a *TreeSitterAdapter) ExtractOperatorsOperands(src []byte, startLine, endLine int) ([]string, []string) {
-	if src == nil || startLine <= 0 || endLine <= 0 || endLine < startLine {
-		return nil, nil
-	}
-	tokens := []string{
-		">>>=", "===", "!==", ">>=", "<<=", "**=", "??=",
-		"+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=",
-		"==", "!=", "<=", ">=", "&&", "||", "??", "?.",
-		"++", "--", "=>", "...", "**",
-		">>>", "<<", ">>",
-		"+", "-", "*", "/", "%", "&", "|", "^", "!", "<", ">", "=", "~",
-		".",
-	}
-
-	lines := strings.Split(string(src), "\n")
-	ops := []string{}
-	opr := []string{}
-
-	for i := startLine - 1; i < endLine && i < len(lines); i++ {
-		raw := strings.TrimSpace(lines[i])
-		if raw == "" {
-			continue
-		}
-		line := raw
-		if idx := strings.Index(line, "//"); idx >= 0 {
-			line = line[:idx]
-		}
-		line = stripTSStrings(line)
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-
-		// Scan operators
-		rest := line
-		for {
-			found := false
-			minPos := len(rest)
-			minTok := ""
-			for _, tok := range tokens {
-				if p := strings.Index(rest, tok); p >= 0 && p < minPos {
-					minPos = p
-					minTok = tok
-					found = true
-				}
-			}
-			if !found {
-				break
-			}
-			ops = append(ops, minTok)
-			rest = rest[minPos+len(minTok):]
-		}
-
-		// Operands: identifiers
-		cleaned := line
-		replacers := []string{",", ";", "(", ")", "[", "]", "{", "}", "*", "&", "|", "^", "/", "+", "-", "%", ":", "<", ">", "=", "!", "~", "?", "."}
-		for _, r := range replacers {
-			cleaned = strings.ReplaceAll(cleaned, r, " ")
-		}
-		fields := strings.Fields(cleaned)
-		for _, f := range fields {
-			if f == "" || isTSKeyword(f) {
-				continue
-			}
-			if f[0] >= '0' && f[0] <= '9' {
-				continue
-			}
-			opr = append(opr, f)
-		}
-	}
-	return ops, opr
+// tsOperatorTokens lists the anonymous token types counted as Halstead
+// operators: arithmetic, comparison, logical, bitwise, assignments, arrows
+// and spreads. The "<" and ">" of generics never reach this map: the AST
+// parses them as type arguments, which are pruned.
+var tsOperatorTokens = map[string]bool{
+	"+": true, "-": true, "*": true, "/": true, "%": true, "**": true,
+	"==": true, "===": true, "!=": true, "!==": true,
+	"<": true, ">": true, "<=": true, ">=": true,
+	"&&": true, "||": true, "??": true, "!": true,
+	"&": true, "|": true, "^": true, "~": true,
+	"<<": true, ">>": true, ">>>": true,
+	"=": true, "+=": true, "-=": true, "*=": true, "/=": true, "%=": true, "**=": true,
+	"&&=": true, "||=": true, "??=": true, "&=": true, "|=": true, "^=": true,
+	"<<=": true, ">>=": true, ">>>=": true,
+	"++": true, "--": true, "=>": true, "...": true,
 }
 
-// ExtractMethodCalls extracts method calls like this.foo, super.bar from TypeScript source.
+// tsOperandTypes lists the named node types counted as Halstead operands.
+// Literals are left out on purpose: the cohesion metrics read the operands,
+// and two methods sharing the literal 0 are not cohesive.
+var tsOperandTypes = map[string]bool{
+	"identifier":                            true,
+	"property_identifier":                   true,
+	"private_property_identifier":           true,
+	"shorthand_property_identifier":         true,
+	"shorthand_property_identifier_pattern": true,
+}
+
+// tsPruneTypes lists the node types never walked: a type annotation is not an
+// operand, and two methods typed "number" are not cohesive. The list names
+// every node the grammar reserves to type positions, so that a type reached
+// outside of an annotation ("raw as Currency") is dropped too.
+var tsPruneTypes = map[string]bool{
+	"type_annotation": true, "type_arguments": true, "type_parameters": true,
+	"type_alias_declaration": true, "interface_declaration": true,
+	"type_identifier": true, "predefined_type": true,
+	"object_type": true, "union_type": true, "intersection_type": true,
+	"generic_type": true, "literal_type": true, "array_type": true,
+	"tuple_type": true, "function_type": true, "constructor_type": true,
+	"type_predicate": true, "type_query": true, "lookup_type": true,
+	"index_type_query": true, "conditional_type": true,
+	"template_literal_type": true, "readonly_type": true,
+	"opting_type_annotation": true, "omitting_type_annotation": true,
+	"asserts": true,
+}
+
+var tsChainTypes = map[string]bool{"member_expression": true}
+
+var tsOperandSpec = Treesitter.OperandSpec{
+	OperatorTokens: tsOperatorTokens,
+	OperandTypes:   tsOperandTypes,
+	PruneTypes:     tsPruneTypes,
+	ChainTypes:     tsChainTypes,
+	// no Receiver: the current object is the keyword "this"
+}
+
+// ExtractOperatorsOperands collects Halstead operators and operands from the
+// AST within the given 1-based inclusive line range. A member access chain is
+// a single operand ("this.total", "console.log"), and an access through
+// "this" reads the attribute whatever is done with it afterwards:
+// "this.items" and "this.items.length" both read "this.items".
+func (a *TreeSitterAdapter) ExtractOperatorsOperands(src []byte, startLine, endLine int) ([]string, []string) {
+	root, source := a.ensureRoot(src)
+	if root == nil {
+		return nil, nil
+	}
+	return tsOperandSpec.Extract(root, source, startLine, endLine)
+}
+
+// ExtractMethodCalls returns the methods called on the current object
+// ("this.foo()", "super.bar()"). A plain read ("this.foo") is not a call: it
+// is an attribute access, reported as an operand by ExtractOperatorsOperands.
 func (a *TreeSitterAdapter) ExtractMethodCalls(src []byte, startLine, endLine int) []string {
-	if src == nil || startLine <= 0 || endLine <= 0 || endLine < startLine {
+	root, source := a.ensureRoot(src)
+	if root == nil {
 		return nil
 	}
-	lines := strings.Split(string(src), "\n")
-	var calls []string
-	for i := startLine - 1; i < endLine && i < len(lines); i++ {
-		ln := strings.TrimSpace(lines[i])
-		if ln == "" {
-			continue
-		}
-		// Strip comments
-		if idx := strings.Index(ln, "//"); idx >= 0 {
-			ln = ln[:idx]
-		}
-		ln = stripTSStrings(ln)
-		// Find this.xxx( or super.xxx( patterns
-		for _, prefix := range []string{"this.", "super."} {
-			rest := ln
-			for {
-				idx := strings.Index(rest, prefix)
-				if idx < 0 {
-					break
-				}
-				after := rest[idx+len(prefix):]
-				// Extract identifier
-				end := 0
-				for end < len(after) && (after[end] == '_' || after[end] == '$' || (after[end] >= 'a' && after[end] <= 'z') || (after[end] >= 'A' && after[end] <= 'Z') || (after[end] >= '0' && after[end] <= '9')) {
-					end++
-				}
-				if end > 0 {
-					name := prefix[:len(prefix)-1] + "." + after[:end]
-					calls = append(calls, name)
-				}
-				rest = after[end:]
-			}
-		}
-	}
-	return calls
+	return tsOperandSpec.MethodCalls(root, source, startLine, endLine)
 }
 
 // ClassDirectOperands scans class body for property declarations and returns property names.
@@ -540,22 +526,4 @@ func stripTSStrings(s string) string {
 		out = append(out, rune(c))
 	}
 	return string(out)
-}
-
-func isTSKeyword(s string) bool {
-	switch s {
-	case "import", "export", "from", "as", "default",
-		"function", "class", "extends", "implements", "interface",
-		"type", "enum", "namespace", "module", "declare",
-		"const", "let", "var", "return", "yield",
-		"if", "else", "for", "while", "do", "switch", "case", "break", "continue",
-		"try", "catch", "finally", "throw",
-		"new", "delete", "typeof", "instanceof", "void", "in", "of",
-		"async", "await", "static", "get", "set",
-		"public", "private", "protected", "readonly", "abstract", "override",
-		"true", "false", "null", "undefined",
-		"this", "super", "constructor":
-		return true
-	}
-	return false
 }

--- a/internal/engine/typescript/typescript_lcom_test.go
+++ b/internal/engine/typescript/typescript_lcom_test.go
@@ -1,0 +1,156 @@
+package typescript
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/halleck45/ast-metrics/internal/analyzer"
+	"github.com/halleck45/ast-metrics/internal/engine"
+)
+
+const sampleTsClass = `class Basket {
+    private items: string[] = [];
+    private owner: string;
+
+    constructor(owner: string) {
+        this.owner = owner;
+    }
+
+    add(item: string): number {
+        this.items.push(item);
+        return this.items.length;
+    }
+
+    count(): number {
+        return this.items.length;
+    }
+
+    rename(label: string): void {
+        this.owner = label;
+        this.trace(label);
+    }
+
+    private trace(message: string): void {
+        console.log(message);
+    }
+}
+`
+
+func Test_Ts_Class_Has_Lack_Of_Cohesion(t *testing.T) {
+	file, err := engine.CreateTestFileWithCode(&TypeScriptRunner{}, sampleTsClass)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	analyzer.AnalyzeFile(file)
+
+	if len(file.Stmts.StmtClass) != 1 {
+		t.Fatalf("expected 1 class, got %d", len(file.Stmts.StmtClass))
+	}
+	class := file.Stmts.StmtClass[0]
+	if class.Stmts.Analyze.ClassCohesion == nil || class.Stmts.Analyze.ClassCohesion.Lcom4 == nil {
+		t.Fatalf("expected LCOM4 to be computed on the class Basket")
+	}
+	// add and count share the attribute items; constructor, rename and trace are
+	// tied together by owner and by the call to trace. The methods typed the same
+	// way ("number", "string", "void") do not create any other component.
+	expected := int32(2)
+	if *class.Stmts.Analyze.ClassCohesion.Lcom4 != expected {
+		t.Fatalf("expected LCOM4=%d, got %d", expected, *class.Stmts.Analyze.ClassCohesion.Lcom4)
+	}
+}
+
+func Test_Ts_Attribute_Access_Is_An_Operand_And_Not_A_Call(t *testing.T) {
+	adapter := NewTreeSitterAdapter([]byte(sampleTsClass))
+	src := []byte(sampleTsClass)
+
+	// `rename(label: string): void {` ... on lines 17 to 20
+	calls := adapter.ExtractMethodCalls(src, 17, 20)
+	if !slices.Contains(calls, "this.trace") {
+		t.Fatalf("expected the call this.trace to be reported, got %v", calls)
+	}
+	if slices.Contains(calls, "this.owner") {
+		t.Fatalf("an attribute access is not a method call, got %v", calls)
+	}
+
+	_, operands := adapter.ExtractOperatorsOperands(src, 17, 20)
+	if !slices.Contains(operands, "this.owner") {
+		t.Fatalf("expected the attribute access this.owner to be an operand, got %v", operands)
+	}
+	if slices.Contains(operands, "this.trace") {
+		t.Fatalf("a call on this is not an operand, got %v", operands)
+	}
+	// the type annotations of the signature are not operands
+	for _, leaked := range []string{"string", "void"} {
+		if slices.Contains(operands, leaked) {
+			t.Fatalf("the type %q leaked into the operands: %v", leaked, operands)
+		}
+	}
+
+	// `add(item: string): number {` ... on lines 9 to 12: the attribute is read
+	// through a chain and through a call
+	_, operands = adapter.ExtractOperatorsOperands(src, 9, 12)
+	if !slices.Contains(operands, "this.items") {
+		t.Fatalf("expected this.items.push() and this.items.length to read this.items, got %v", operands)
+	}
+}
+
+func Test_Ts_Type_Annotations_Are_Not_Operands(t *testing.T) {
+	src := []byte(`function convert(a: number, flag: boolean): number {
+    const map = new Map<string, number>();
+    const label: string = flag ? left : right;
+    const currency = raw as Currency;
+    if (a < threshold && a > floor) {
+        return { mode: mode, total: a };
+    }
+}
+`)
+	adapter := NewTreeSitterAdapter(src)
+	operators, operands := adapter.ExtractOperatorsOperands(src, 1, 8)
+
+	// the types, wherever they stand (parameter, result, declaration, generic
+	// argument, "as" cast), never leak into the operands
+	for _, leaked := range []string{"number", "boolean", "string", "Currency"} {
+		if slices.Contains(operands, leaked) {
+			t.Errorf("the type %q leaked into the operands: %v", leaked, operands)
+		}
+	}
+	// the names, the values and the object literal keys are operands
+	for _, expected := range []string{"convert", "a", "flag", "map", "Map", "label", "left", "right", "currency", "raw", "threshold", "floor", "mode", "total"} {
+		if !slices.Contains(operands, expected) {
+			t.Errorf("expected the operand %q, got %v", expected, operands)
+		}
+	}
+	// "<" and ">" are comparisons here, not generics
+	for _, expected := range []string{"<", ">", "&&"} {
+		if !slices.Contains(operators, expected) {
+			t.Errorf("expected the operator %q, got %v", expected, operators)
+		}
+	}
+}
+
+func Test_Ts_Operands_Keep_Member_Access_Chains(t *testing.T) {
+	src := []byte(`class Chains {
+    run(message: string) {
+        this.total = this.total + 1;
+        console.log(message);
+        const size = this.items.length;
+        return this;
+    }
+}
+`)
+	adapter := NewTreeSitterAdapter(src)
+	_, operands := adapter.ExtractOperatorsOperands(src, 2, 7)
+
+	for _, expected := range []string{"this.total", "console.log", "message", "size", "this.items"} {
+		if !slices.Contains(operands, expected) {
+			t.Errorf("expected the operand %q, got %v", expected, operands)
+		}
+	}
+	// a chain is a single operand: its segments are not reported on their own,
+	// and a bare "this" does not tell which attribute is used
+	for _, unwanted := range []string{"this", "total", "console", "log", "items", "length"} {
+		if slices.Contains(operands, unwanted) {
+			t.Errorf("did not expect the operand %q, got %v", unwanted, operands)
+		}
+	}
+}


### PR DESCRIPTION
Go methods declared with a receiver are now bound to their struct, so class-level metrics (LCOM4, method counts) stop reporting empty structs. 

Operand/operator extraction for Go and TypeScript moves from line-based string parsing to the tree-sitter AST (shared OperandSpec), so type annotations no longer leak into operands and member access chains are reported as single operands normalized as "this.attr".