### PR TITLE
fix: trace Go tests to production code by extracting referenced symbols

### DIFF
--- a/internal/analyzer/testquality_aggregator_test.go
+++ b/internal/analyzer/testquality_aggregator_test.go
@@ -443,6 +443,61 @@ func TestTestQualityAggregator_MixedClassesAndFunctions(t *testing.T) {
 	assert.Equal(t, 0, len(agg.TestQuality.OrphanClasses))
 }
 
+func TestTestQualityAggregator_GoTraceability(t *testing.T) {
+	// Go test files reference the tested symbols directly (no import): the Go
+	// engine emits synthetic dependencies for them. Structs arrive qualified
+	// with the package name ("counter\Counter"), top-level functions arrive
+	// with their short name ("NewCounter"). Both must match the prod index.
+	agg := newAggregated()
+
+	ccn := int32(2)
+	prodFile := &pb.File{
+		Path:                "counter/counter.go",
+		ShortPath:           "counter.go",
+		ProgrammingLanguage: "Golang",
+		IsTest:              false,
+		Stmts: &pb.Stmts{
+			StmtClass: []*pb.StmtClass{
+				{
+					Name:  &pb.Name{Qualified: `counter\Counter`, Short: "Counter"},
+					Stmts: &pb.Stmts{Analyze: &pb.Analyze{Complexity: &pb.Complexity{Cyclomatic: &ccn}}},
+				},
+			},
+			StmtFunction: []*pb.StmtFunction{
+				{
+					Name:  &pb.Name{Qualified: "NewCounter", Short: "NewCounter"},
+					Stmts: &pb.Stmts{Analyze: &pb.Analyze{Complexity: &pb.Complexity{Cyclomatic: &ccn}}},
+				},
+			},
+		},
+	}
+
+	testFile := &pb.File{
+		Path:                "counter/counter_test.go",
+		ShortPath:           "counter_test.go",
+		ProgrammingLanguage: "Golang",
+		IsTest:              true,
+		Stmts: &pb.Stmts{
+			StmtExternalDependencies: []*pb.StmtExternalDependency{
+				{ClassName: `counter\Counter`, Namespace: "counter", From: "counter"},
+				{ClassName: "NewCounter", Namespace: "counter", From: "counter"},
+				{ClassName: "testing", Namespace: "testing", From: "counter"},
+			},
+		},
+	}
+
+	agg.ConcernedFiles = []*pb.File{prodFile, testFile}
+
+	tqa := NewTestQualityAggregator()
+	tqa.Calculate(&agg)
+
+	assert.NotNil(t, agg.TestQuality)
+	assert.Equal(t, 2, agg.TestQuality.NbProdClasses)
+	assert.Equal(t, 2, agg.TestQuality.NbTestedClasses)
+	assert.Equal(t, float64(100), agg.TestQuality.TraceabilityPct)
+	assert.Equal(t, 0, len(agg.TestQuality.OrphanClasses))
+}
+
 func TestBuildTestQualityJSON_Nil(t *testing.T) {
 	json := BuildTestQualityJSON(nil)
 	assert.Equal(t, "{}", json)

--- a/internal/engine/golang/golang_runner.go
+++ b/internal/engine/golang/golang_runner.go
@@ -129,6 +129,9 @@ func (r *GolangRunner) Parse(path string) (*pb.File, error) {
 
 	// Detect if file is a test file
 	file.IsTest = r.isTestFile(path, file)
+	if file.IsTest {
+		attachTestSymbolRefs(file, adapter, root, src)
+	}
 
 	return file, nil
 }

--- a/internal/engine/golang/golang_test_refs.go
+++ b/internal/engine/golang/golang_test_refs.go
@@ -1,0 +1,142 @@
+package golang
+
+import (
+	pb "github.com/halleck45/ast-metrics/pb"
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// A Go test lives in the same package as the code it tests: it references the
+// tested symbols directly, without any import. The import list of a test file
+// therefore says nothing about what the test exercises. To trace tests back to
+// production code, walk the test file and record the symbols it references:
+// type usages (Counter{}, var c Counter) and function calls (NewCounter()).
+// Types are qualified with the package name ("counter\Counter") to match the
+// qualified names produced by the visitor; functions keep their short name,
+// which is how top-level functions are indexed.
+
+// goBuiltinTypes lists the predeclared Go types: referencing one says nothing
+// about production code.
+var goBuiltinTypes = map[string]bool{
+	"bool": true, "byte": true, "complex64": true, "complex128": true,
+	"error": true, "float32": true, "float64": true,
+	"int": true, "int8": true, "int16": true, "int32": true, "int64": true,
+	"rune": true, "string": true,
+	"uint": true, "uint8": true, "uint16": true, "uint32": true, "uint64": true,
+	"uintptr": true, "any": true, "comparable": true,
+}
+
+// goBuiltinFuncs lists the predeclared Go functions.
+var goBuiltinFuncs = map[string]bool{
+	"append": true, "cap": true, "clear": true, "close": true, "complex": true,
+	"copy": true, "delete": true, "imag": true, "len": true, "make": true,
+	"max": true, "min": true, "new": true, "panic": true, "print": true,
+	"println": true, "real": true, "recover": true,
+}
+
+// attachTestSymbolRefs appends the symbols referenced by a test file to its
+// external dependencies, so the test quality aggregator can match them against
+// production structs and functions.
+func attachTestSymbolRefs(file *pb.File, adapter *TreeSitterAdapter, root *sitter.Node, src []byte) {
+	if file == nil || file.Stmts == nil || root == nil {
+		return
+	}
+
+	pkg := ""
+	if len(file.Stmts.StmtNamespace) > 0 && file.Stmts.StmtNamespace[0].Name != nil {
+		pkg = file.Stmts.StmtNamespace[0].Name.GetShort()
+	}
+
+	// imports maps the local name of an import ("assert") to its module path.
+	// A selector whose operand is not in this map is a call on a variable, not
+	// a package reference.
+	imports := map[string]string{}
+	// declared holds the names declared by the test file itself (helpers,
+	// mocks): a reference to them is not a reference to production code.
+	declared := map[string]bool{}
+	for i := 0; i < int(root.ChildCount()); i++ {
+		child := root.Child(i)
+		switch child.Type() {
+		case "import_declaration":
+			for _, it := range adapter.Imports(child) {
+				imports[it.Name] = it.Module
+			}
+		case "function_declaration":
+			if id := firstChildOfType(child, "identifier"); id != nil {
+				declared[text(src, id)] = true
+			}
+		case "type_declaration":
+			eachDescendantOfType(child, "type_spec", func(spec *sitter.Node) {
+				if name := spec.ChildByFieldName("name"); name != nil {
+					declared[text(src, name)] = true
+				}
+			})
+		}
+	}
+
+	seen := map[string]bool{}
+	addRef := func(className, namespace string) {
+		key := className + "|" + namespace
+		if className == "" || seen[key] {
+			return
+		}
+		seen[key] = true
+		file.Stmts.StmtExternalDependencies = append(file.Stmts.StmtExternalDependencies, &pb.StmtExternalDependency{
+			ClassName: className,
+			Namespace: namespace,
+			From:      pkg,
+		})
+	}
+
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "package_clause", "import_declaration":
+			return
+		case "qualified_type":
+			// pkg.Type: a type from another package (external test packages,
+			// "package counter_test", reference the tested package this way)
+			pkgID := firstChildOfType(n, "package_identifier")
+			typeID := firstChildOfType(n, "type_identifier")
+			if pkgID != nil && typeID != nil {
+				p := text(src, pkgID)
+				if module, ok := imports[p]; ok {
+					addRef(p+"\\"+text(src, typeID), module)
+				}
+			}
+			return
+		case "type_identifier":
+			name := text(src, n)
+			if pkg != "" && !goBuiltinTypes[name] && !declared[name] {
+				addRef(pkg+"\\"+name, pkg)
+			}
+			return
+		case "call_expression":
+			if fn := n.ChildByFieldName("function"); fn != nil {
+				switch fn.Type() {
+				case "identifier":
+					name := text(src, fn)
+					if !goBuiltinFuncs[name] && !goBuiltinTypes[name] && !declared[name] {
+						addRef(name, pkg)
+					}
+				case "selector_expression":
+					op := fn.ChildByFieldName("operand")
+					field := fn.ChildByFieldName("field")
+					if op != nil && op.Type() == "identifier" && field != nil {
+						p := text(src, op)
+						if module, ok := imports[p]; ok {
+							addRef(p+"\\"+text(src, field), module)
+						}
+					}
+				}
+			}
+			// keep walking: arguments may hold composite literals or nested calls
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+}

--- a/internal/engine/golang/golang_test_refs_test.go
+++ b/internal/engine/golang/golang_test_refs_test.go
@@ -1,0 +1,100 @@
+package golang
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/halleck45/ast-metrics/internal/engine"
+	"github.com/stretchr/testify/assert"
+)
+
+func parseGoSource(t *testing.T, filename, source string) map[string]bool {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, []byte(source), 0644); err != nil {
+		t.Fatal(err)
+	}
+	r := &GolangRunner{}
+	file, err := r.Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deps := map[string]bool{}
+	for _, d := range engine.GetDependenciesInFile(file) {
+		deps[d.GetClassName()] = true
+	}
+	return deps
+}
+
+func TestTestSymbolRefs_SamePackage(t *testing.T) {
+	deps := parseGoSource(t, "counter_test.go", `package counter
+
+import "testing"
+
+type mockClock struct{}
+
+func makeCounter() *Counter {
+	return NewCounter()
+}
+
+func TestCounter_Add(t *testing.T) {
+	c := makeCounter()
+	c.Add(2)
+	var other Counter
+	other.Add(len("x"))
+}
+`)
+
+	// struct references are qualified with the package name, like the visitor does
+	assert.True(t, deps[`counter\Counter`], "expected struct reference counter\\Counter, got %v", deps)
+	// top-level function calls keep their short name, which is how they are indexed
+	assert.True(t, deps["NewCounter"], "expected function reference NewCounter, got %v", deps)
+
+	// symbols declared by the test file itself are not production references
+	assert.False(t, deps[`counter\mockClock`])
+	assert.False(t, deps["makeCounter"])
+	assert.False(t, deps["TestCounter_Add"])
+	// builtins are ignored
+	assert.False(t, deps["len"])
+	assert.False(t, deps[`counter\int`])
+	// method calls on variables say nothing about which type is tested
+	assert.False(t, deps["Add"])
+}
+
+func TestTestSymbolRefs_ExternalTestPackage(t *testing.T) {
+	deps := parseGoSource(t, "counter_test.go", `package counter_test
+
+import (
+	"testing"
+
+	"example.com/mod/counter"
+)
+
+func TestCounter(t *testing.T) {
+	c := counter.Counter{}
+	_ = c
+	counter.NewCounter()
+}
+`)
+
+	assert.True(t, deps[`counter\Counter`], "expected qualified type reference, got %v", deps)
+	assert.True(t, deps[`counter\NewCounter`], "expected qualified call reference, got %v", deps)
+	// selectors on variables are not package references
+	assert.False(t, deps[`t\Run`])
+}
+
+func TestTestSymbolRefs_NotAttachedToProdFiles(t *testing.T) {
+	deps := parseGoSource(t, "counter.go", `package counter
+
+type Counter struct{ value int }
+
+func NewCounter() *Counter {
+	return &Counter{}
+}
+`)
+
+	assert.False(t, deps[`counter\Counter`])
+	assert.False(t, deps["NewCounter"])
+}


### PR DESCRIPTION
Extracts the symbols referenced by Go test files so the test-quality analyzer can link a test back to the production code it exercises.