### PR TITLE
chore: point the deploy PR documentation link to ast-metrics.dev

### DIFF
--- a/internal/command/deploy_github_organization_command.go
+++ b/internal/command/deploy_github_organization_command.go
@@ -591,7 +591,7 @@ func (c *DeployGithubOrganizationCommand) createPullRequest(repo GitHubRepo, hea
 architecture, complexity and hotspots on each push.
 
 No configuration needed.
-Documentation: https://halleck45.github.io/ast-metrics/`
+Documentation: https://ast-metrics.dev/`
 
 	payload := map[string]interface{}{
 		"title": title,


### PR DESCRIPTION
Updates the documentation URL used in the deploy GitHub organization command.