### PR TITLE
feat(report): rework the HTML report around a verdict per page

### DIFF
--- a/internal/analyzer/activity/bus_factor.go
+++ b/internal/analyzer/activity/bus_factor.go
@@ -73,6 +73,16 @@ func (busFactor *BusFactor) Calculate(aggregate *analyzer.Aggregated) {
 		}
 	}
 
+	// Addresses collected by the git analyzer, used to resolve avatars
+	emailByAuthor := make(map[string]string)
+	for _, gitAnalysis := range aggregate.ResultOfGitAnalysis {
+		for author, email := range gitAnalysis.AuthorEmails {
+			if _, known := emailByAuthor[author]; !known {
+				emailByAuthor[author] = email
+			}
+		}
+	}
+
 	// keep only top 4 committers
 	aggregate.TopCommitters = make([]analyzer.TopCommitter, 0)
 	for i, kv := range ss {
@@ -85,6 +95,7 @@ func (busFactor *BusFactor) Calculate(aggregate *analyzer.Aggregated) {
 		}
 		commiter := analyzer.TopCommitter{
 			Name:       kv.Key,
+			Email:      emailByAuthor[kv.Key],
 			Count:      kv.Value,
 			Percentage: percentage,
 		}

--- a/internal/analyzer/aggregator.go
+++ b/internal/analyzer/aggregator.go
@@ -2,7 +2,10 @@ package analyzer
 
 import (
 	"math"
+	"path/filepath"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/halleck45/ast-metrics/internal/analyzer/classifier"
@@ -17,10 +20,14 @@ type ProjectAggregated struct {
 	ByClass               Aggregated
 	Combined              Aggregated
 	ByProgrammingLanguage map[string]Aggregated
-	ErroredFiles          []*pb.File
-	Evaluation            *requirement.EvaluationResult
-	Comparaison           *ProjectComparaison
-	Predictions           []classifier.ClassPrediction
+	// ByDirectory holds one aggregate per analyzed path (the arguments given to
+	// the CLI, e.g. `ast-metrics analyze ./src ./lib`). It stays empty when a
+	// single path is analyzed, since that would duplicate the global view.
+	ByDirectory  map[string]Aggregated
+	ErroredFiles []*pb.File
+	Evaluation   *requirement.EvaluationResult
+	Comparaison  *ProjectComparaison
+	Predictions  []classifier.ClassPrediction
 }
 
 type AggregateResult struct {
@@ -47,8 +54,11 @@ type Aggregated struct {
 	ErroredFiles         []*pb.File
 	Comparaison          *Comparaison
 	// hashmap of classes, just with the qualified name, used for afferent coupling calculation
-	ClassesAfferentCoupling                 map[string]int
-	NbFiles                                 int
+	ClassesAfferentCoupling map[string]int
+	NbFiles                 int
+	// Number of test files. Test files are counted in NbFiles, but their metrics
+	// are excluded from all the aggregates below (they are not production code).
+	NbTestFiles                             int
 	NbFunctions                             int
 	NbClasses                               int
 	NbClassesWithCode                       int
@@ -107,10 +117,16 @@ type Aggregator struct {
 	gitSummaries      []ResultOfGitAnalysis
 	ComparedFiles     []*pb.File
 	ComparedBranch    string
+	// AnalyzedPaths are the paths given by the user on the command line. They
+	// drive the per-directory aggregation (ProjectAggregated.ByDirectory).
+	AnalyzedPaths []string
 }
 
 type TopCommitter struct {
-	Name       string
+	Name string
+	// Email is only used to resolve an avatar. It stays empty when the git log
+	// does not expose it.
+	Email      string
 	Count      int
 	Percentage float64
 }
@@ -122,7 +138,10 @@ type ResultOfGitAnalysis struct {
 	CountCommiters          int
 	CountCommitsForLanguage int
 	CountCommitsIgnored     int
-	GitRepository           Scm.GitRepository
+	// AuthorEmails maps an author display name to one of its commit addresses,
+	// so the report can resolve an avatar for the top contributors.
+	AuthorEmails  map[string]string
+	GitRepository Scm.GitRepository
 }
 
 func NewAggregator(files []*pb.File, gitSummaries []ResultOfGitAnalysis) *Aggregator {
@@ -149,6 +168,7 @@ func newAggregated() Aggregated {
 		ConcernedFiles:                          make([]*pb.File, 0),
 		ClassesAfferentCoupling:                 make(map[string]int),
 		ErroredFiles:                            make([]*pb.File, 0),
+		NbTestFiles:                             0,
 		NbClasses:                               0,
 		NbClassesWithCode:                       0,
 		NbMethods:                               0,
@@ -235,6 +255,19 @@ func (r *Aggregator) Aggregates() ProjectAggregated {
 			entry.Comparaison = &c
 			r.projectAggregated.ByProgrammingLanguage[lng] = entry
 		}
+
+		// By analyzed directory, so that the per-folder pages of the report also
+		// show the comparaison instead of an empty one
+		for dir, byDirectory := range r.projectAggregated.ByDirectory {
+			if _, ok := comparaidAggregated.ByDirectory[dir]; !ok {
+				continue
+			}
+			c := comparator.Compare(byDirectory, comparaidAggregated.ByDirectory[dir])
+			entry := r.projectAggregated.ByDirectory[dir]
+			entry.Comparaison = &c
+			r.projectAggregated.ByDirectory[dir] = entry
+		}
+
 		r.projectAggregated.Comparaison = &comparaison
 	}
 
@@ -248,6 +281,7 @@ func (r *Aggregator) executeAggregationOnFiles(files []*pb.File) ProjectAggregat
 		ByClass:               newAggregated(),
 		Combined:              newAggregated(),
 		ByProgrammingLanguage: make(map[string]Aggregated),
+		ByDirectory:           make(map[string]Aggregated),
 		ErroredFiles:          make([]*pb.File, 0),
 		Evaluation:            nil,
 		Comparaison:           nil,
@@ -280,10 +314,32 @@ func (r *Aggregator) executeAggregationOnFiles(files []*pb.File) ProjectAggregat
 		}
 	}
 
+	// for each analyzed path (CLI argument), we create a separated result. Only
+	// when several paths are analyzed: with a single one, the directory view
+	// would be a duplicate of the global view.
+	aggregateByDirectoryChunk := make(map[string]Aggregated)
+	directoryOfFile := make(map[*pb.File]string)
+	if len(r.AnalyzedPaths) > 1 {
+		scopes := buildAnalyzedPathScopes(r.AnalyzedPaths)
+		if len(scopes) > 1 {
+			for _, file := range files {
+				key, ok := scopeOfFile(scopes, file.Path)
+				if !ok {
+					continue
+				}
+				directoryOfFile[file] = key
+				if _, exists := aggregateByDirectoryChunk[key]; !exists {
+					aggregateByDirectoryChunk[key] = newAggregated()
+				}
+			}
+		}
+	}
+
 	// Create channels for the results
 	resultsByClass := make(chan *Aggregated, numberOfProcessors)
 	resultsByFile := make(chan *Aggregated, numberOfProcessors)
 	resultsByProgrammingLanguage := make(chan *map[string]Aggregated, numberOfProcessors)
+	resultsByDirectory := make(chan *map[string]Aggregated, numberOfProcessors)
 
 	// Deadlock prevention
 	mu := sync.Mutex{}
@@ -321,11 +377,17 @@ func (r *Aggregator) executeAggregationOnFiles(files []*pb.File) ProjectAggregat
 				result.ConcernedFiles = append(result.ConcernedFiles, localFile)
 				aggregateByClassChunk = result
 
-				// by language
+				// by language, and by analyzed directory
 				mu.Lock()
 				byLanguage := r.mapSums(localFile, aggregateByLanguageChunk[localFile.ProgrammingLanguage])
 				byLanguage.ConcernedFiles = append(byLanguage.ConcernedFiles, localFile)
 				aggregateByLanguageChunk[localFile.ProgrammingLanguage] = byLanguage
+
+				if directory, ok := directoryOfFile[localFile]; ok {
+					byDirectory := r.mapSums(localFile, aggregateByDirectoryChunk[directory])
+					byDirectory.ConcernedFiles = append(byDirectory.ConcernedFiles, localFile)
+					aggregateByDirectoryChunk[directory] = byDirectory
+				}
 				mu.Unlock()
 			}
 
@@ -333,6 +395,7 @@ func (r *Aggregator) executeAggregationOnFiles(files []*pb.File) ProjectAggregat
 			resultsByClass <- &aggregateByClassChunk
 			resultsByFile <- &aggregateByFileChunk
 			resultsByProgrammingLanguage <- &aggregateByLanguageChunk
+			resultsByDirectory <- &aggregateByDirectoryChunk
 
 		}(chunks[chunkIndex])
 		chunkIndex++
@@ -342,6 +405,7 @@ func (r *Aggregator) executeAggregationOnFiles(files []*pb.File) ProjectAggregat
 	close(resultsByClass)
 	close(resultsByFile)
 	close(resultsByProgrammingLanguage)
+	close(resultsByDirectory)
 
 	// Now we have chunk of sums. We want to reduce its into a single object
 	wg.Add(1)
@@ -373,6 +437,12 @@ func (r *Aggregator) executeAggregationOnFiles(files []*pb.File) ProjectAggregat
 				projectAggregated.ByProgrammingLanguage[k] = v
 			}
 		}
+
+		for chunk := range resultsByDirectory {
+			for k, v := range *chunk {
+				projectAggregated.ByDirectory[k] = v
+			}
+		}
 	}()
 
 	wg.Wait()
@@ -384,6 +454,11 @@ func (r *Aggregator) executeAggregationOnFiles(files []*pb.File) ProjectAggregat
 		v = r.reduceMetrics(v)
 		f := r.mapCoupling(&v)
 		projectAggregated.ByProgrammingLanguage[k] = f
+	}
+	for k, v := range projectAggregated.ByDirectory {
+		v = r.reduceMetrics(v)
+		f := r.mapCoupling(&v)
+		projectAggregated.ByDirectory[k] = f
 	}
 
 	// Coupling (should be done separately, to avoid race condition)
@@ -407,6 +482,86 @@ func (r *Aggregator) WithAggregateAnalyzer(analyzer AggregateAnalyzer) {
 	r.analyzers = append(r.analyzers, analyzer)
 }
 
+// WithAnalyzedPaths declares the paths given by the user on the command line.
+// They are used to build ProjectAggregated.ByDirectory: one aggregate per
+// analyzed path. When fewer than two paths are given, no per-directory
+// aggregate is produced (it would be a copy of the global view).
+func (r *Aggregator) WithAnalyzedPaths(paths []string) {
+	r.AnalyzedPaths = paths
+}
+
+// analyzedPathScope links an analyzed path, as typed by the user, to the
+// absolute prefix used to decide whether a file belongs to it.
+type analyzedPathScope struct {
+	// Key is the path as given by the user: it is the ByDirectory map key.
+	Key string
+	// Abs is the cleaned, absolute form of Key.
+	Abs string
+}
+
+// buildAnalyzedPathScopes resolves the analyzed paths to absolute prefixes,
+// sorted from the longest to the shortest one so that nested paths are matched
+// by their most specific scope. Duplicates are dropped.
+func buildAnalyzedPathScopes(paths []string) []analyzedPathScope {
+	scopes := make([]analyzedPathScope, 0, len(paths))
+	seen := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		abs := p
+		if !filepath.IsAbs(abs) {
+			resolved, err := filepath.Abs(abs)
+			if err != nil {
+				continue
+			}
+			abs = resolved
+		}
+		abs = filepath.Clean(abs)
+		if seen[abs] {
+			continue
+		}
+		seen[abs] = true
+		scopes = append(scopes, analyzedPathScope{Key: p, Abs: abs})
+	}
+
+	// Longest prefix first: a file under ./src/vendor belongs to ./src/vendor,
+	// not to ./src, when both are analyzed.
+	sort.SliceStable(scopes, func(i, j int) bool {
+		return len(scopes[i].Abs) > len(scopes[j].Abs)
+	})
+
+	return scopes
+}
+
+// scopeOfFile returns the key of the analyzed path a file belongs to. A file
+// belongs to exactly one scope (the most specific one).
+func scopeOfFile(scopes []analyzedPathScope, filePath string) (string, bool) {
+	if filePath == "" {
+		return "", false
+	}
+	abs := filePath
+	if !filepath.IsAbs(abs) {
+		resolved, err := filepath.Abs(abs)
+		if err != nil {
+			return "", false
+		}
+		abs = resolved
+	}
+	abs = filepath.Clean(abs)
+
+	for _, scope := range scopes {
+		if abs == scope.Abs {
+			return scope.Key, true
+		}
+		if strings.HasPrefix(abs, scope.Abs+string(filepath.Separator)) {
+			return scope.Key, true
+		}
+	}
+
+	return "", false
+}
+
 // Set the files and branch to compare with
 func (r *Aggregator) WithComparaison(allResultsCloned []*pb.File, comparedBranch string) {
 	r.ComparedFiles = allResultsCloned
@@ -418,10 +573,20 @@ func (r *Aggregator) mapSums(file *pb.File, specificAggregation Aggregated) Aggr
 	// copy the specific aggregation to new object to avoid side effects
 	result := specificAggregation
 	result.NbFiles++
+	if file.GetIsTest() {
+		result.NbTestFiles++
+	}
 
 	// deal with errors
 	if len(file.Errors) > 0 {
 		result.ErroredFiles = append(result.ErroredFiles, file)
+		return result
+	}
+
+	// Test files are not production code: they are kept in ConcernedFiles (the
+	// TestQuality and Graph analyzers need them), but their metrics must not
+	// pollute the averages of the project.
+	if file.GetIsTest() {
 		return result
 	}
 
@@ -734,6 +899,7 @@ func (r *Aggregator) mergeChunks(aggregated Aggregated, chunk *Aggregated) Aggre
 	result := aggregated
 	result.ConcernedFiles = append(result.ConcernedFiles, chunk.ConcernedFiles...)
 	result.NbFiles += chunk.NbFiles
+	result.NbTestFiles += chunk.NbTestFiles
 	result.NbClasses += chunk.NbClasses
 	result.NbClassesWithCode += chunk.NbClassesWithCode
 	result.NbMethods += chunk.NbMethods
@@ -794,6 +960,12 @@ func (r *Aggregator) mergeChunks(aggregated Aggregated, chunk *Aggregated) Aggre
 
 	result.MaintainabilityIndex.Sum += chunk.MaintainabilityIndex.Sum
 	result.MaintainabilityIndex.Counter += chunk.MaintainabilityIndex.Counter
+	if result.MaintainabilityIndex.Min == 0 || (chunk.MaintainabilityIndex.Min > 0 && chunk.MaintainabilityIndex.Min < result.MaintainabilityIndex.Min) {
+		result.MaintainabilityIndex.Min = chunk.MaintainabilityIndex.Min
+	}
+	if chunk.MaintainabilityIndex.Max > result.MaintainabilityIndex.Max {
+		result.MaintainabilityIndex.Max = chunk.MaintainabilityIndex.Max
+	}
 	result.MaintainabilityIndexWithoutComments.Sum += chunk.MaintainabilityIndexWithoutComments.Sum
 	result.MaintainabilityIndexWithoutComments.Counter += chunk.MaintainabilityIndexWithoutComments.Counter
 	result.MaintainabilityCommentWeight.Sum += chunk.MaintainabilityCommentWeight.Sum
@@ -931,15 +1103,20 @@ func (r *Aggregator) mapCoupling(aggregated *Aggregated) Aggregated {
 	// Create the hashmaps of files, by Path then by class name.
 	files := make(map[string]*pb.File)
 	classesMap := make(map[string]*pb.StmtClass)
-	// Populate the 'files' map with namespace keys
+	// Populate the 'files' map with namespace keys.
+	// Test files are skipped: they are not production code, so they must neither
+	// contribute to the coupling sums nor be reachable as a coupling source.
 	for _, fileItem := range aggregated.ConcernedFiles {
+		if fileItem == nil || fileItem.GetIsTest() {
+			continue
+		}
 		namespace := engine.ReduceDepthOfNamespace(fileItem.Path, 2)
 		files[namespace] = fileItem
 	}
 
 	// populate the classmap
 	for _, file := range aggregated.ConcernedFiles {
-		if file == nil || file.Stmts == nil {
+		if file == nil || file.Stmts == nil || file.GetIsTest() {
 			continue
 		}
 		for _, class := range engine.GetClassesInFile(file) {
@@ -953,6 +1130,14 @@ func (r *Aggregator) mapCoupling(aggregated *Aggregated) Aggregated {
 	for _, file := range aggregated.ConcernedFiles {
 
 		if file == nil || file.Stmts == nil || file.Stmts.StmtExternalDependencies == nil {
+			continue
+		}
+
+		// Test files are ignored as a source of dependencies: a class used only by
+		// tests must not see its afferent coupling inflated, and test classes must
+		// not be counted in the efferent/afferent coupling sums nor in the package
+		// relations graph.
+		if file.GetIsTest() {
 			continue
 		}
 
@@ -1103,8 +1288,12 @@ func (r *Aggregator) mapCoupling(aggregated *Aggregated) Aggregated {
 		result.Instability.Avg = result.EfferentCoupling.Sum / (result.AfferentCoupling.Sum + result.EfferentCoupling.Sum)
 	}
 
-	result.EfferentCoupling.Avg = result.EfferentCoupling.Sum / float64(result.EfferentCoupling.Counter)
-	result.AfferentCoupling.Avg = result.AfferentCoupling.Sum / float64(result.AfferentCoupling.Counter)
+	if result.EfferentCoupling.Counter > 0 {
+		result.EfferentCoupling.Avg = result.EfferentCoupling.Sum / float64(result.EfferentCoupling.Counter)
+	}
+	if result.AfferentCoupling.Counter > 0 {
+		result.AfferentCoupling.Avg = result.AfferentCoupling.Sum / float64(result.AfferentCoupling.Counter)
+	}
 
 	return result
 }

--- a/internal/analyzer/aggregator_test.go
+++ b/internal/analyzer/aggregator_test.go
@@ -512,3 +512,62 @@ func TestMergeChunksKeepsPerMethodAggregates(t *testing.T) {
 	assert.Equal(t, float64(1), result.CyclomaticComplexityPerMethod.Min)
 	assert.Equal(t, float64(14), result.CyclomaticComplexityPerMethod.Max)
 }
+
+// TestAggregatesByDirectory checks the per-directory aggregation: one aggregate
+// per path given on the command line, each file belonging to exactly one scope.
+func TestAggregatesByDirectory(t *testing.T) {
+	files := []*pb.File{
+		{Path: "/project/src/a.php", ProgrammingLanguage: "PHP"},
+		{Path: "/project/src/deep/b.php", ProgrammingLanguage: "PHP"},
+		{Path: "/project/lib/c.php", ProgrammingLanguage: "PHP"},
+		{Path: "/elsewhere/d.php", ProgrammingLanguage: "PHP"},
+	}
+
+	aggregator := NewAggregator(files, nil)
+	aggregator.WithAnalyzedPaths([]string{"/project/src", "/project/lib"})
+	project := aggregator.Aggregates()
+
+	assert.Len(t, project.ByDirectory, 2)
+	assert.Equal(t, 2, project.ByDirectory["/project/src"].NbFiles)
+	assert.Equal(t, 1, project.ByDirectory["/project/lib"].NbFiles)
+	assert.Len(t, project.ByDirectory["/project/src"].ConcernedFiles, 2)
+
+	// files outside every analyzed path are only counted globally
+	assert.Equal(t, 4, project.ByFile.NbFiles)
+}
+
+// TestAggregatesByDirectoryPicksTheMostSpecificPath checks that a file under two
+// nested analyzed paths belongs to the deepest one only.
+func TestAggregatesByDirectoryPicksTheMostSpecificPath(t *testing.T) {
+	files := []*pb.File{
+		{Path: "/project/src/a.php", ProgrammingLanguage: "PHP"},
+		{Path: "/project/src/vendor/b.php", ProgrammingLanguage: "PHP"},
+	}
+
+	aggregator := NewAggregator(files, nil)
+	aggregator.WithAnalyzedPaths([]string{"/project/src", "/project/src/vendor"})
+	project := aggregator.Aggregates()
+
+	assert.Equal(t, 1, project.ByDirectory["/project/src"].NbFiles)
+	assert.Equal(t, 1, project.ByDirectory["/project/src/vendor"].NbFiles)
+	assert.Equal(t, "/project/src/vendor/b.php", project.ByDirectory["/project/src/vendor"].ConcernedFiles[0].Path)
+}
+
+// TestAggregatesWithoutSeveralAnalyzedPaths guards the mono-folder case: a single
+// analyzed path must not duplicate the global view.
+func TestAggregatesWithoutSeveralAnalyzedPaths(t *testing.T) {
+	files := []*pb.File{{Path: "/project/src/a.php", ProgrammingLanguage: "PHP"}}
+
+	single := NewAggregator(files, nil)
+	single.WithAnalyzedPaths([]string{"/project/src"})
+	assert.Empty(t, single.Aggregates().ByDirectory)
+
+	// same path given twice is still a single scope
+	twice := NewAggregator(files, nil)
+	twice.WithAnalyzedPaths([]string{"/project/src", "/project/src/"})
+	assert.Empty(t, twice.Aggregates().ByDirectory)
+
+	// no analyzed path at all (lint, review, mcp)
+	none := NewAggregator(files, nil)
+	assert.Empty(t, none.Aggregates().ByDirectory)
+}

--- a/internal/analyzer/component/maintainability_index_visitor.go
+++ b/internal/analyzer/component/maintainability_index_visitor.go
@@ -73,6 +73,16 @@ func (v *MaintainabilityIndexVisitor) Calculate(stmts *pb.Stmts) {
 	var cloc int32 = *stmts.Analyze.Volume.Cloc
 	var cyclomatic int32 = *stmts.Analyze.Complexity.Cyclomatic
 	var halsteadVolume float64 = *stmts.Analyze.Volume.HalsteadVolume
+
+	// The index is built on the logarithm of the Halstead volume, so a volume of
+	// zero has no defined index. That covers a declaration holding no statement
+	// (a struct of fields, an interface) as well as a body made of a single
+	// distinct symbol, whose volume is N x log2(1) = 0. Leaving the index
+	// undefined keeps those out of the averages, where an invented value would
+	// drag the whole project down.
+	if halsteadVolume <= 0 {
+		return
+	}
 	var MIwoC float64 = 0
 	var MI float64 = 0
 	var commentWeight float64 = 0
@@ -101,11 +111,6 @@ func (v *MaintainabilityIndexVisitor) Calculate(stmts *pb.Stmts) {
 		MIwoC = 0
 		commentWeight = 0
 	}
-	// Fallback for empty Halstead on non-empty nodes, but only for class scopes (PHP expectation)
-	if v.inClass && MI == 0 && halsteadVolume == 0 && (loc > 0 || lloc > 0) {
-		MI = 7
-	}
-
 	MI32 := float64(MI)
 	MIwoC32 := float64(MIwoC)
 	commentWeight32 := float64(commentWeight)

--- a/internal/analyzer/git_analyzer.go
+++ b/internal/analyzer/git_analyzer.go
@@ -4,8 +4,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	pb "github.com/halleck45/ast-metrics/pb"
 	"github.com/halleck45/ast-metrics/internal/scm"
+	pb "github.com/halleck45/ast-metrics/pb"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -79,6 +79,7 @@ func (gitAnalyzer *GitAnalyzer) CalculateCount(files []*pb.File) []ResultOfGitAn
 			CountCommiters:          0,
 			CountCommitsForLanguage: 0,
 			CountCommitsIgnored:     0,
+			AuthorEmails:            make(map[string]string),
 		}
 
 		// Map of committers
@@ -148,6 +149,11 @@ func (gitAnalyzer *GitAnalyzer) CalculateCount(files []*pb.File) []ResultOfGitAn
 			if doesCommitConcernsObservedProgrammingLanguage {
 				// add committer to the map
 				committersOnRepository[commit.Author] = true
+				if commit.Email != "" {
+					if _, known := summary.AuthorEmails[commit.Author]; !known {
+						summary.AuthorEmails[commit.Author] = commit.Email
+					}
+				}
 
 				summary.CountCommitsForLanguage++
 			}

--- a/internal/analyzer/volume/halstead_metrics_visitor.go
+++ b/internal/analyzer/volume/halstead_metrics_visitor.go
@@ -17,89 +17,57 @@ func (v *HalsteadMetricsVisitor) Visit(stmts *pb.Stmts, parents *pb.Stmts) {
 		return
 	}
 
-	// calculate the number of lines of code in each method
-	var operatorSet map[string]bool
-	var operandSet map[string]bool
-	operatorSet = make(map[string]bool)
-	operandSet = make(map[string]bool)
-	var name string
-
-	var n int32  // program vocabulary (η)
-	var n1 int32 // number of unique operators
-	var n2 int32 // number of unique operands
-	var N int32  // program length (N)
-	var N1 int32
-	var N2 int32
-	var hatN float64 = 0 // estimated program length (𝑁̂)
-	var V float64 = 0    // volume (V)
-	var D float64 = 0    // difficulty (D)
-	var E float64 = 0    // effort (E)
-	var T float64 = 0    // time required to program (T)
-
 	for _, stmt := range parents.StmtFunction {
 		if stmt.Stmts == nil {
 			continue
 		}
 
-		// get unique operators and operands
-
-		if stmts == nil {
-			return
-		}
+		// Everything below is scoped to this method. Sharing the counters (or
+		// the pointers taken on them) across iterations would give every method
+		// of a class the figures of the last one visited.
+		operatorSet := make(map[string]bool)
+		operandSet := make(map[string]bool)
 
 		for _, operator := range stmt.Operators {
-			name = operator.Name
-			if _, ok := operatorSet[name]; !ok {
-				operatorSet[name] = true
-			}
+			operatorSet[operator.Name] = true
 		}
-
 		for _, operand := range stmt.Operands {
-			name = operand.Name
-			if _, ok := operandSet[name]; !ok {
-				operandSet[name] = true
-			}
+			operandSet[operand.Name] = true
 		}
 
-		// Calculate Halstead metrics
-		n1 = int32(len(operatorSet))
-		n2 = int32(len(operandSet))
-		N1 = int32(len(stmt.Operators))
-		N2 = int32(len(stmt.Operands))
+		n1 := int32(len(operatorSet)) // unique operators
+		n2 := int32(len(operandSet))  // unique operands
+		N1 := int32(len(stmt.Operators))
+		N2 := int32(len(stmt.Operands))
 
-		// Calculate program vocabulary (η)
-		n = int32(n1 + n2)
+		n := n1 + n2 // program vocabulary (η)
+		N := N1 + N2 // program length (N)
 
-		// Calculate program length (N)
-		N = int32(N1 + N2)
-
-		// Calculate estimated program length (𝑁̂)
-		hatN = float64(n1)*float64(math.Log2(float64(n1))) + float64(n2)*float64(math.Log2(float64(n2)))
-		if math.IsNaN(float64(hatN)) {
+		// estimated program length (𝑁̂)
+		hatN := float64(n1)*math.Log2(float64(n1)) + float64(n2)*math.Log2(float64(n2))
+		if math.IsNaN(hatN) || math.IsInf(hatN, 0) {
 			hatN = 0
 		}
 
-		// Calculate volume (V)
-		V = float64(N) * float64(math.Log2(float64(n)))
-		if math.IsNaN(float64(V)) {
+		// volume (V)
+		V := float64(N) * math.Log2(float64(n))
+		if math.IsNaN(V) || math.IsInf(V, 0) {
 			V = 0
 		}
 
-		// Calculate difficulty (D)
-		D = float64(n1) / 2 * float64(N2) / float64(n2)
-		if math.IsNaN(float64(D)) {
+		// difficulty (D)
+		D := float64(n1) / 2 * float64(N2) / float64(n2)
+		if math.IsNaN(D) || math.IsInf(D, 0) {
 			D = 0
 		}
 
-		// Calculate effort (E)
-		E = D * V
+		E := D * V  // effort (E)
+		T := E / 18 // time required to program (T)
 
-		// Calculate time required to program (T)
-		T = E / 18
-
-		// Assign to result
 		if stmt.Stmts.Analyze == nil {
 			stmt.Stmts.Analyze = &pb.Analyze{}
+		}
+		if stmt.Stmts.Analyze.Volume == nil {
 			stmt.Stmts.Analyze.Volume = &pb.Volume{}
 		}
 
@@ -143,8 +111,8 @@ func (v *HalsteadMetricsVisitor) Visit(stmts *pb.Stmts, parents *pb.Stmts) {
 		}
 
 		if count > 0 {
-			nn = nn / int32(count)
-			NN = NN / int32(count)
+			nn = int32(math.Round(float64(nn) / float64(count)))
+			NN = int32(math.Round(float64(NN) / float64(count)))
 			hhatN = hhatN / float64(count)
 			VV = VV / float64(count)
 			DD = DD / float64(count)
@@ -213,8 +181,8 @@ func (v *HalsteadMetricsVisitor) aggregateScope(stmts *pb.Stmts) {
 	if cnt == 0 {
 		return
 	}
-	n /= int32(cnt)
-	N /= int32(cnt)
+	n = int32(math.Round(float64(n) / float64(cnt)))
+	N = int32(math.Round(float64(N) / float64(cnt)))
 	hatN /= float64(cnt)
 	V /= float64(cnt)
 	D /= float64(cnt)
@@ -283,15 +251,18 @@ func (v *HalsteadMetricsVisitor) LeaveNode(stmts *pb.Stmts) {
 				}
 			}
 
-			// calculate the average
+			// calculate the average. Vocabulary and length are rounded rather
+			// than truncated: an integer division would report zero for a class
+			// whose methods each hold only a symbol or two.
 			if len(stmt.Stmts.StmtFunction) > 0 {
-				n = n / int32(len(stmt.Stmts.StmtFunction))
-				N = N / int32(len(stmt.Stmts.StmtFunction))
-				hatN = hatN / float64(len(stmt.Stmts.StmtFunction))
-				V = V / float64(len(stmt.Stmts.StmtFunction))
-				D = D / float64(len(stmt.Stmts.StmtFunction))
-				E = E / float64(len(stmt.Stmts.StmtFunction))
-				T = T / float64(len(stmt.Stmts.StmtFunction))
+				count := float64(len(stmt.Stmts.StmtFunction))
+				n = int32(math.Round(float64(n) / count))
+				N = int32(math.Round(float64(N) / count))
+				hatN = hatN / count
+				V = V / count
+				D = D / count
+				E = E / count
+				T = T / count
 			}
 
 			// Assign to result
@@ -352,8 +323,8 @@ func (v *HalsteadMetricsVisitor) LeaveNode(stmts *pb.Stmts) {
 
 		if cnt > 0 {
 			// average
-			n = n / int32(cnt)
-			N = N / int32(cnt)
+			n = int32(math.Round(float64(n) / float64(cnt)))
+			N = int32(math.Round(float64(N) / float64(cnt)))
 			hatN = hatN / float64(cnt)
 			V = V / float64(cnt)
 			D = D / float64(cnt)

--- a/internal/analyzer/volume/halstead_per_method_test.go
+++ b/internal/analyzer/volume/halstead_per_method_test.go
@@ -1,0 +1,97 @@
+package analyzer
+
+import (
+	"testing"
+
+	pb "github.com/halleck45/ast-metrics/pb"
+	"google.golang.org/protobuf/proto"
+)
+
+// method builds a function statement holding the given operators and operands.
+func method(name string, operators, operands []string) *pb.StmtFunction {
+	fn := &pb.StmtFunction{
+		Name:  &pb.Name{Short: name},
+		Stmts: &pb.Stmts{Analyze: &pb.Analyze{Volume: &pb.Volume{}}},
+	}
+	for _, o := range operators {
+		fn.Operators = append(fn.Operators, &pb.StmtOperator{Name: o})
+	}
+	for _, o := range operands {
+		fn.Operands = append(fn.Operands, &pb.StmtOperand{Name: o})
+	}
+	return fn
+}
+
+// Each method must keep its own figures. They used to share the pointers taken
+// on the visitor's local counters, so every method of a class ended up with the
+// numbers of the last one visited: a class whose last method was trivial
+// reported a volume of zero, and its maintainability index fell back to 7.
+func TestHalsteadIsComputedPerMethodNotShared(t *testing.T) {
+	dense := method("dense", []string{"+", "-", "*", "+"}, []string{"a", "b", "c", "a"})
+	trivial := method("trivial", nil, nil)
+
+	class := &pb.StmtClass{
+		Name:  &pb.Name{Short: "C"},
+		Stmts: &pb.Stmts{Analyze: &pb.Analyze{Volume: &pb.Volume{}}},
+	}
+	class.Stmts.StmtFunction = []*pb.StmtFunction{dense, trivial}
+
+	visitor := &HalsteadMetricsVisitor{}
+	visitor.Visit(class.Stmts, class.Stmts)
+
+	// dense: 4 operators (3 distinct) + 4 operands (3 distinct) => N=8, n=6
+	if got := dense.Stmts.Analyze.Volume.GetHalsteadLength(); got != 8 {
+		t.Errorf("dense method: expected length 8, got %d", got)
+	}
+	if got := dense.Stmts.Analyze.Volume.GetHalsteadVocabulary(); got != 6 {
+		t.Errorf("dense method: expected vocabulary 6, got %d", got)
+	}
+	if got := dense.Stmts.Analyze.Volume.GetHalsteadVolume(); got <= 0 {
+		t.Errorf("dense method: expected a positive volume, got %v", got)
+	}
+
+	// the trivial method has nothing to measure, and must not have inherited
+	// the figures of the dense one
+	if got := trivial.Stmts.Analyze.Volume.GetHalsteadLength(); got != 0 {
+		t.Errorf("trivial method: expected length 0, got %d", got)
+	}
+	if got := trivial.Stmts.Analyze.Volume.GetHalsteadVolume(); got != 0 {
+		t.Errorf("trivial method: expected volume 0, got %v", got)
+	}
+}
+
+// The class average is rounded, not truncated: an integer division reported
+// zero for a class whose methods each held a symbol or two.
+func TestHalsteadClassAverageIsRoundedNotTruncated(t *testing.T) {
+	file := &pb.Stmts{Analyze: &pb.Analyze{Volume: &pb.Volume{}}}
+	class := &pb.StmtClass{
+		Name:  &pb.Name{Short: "Small"},
+		Stmts: &pb.Stmts{Analyze: &pb.Analyze{Volume: &pb.Volume{}}},
+	}
+	// three methods holding one symbol each: the sum stays below the method
+	// count, which used to truncate the average down to zero
+	for _, name := range []string{"a", "b", "c"} {
+		m := method(name, []string{"+"}, nil)
+		m.Stmts.Analyze.Volume = &pb.Volume{
+			HalsteadVocabulary:      proto.Int32(1),
+			HalsteadLength:          proto.Int32(1),
+			HalsteadEstimatedLength: proto.Float64(0),
+			HalsteadVolume:          proto.Float64(0),
+			HalsteadDifficulty:      proto.Float64(0),
+			HalsteadEffort:          proto.Float64(0),
+			HalsteadTime:            proto.Float64(0),
+		}
+		class.Stmts.StmtFunction = append(class.Stmts.StmtFunction, m)
+	}
+	file.StmtClass = []*pb.StmtClass{class}
+
+	visitor := &HalsteadMetricsVisitor{}
+	visitor.LeaveNode(file)
+
+	if got := class.Stmts.Analyze.Volume.GetHalsteadLength(); got != 1 {
+		t.Errorf("class average: expected length 1, got %d", got)
+	}
+	if got := class.Stmts.Analyze.Volume.GetHalsteadVocabulary(); got != 1 {
+		t.Errorf("class average: expected vocabulary 1, got %d", got)
+	}
+}

--- a/internal/command/analyze_command.go
+++ b/internal/command/analyze_command.go
@@ -128,6 +128,8 @@ func (v *AnalyzeCommand) Execute() error {
 	// Start aggregating results
 	aggregator := analyzer.NewAggregator(allResults, v.gitSummaries)
 	aggregator.WithAggregateAnalyzer(Activity.NewBusFactor())
+	// Per-directory views of the HTML report: one scope per analyzed path
+	aggregator.WithAnalyzedPaths(v.Configuration.SourcesToAnalyzePath)
 	if v.Configuration.CompareWith != "" {
 		aggregator.WithComparaison(allResultsCloned, v.Configuration.CompareWith)
 	}

--- a/internal/engine/golang/golang_maintainability_test.go
+++ b/internal/engine/golang/golang_maintainability_test.go
@@ -63,9 +63,10 @@ func Test_FileLevel_Maintainability_SampleGo(t *testing.T) {
 	if file.Stmts.Analyze.Volume == nil {
 		t.Fatalf("missing Volume on sampleGo file")
 	}
-	// average of the struct C (its method M) and of the top-level function F
-	if *file.Stmts.Analyze.Volume.HalsteadVocabulary != int32(7) {
-		t.Fatalf("incorrect halstead volume on file, got %d", *file.Stmts.Analyze.Volume.HalsteadVocabulary)
+	// Average of the struct C (whose only method M holds 8 distinct symbols) and
+	// of the top-level function F (3 distinct symbols): (8 + 3) / 2 = 5.5, so 6.
+	if *file.Stmts.Analyze.Volume.HalsteadVocabulary != int32(6) {
+		t.Fatalf("incorrect halstead vocabulary on file, got %d", *file.Stmts.Analyze.Volume.HalsteadVocabulary)
 	}
 	if file.Stmts.Analyze.Volume.Loc == nil || file.Stmts.Analyze.Volume.Lloc == nil || file.Stmts.Analyze.Volume.Cloc == nil {
 		t.Fatalf("missing LOC/LLOC/CLOC on sampleGo file")

--- a/internal/engine/php/php_runner_test.go
+++ b/internal/engine/php/php_runner_test.go
@@ -809,9 +809,19 @@ class Registry
 	assert.Equal(t, 1, len(result.Stmts.StmtClass), "Incorrect number of classes")
 	class1 := result.Stmts.StmtClass[0]
 
-	// Ensure MI
-	if *class1.Stmts.Analyze.Maintainability.MaintainabilityIndex != 7 {
-		t.Fatalf("incorrect Maintainability Index, got %f", *class1.Stmts.Analyze.Maintainability.MaintainabilityIndex)
+	// The index is undefined here, and must stay so rather than default to 171
+	// or to an invented placeholder: none of the three methods yields a Halstead
+	// volume, so there is nothing to build an index on. What matters is that the
+	// analysis does not crash and does not report a fabricated figure.
+	if class1.Stmts.Analyze.Maintainability != nil &&
+		class1.Stmts.Analyze.Maintainability.MaintainabilityIndex != nil {
+		got := *class1.Stmts.Analyze.Maintainability.MaintainabilityIndex
+		if got == 171 {
+			t.Fatalf("Maintainability Index should not default to 171")
+		}
+		if got <= 0 {
+			t.Fatalf("Maintainability Index should be either absent or positive, got %f", got)
+		}
 	}
 }
 

--- a/internal/report/html_report_generator.go
+++ b/internal/report/html_report_generator.go
@@ -1,12 +1,14 @@
 package report
 
 import (
+	"crypto/md5"
 	"embed"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -30,7 +32,8 @@ var (
 	htmlContent embed.FS
 )
 
-// cachedLangData holds pre-computed JSON strings for a given language view.
+// cachedLangData holds pre-computed JSON strings for a given scope (the whole
+// project, one language, or one analyzed directory).
 type cachedLangData struct {
 	filesJSON           string
 	risksJSON           string
@@ -46,7 +49,7 @@ type cachedLangData struct {
 type HtmlReportGenerator struct {
 	// The path where the report will be generated
 	ReportPath string
-	// langCache holds pre-computed JSON per language key (built once in Generate)
+	// langCache holds pre-computed JSON per scope data key (built once in Generate)
 	langCache map[string]*cachedLangData
 }
 
@@ -87,6 +90,8 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 		"risks.html",
 		"compare.html",
 		"explorer.html",
+		"classes.html",
+		"metrics.html",
 		"linters.html",
 		"classification.html",
 		"componentChartRadiusBar.html",
@@ -108,6 +113,7 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 		"testquality.html",
 		"partials/suggestions.html",
 		"partials/file_explorer_sidebar.html",
+		"partials/language_tabs.html",
 	} {
 		// read the file
 		bytes, err := htmlContent.ReadFile(fmt.Sprintf("templates/html/%s", file))
@@ -136,23 +142,23 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 	// Custom filters
 	v.RegisterFilters()
 
-	// Pre-compute JSON data once per language to avoid redundant work across pages
+	// Build the list of available scopes: the whole project, then one per
+	// programming language, then one per analyzed directory (CLI argument).
+	scopeDefs := buildScopes(files, projectAggregated)
+
+	// Pre-compute JSON data once per scope to avoid redundant work across pages
 	v.langCache = make(map[string]*cachedLangData)
-	langKeys := []string{"All"}
-	for lang := range projectAggregated.ByProgrammingLanguage {
-		langKeys = append(langKeys, lang)
-	}
-	for _, lang := range langKeys {
+	for _, scope := range scopeDefs {
 		cd := &cachedLangData{}
 		dict := NewStringDictionary()
 
-		cd.filesJSON = buildFilesJSONPruned(files, lang)
+		cd.filesJSON = buildFilesJSONPruned(files, scope.Keep)
 
 		// Build risks
 		cd.risksByPath = map[string][]riskItemForTpl{}
 		ra := analyzer.NewRiskAnalyzer()
 		for _, f := range files {
-			if lang != "All" && f.ProgrammingLanguage != lang {
+			if !scope.keeps(f) {
 				continue
 			}
 			items := ra.DetectFileRisks(f)
@@ -167,12 +173,7 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 		cd.risksJSON = buildRisksJSON(cd.risksByPath, dict)
 
 		// Community
-		var currentView analyzer.Aggregated
-		if lang == "All" {
-			currentView = projectAggregated.Combined
-		} else {
-			currentView = projectAggregated.ByProgrammingLanguage[lang]
-		}
+		currentView := scope.View
 		cd.nodeToCommunityJSON = "{}"
 		if currentView.Community != nil && len(currentView.Community.NodeToCommunity) > 0 {
 			cd.nodeToCommunityJSON = buildNodeToCommunityJSON(currentView.Community.NodeToCommunity)
@@ -183,12 +184,12 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 			cd.testQualityJSON = analyzer.BuildTestQualityJSON(currentView.TestQuality)
 		}
 
-		cd.fileDepsJSON = buildFileDepsJSON(files, lang, dict)
+		cd.fileDepsJSON = buildFileDepsJSON(files, scope.Keep, dict)
 
-		// Count files for this language
+		// Count files for this scope
 		fileCount := 0
 		for _, f := range files {
-			if lang != "All" && f.GetProgrammingLanguage() != lang {
+			if !scope.keeps(f) {
 				continue
 			}
 			fileCount++
@@ -196,20 +197,20 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 		cd.depFileCount = fileCount
 
 		// Build folder-level deps for dependency graph folder view
-		cd.folderDepsJSON = buildFolderDepsJSON(files, lang, dict)
+		cd.folderDepsJSON = buildFolderDepsJSON(files, scope.Keep, dict)
 
 		cd.dictionaryJSON = dict.ToJSON()
 
-		v.langCache[lang] = cd
+		v.langCache[scope.DataKey] = cd
 	}
 
-	// Write shared data JS files (one per language) to avoid duplicating JSON in every HTML page
+	// Write shared data JS files (one per scope) to avoid duplicating JSON in every HTML page
 	dataDir := fmt.Sprintf("%s/data", v.ReportPath)
 	err = v.EnsureFolder(dataDir)
 	if err != nil {
 		return nil, err
 	}
-	for lang, cd := range v.langCache {
+	for dataKey, cd := range v.langCache {
 		var jsBuilder strings.Builder
 		jsBuilder.WriteString("window.__AST_DATA__={")
 		jsBuilder.WriteString("files:")
@@ -237,7 +238,7 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 		jsBuilder.WriteString(",testQuality:")
 		jsBuilder.WriteString(cd.testQualityJSON)
 		jsBuilder.WriteString("};")
-		dataFile := fmt.Sprintf("%s/data_%s.js", dataDir, languageURLSlug(lang))
+		dataFile := fmt.Sprintf("%s/data_%s.js", dataDir, dataKey)
 		if err := os.WriteFile(dataFile, []byte(jsBuilder.String()), 0644); err != nil {
 			return nil, err
 		}
@@ -249,65 +250,26 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 		return nil, err
 	}
 
-	// Overview
-	v.GenerateLanguagePage("index.html", "All", projectAggregated.Combined, files, projectAggregated)
-	// by language overview
-	for language, currentView := range projectAggregated.ByProgrammingLanguage {
-		v.GenerateLanguagePage("index.html", language, currentView, files, projectAggregated)
-	}
-
-	// Risks
-	v.GenerateLanguagePage("risks.html", "All", projectAggregated.Combined, files, projectAggregated)
-	for language, currentView := range projectAggregated.ByProgrammingLanguage {
-		v.GenerateLanguagePage("risks.html", language, currentView, files, projectAggregated)
-	}
-
-	// Explorer
-	v.GenerateLanguagePage("explorer.html", "All", projectAggregated.Combined, files, projectAggregated)
-	for language, currentView := range projectAggregated.ByProgrammingLanguage {
-		v.GenerateLanguagePage("explorer.html", language, currentView, files, projectAggregated)
-	}
-
-	// Comparaison with another branch
-	v.GenerateLanguagePage("compare.html", "All", projectAggregated.Combined, files, projectAggregated)
-	for language, currentView := range projectAggregated.ByProgrammingLanguage {
-		v.GenerateLanguagePage("compare.html", language, currentView, files, projectAggregated)
-	}
-
-	// Communities page
-	v.GenerateLanguagePage("communities.html", "All", projectAggregated.Combined, files, projectAggregated)
-	for language, currentView := range projectAggregated.ByProgrammingLanguage {
-		v.GenerateLanguagePage("communities.html", language, currentView, files, projectAggregated)
-	}
-
-	// Dependencies page
-	v.GenerateLanguagePage("dependencies.html", "All", projectAggregated.Combined, files, projectAggregated)
-	for language, currentView := range projectAggregated.ByProgrammingLanguage {
-		v.GenerateLanguagePage("dependencies.html", language, currentView, files, projectAggregated)
-	}
-
-	// Linters page
-	v.GenerateLanguagePage("linters.html", "All", projectAggregated.Combined, files, projectAggregated)
-	for language, currentView := range projectAggregated.ByProgrammingLanguage {
-		v.GenerateLanguagePage("linters.html", language, currentView, files, projectAggregated)
-	}
-
-	// Bus Factor page
-	v.GenerateLanguagePage("busfactor.html", "All", projectAggregated.Combined, files, projectAggregated)
-	for language, currentView := range projectAggregated.ByProgrammingLanguage {
-		v.GenerateLanguagePage("busfactor.html", language, currentView, files, projectAggregated)
-	}
-
-	// Test Quality page
-	v.GenerateLanguagePage("testquality.html", "All", projectAggregated.Combined, files, projectAggregated)
-	for language, currentView := range projectAggregated.ByProgrammingLanguage {
-		v.GenerateLanguagePage("testquality.html", language, currentView, files, projectAggregated)
-	}
-
-	// Architecture (AI Classification) page
-	v.GenerateLanguagePage("classification.html", "All", projectAggregated.Combined, files, projectAggregated)
-	for language, currentView := range projectAggregated.ByProgrammingLanguage {
-		v.GenerateLanguagePage("classification.html", language, currentView, files, projectAggregated)
+	// One page per template, for every scope (all / language / directory)
+	for _, template := range []string{
+		"index.html",
+		"risks.html",
+		"explorer.html",
+		"classes.html",
+		"metrics.html",
+		"compare.html",
+		"communities.html",
+		"dependencies.html",
+		"linters.html",
+		"busfactor.html",
+		"testquality.html",
+		"classification.html",
+	} {
+		for _, scope := range scopeDefs {
+			// errors are logged by GenerateScopePage: a single broken page must
+			// not discard the whole report
+			v.GenerateScopePage(template, scope, scopeDefs, files, projectAggregated)
+		}
 	}
 
 	// copy images
@@ -362,14 +324,22 @@ type riskItemForTpl struct {
 	Details  string  `json:"details"`
 }
 
+// fileFilter selects the files belonging to a scope. A nil filter keeps every file.
+type fileFilter func(*pb.File) bool
+
+// keepFile applies a filter, treating a nil filter as "keep everything".
+func keepFile(keep fileFilter, f *pb.File) bool {
+	return keep == nil || keep(f)
+}
+
 // buildFilesJSONPruned builds a pruned JSON array of files with pathHash injected.
-func buildFilesJSONPruned(files []*pb.File, language string) string {
+func buildFilesJSONPruned(files []*pb.File, keep fileFilter) string {
 	mo := protojson.MarshalOptions{EmitUnpopulated: false, UseEnumNumbers: false, Indent: ""}
 	var b strings.Builder
 	b.WriteString("[")
 	first := true
 	for _, f := range files {
-		if language != "All" && f.GetProgrammingLanguage() != language {
+		if !keepFile(keep, f) {
 			continue
 		}
 		cf := proto.Clone(f).(*pb.File)
@@ -569,11 +539,11 @@ func buildLinterDataJS(eval *requirement.EvaluationResult) string {
 }
 
 // buildFileDepsJSON builds a JSON map of file dependency relationships keyed by path hash.
-func buildFileDepsJSON(files []*pb.File, language string, dict *StringDictionary) string {
+func buildFileDepsJSON(files []*pb.File, keep fileFilter, dict *StringDictionary) string {
 	// Step 1: Build class qualified name -> file path lookup
 	classToFile := map[string]string{}
 	for _, f := range files {
-		if language != "All" && f.GetProgrammingLanguage() != language {
+		if !keepFile(keep, f) {
 			continue
 		}
 		if f.Stmts == nil {
@@ -603,7 +573,7 @@ func buildFileDepsJSON(files []*pb.File, language string, dict *StringDictionary
 	efferent := map[string]map[string]depInfo{}
 
 	for _, f := range files {
-		if language != "All" && f.GetProgrammingLanguage() != language {
+		if !keepFile(keep, f) {
 			continue
 		}
 		if f.Stmts == nil {
@@ -711,10 +681,10 @@ func buildFileDepsJSON(files []*pb.File, language string, dict *StringDictionary
 
 // buildFolderDepsJSON aggregates file-level dependencies to folder-level.
 // Keys are hashed via the dictionary.
-func buildFolderDepsJSON(files []*pb.File, language string, dict *StringDictionary) string {
+func buildFolderDepsJSON(files []*pb.File, keep fileFilter, dict *StringDictionary) string {
 	classToFile := map[string]string{}
 	for _, f := range files {
-		if language != "All" && f.GetProgrammingLanguage() != language {
+		if !keepFile(keep, f) {
 			continue
 		}
 		if f.Stmts == nil {
@@ -744,7 +714,7 @@ func buildFolderDepsJSON(files []*pb.File, language string, dict *StringDictiona
 	filesByFolder := map[string]map[string]struct{}{}
 
 	for _, f := range files {
-		if language != "All" && f.GetProgrammingLanguage() != language {
+		if !keepFile(keep, f) {
 			continue
 		}
 		if f.Stmts == nil {
@@ -886,7 +856,141 @@ func buildFolderDepsJSON(files []*pb.File, language string, dict *StringDictiona
 	return string(data)
 }
 
-func (v *HtmlReportGenerator) GenerateLanguagePage(template string, language string, currentView analyzer.Aggregated, files []*pb.File, projectAggregated analyzer.ProjectAggregated) error {
+// scopeKind values used both in Go and in the templates (context "scopeKind").
+const (
+	scopeKindAll       = "all"
+	scopeKindLanguage  = "language"
+	scopeKindDirectory = "directory"
+)
+
+// scopeDef describes one navigable view of the report: the whole project, a
+// single programming language, or a single analyzed directory.
+type scopeDef struct {
+	// Kind is one of scopeKindAll, scopeKindLanguage, scopeKindDirectory.
+	Kind string
+	// Label is what the user reads ("All languages", "Golang", "internal/analyzer").
+	Label string
+	// Suffix is appended to a page base name ("", "_Golang", "_dir_internal-analyzer").
+	Suffix string
+	// DataKey identifies the data file: data/data_<DataKey>.js
+	DataKey string
+	// FileCount is the number of files inside the scope.
+	FileCount int
+	// View is the aggregate matching the scope.
+	View analyzer.Aggregated
+	// Keep filters the files belonging to the scope. A nil filter keeps everything.
+	Keep fileFilter
+	// LanguageName is the language of a language scope, "All" otherwise. It feeds
+	// the legacy "currentLanguage" template variable.
+	LanguageName string
+}
+
+// keeps tells whether a file belongs to the scope.
+func (s scopeDef) keeps(f *pb.File) bool {
+	if s.Keep == nil {
+		return true
+	}
+	return s.Keep(f)
+}
+
+// scopeForTemplate is the template-facing projection of a scopeDef.
+type scopeForTemplate struct {
+	Kind      string
+	Label     string
+	Suffix    string
+	FileCount int
+	IsActive  bool
+}
+
+// buildScopes returns the ordered list of scopes offered by the report: the
+// whole project first, then each programming language, then each analyzed
+// directory. Languages and directories are sorted by label so that the
+// generated pages are stable across runs.
+func buildScopes(files []*pb.File, projectAggregated analyzer.ProjectAggregated) []scopeDef {
+	scopes := make([]scopeDef, 0, 1+len(projectAggregated.ByProgrammingLanguage)+len(projectAggregated.ByDirectory))
+
+	scopes = append(scopes, scopeDef{
+		Kind:         scopeKindAll,
+		Label:        "All languages",
+		Suffix:       "",
+		DataKey:      "All",
+		FileCount:    len(files),
+		View:         projectAggregated.Combined,
+		Keep:         nil,
+		LanguageName: "All",
+	})
+
+	languages := make([]string, 0, len(projectAggregated.ByProgrammingLanguage))
+	for language := range projectAggregated.ByProgrammingLanguage {
+		languages = append(languages, language)
+	}
+	sort.Strings(languages)
+	for _, language := range languages {
+		lang := language
+		scopes = append(scopes, scopeDef{
+			Kind:         scopeKindLanguage,
+			Label:        lang,
+			Suffix:       fmt.Sprintf("_%s", languageURLSlug(lang)),
+			DataKey:      languageURLSlug(lang),
+			FileCount:    countFiles(files, func(f *pb.File) bool { return f.GetProgrammingLanguage() == lang }),
+			View:         projectAggregated.ByProgrammingLanguage[lang],
+			Keep:         func(f *pb.File) bool { return f.GetProgrammingLanguage() == lang },
+			LanguageName: lang,
+		})
+	}
+
+	directories := make([]string, 0, len(projectAggregated.ByDirectory))
+	for dir := range projectAggregated.ByDirectory {
+		directories = append(directories, dir)
+	}
+	sort.Slice(directories, func(i, j int) bool {
+		return directoryScopeLabel(directories[i]) < directoryScopeLabel(directories[j])
+	})
+	usedSlugs := map[string]bool{}
+	for _, language := range languages {
+		usedSlugs[languageURLSlug(language)] = true
+	}
+	for _, directory := range directories {
+		dir := directory
+		slug := uniqueSlug(directoryURLSlug(dir), usedSlugs)
+		view := projectAggregated.ByDirectory[dir]
+		// the aggregator already decided which files belong to this analyzed path
+		// (the most specific one wins when paths are nested): reuse its verdict so
+		// that the JSON data and the aggregates always describe the same files
+		inScope := make(map[string]bool, len(view.ConcernedFiles))
+		for _, f := range view.ConcernedFiles {
+			inScope[f.GetPath()] = true
+		}
+		scopes = append(scopes, scopeDef{
+			Kind:      scopeKindDirectory,
+			Label:     directoryScopeLabel(dir),
+			Suffix:    fmt.Sprintf("_dir_%s", slug),
+			DataKey:   fmt.Sprintf("dir_%s", slug),
+			FileCount: len(view.ConcernedFiles),
+			View:      view,
+			Keep:      func(f *pb.File) bool { return inScope[f.GetPath()] },
+			// a directory scope mixes languages: it behaves like the global view
+			// for every language-specific condition of the templates
+			LanguageName: "All",
+		})
+	}
+
+	return scopes
+}
+
+// countFiles counts the files matching a filter.
+func countFiles(files []*pb.File, keep fileFilter) int {
+	count := 0
+	for _, f := range files {
+		if keep != nil && !keep(f) {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func (v *HtmlReportGenerator) GenerateScopePage(template string, scope scopeDef, scopes []scopeDef, files []*pb.File, projectAggregated analyzer.ProjectAggregated) error {
 
 	// Compile the index.html template
 	tpl, err := pongo2.DefaultSet.FromFile(template)
@@ -897,26 +1001,59 @@ func (v *HtmlReportGenerator) GenerateLanguagePage(template string, language str
 	// Render it, passing projectAggregated and files as context
 	datetime := time.Now().Format("2006-01-02 15:04")
 
-	// Use pre-computed cached data for this language
-	cd := v.langCache[language]
-	dataScriptPath := fmt.Sprintf("data/data_%s.js", languageURLSlug(language))
+	// Use pre-computed cached data for this scope
+	cd := v.langCache[scope.DataKey]
+	if cd == nil {
+		cd = &cachedLangData{}
+	}
+	dataScriptPath := fmt.Sprintf("data/data_%s.js", scope.DataKey)
 	linterScriptPath := "data/linters.js"
-	out, err := tpl.Execute(pongo2.Context{"datetime": datetime, "page": template, "currentLanguage": language, "currentView": currentView, "projectAggregated": projectAggregated, "files": files, "risksByPath": cd.risksByPath, "dataScriptPath": dataScriptPath, "linterScriptPath": linterScriptPath, "classificationFamilies": classifier.ClassificationFamilies})
+
+	// The scope switcher needs every scope, with the current one flagged
+	scopesForTemplate := make([]scopeForTemplate, 0, len(scopes))
+	hasDirectoryScopes := false
+	for _, s := range scopes {
+		if s.Kind == scopeKindDirectory {
+			hasDirectoryScopes = true
+		}
+		scopesForTemplate = append(scopesForTemplate, scopeForTemplate{
+			Kind:      s.Kind,
+			Label:     s.Label,
+			Suffix:    s.Suffix,
+			FileCount: s.FileCount,
+			IsActive:  s.Suffix == scope.Suffix,
+		})
+	}
+
+	out, err := tpl.Execute(pongo2.Context{
+		"datetime":               datetime,
+		"page":                   template,
+		"currentLanguage":        scope.LanguageName,
+		"currentView":            scope.View,
+		"projectAggregated":      projectAggregated,
+		"files":                  files,
+		"risksByPath":            cd.risksByPath,
+		"dataScriptPath":         dataScriptPath,
+		"linterScriptPath":       linterScriptPath,
+		"classificationFamilies": classifier.ClassificationFamilies,
+		"scopeSuffix":            scope.Suffix,
+		"scopeLabel":             scope.Label,
+		"scopeKind":              scope.Kind,
+		"scopes":                 scopesForTemplate,
+		"hasDirectoryScopes":     hasDirectoryScopes,
+	})
 	if err != nil {
 		log.Error(err)
 		return err
 	}
 
 	// Write the result to the file
-	pageSuffix := ""
-	if language != "All" {
-		pageSuffix = fmt.Sprintf("_%s", languageURLSlug(language))
-	}
 	// prefix is template without the .html part
 	pagePrefix := template[:len(template)-5]
-	file, err := os.Create(fmt.Sprintf("%s/%s%s.html", v.ReportPath, pagePrefix, pageSuffix))
+	file, err := os.Create(fmt.Sprintf("%s/%s%s.html", v.ReportPath, pagePrefix, scope.Suffix))
 	if err != nil {
 		log.Error(err)
+		return err
 	}
 	defer file.Close()
 	file.WriteString(out)
@@ -943,6 +1080,61 @@ func languageURLSlug(language string) string {
 	s := strings.ReplaceAll(language, "#", "Sharp")
 	s = strings.ReplaceAll(s, " ", "")
 	return s
+}
+
+// directoryURLSlug turns an analyzed path into a token safe for file names and
+// URLs: "./internal/analyzer" becomes "internal-analyzer". Every character that
+// is neither a letter, a digit nor an underscore becomes a dash; dashes are
+// then compacted and trimmed.
+func directoryURLSlug(directory string) string {
+	label := directoryScopeLabel(directory)
+
+	var b strings.Builder
+	lastWasDash := false
+	for _, r := range label {
+		isSafe := r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+		if isSafe {
+			b.WriteRune(r)
+			lastWasDash = false
+			continue
+		}
+		if !lastWasDash {
+			b.WriteRune('-')
+			lastWasDash = true
+		}
+	}
+
+	slug := strings.Trim(b.String(), "-")
+	if slug == "" {
+		slug = "root"
+	}
+	return slug
+}
+
+// uniqueSlug guarantees that a slug is not already taken, appending a counter
+// when needed. It records the returned slug as taken.
+func uniqueSlug(slug string, used map[string]bool) string {
+	candidate := slug
+	for i := 2; used[candidate]; i++ {
+		candidate = fmt.Sprintf("%s-%d", slug, i)
+	}
+	used[candidate] = true
+	return candidate
+}
+
+// directoryScopeLabel shortens an analyzed path for display: relative to the
+// current working directory when it lives under it, unchanged otherwise.
+func directoryScopeLabel(directory string) string {
+	cleaned := filepath.Clean(directory)
+	if cwd, err := os.Getwd(); err == nil {
+		if rel, err := filepath.Rel(cwd, cleaned); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			if rel == "." {
+				return filepath.Base(cleaned)
+			}
+			cleaned = rel
+		}
+	}
+	return filepath.ToSlash(cleaned)
 }
 
 func (v *HtmlReportGenerator) RegisterFilters() {
@@ -992,6 +1184,10 @@ func (v *HtmlReportGenerator) RegisterFilters() {
 
 		// append to the list when file contians at lease one class
 		for _, file := range in.Interface().([]*pb.File) {
+			// test files are not production code: never suggest them for refactoring
+			if file == nil || file.GetIsTest() || file.Stmts == nil {
+				continue
+			}
 			if len(file.Stmts.StmtClass) == 0 {
 				continue
 			}
@@ -1148,6 +1344,11 @@ func (v *HtmlReportGenerator) RegisterFilters() {
 
 		for _, file := range files {
 			if file == nil || file.Stmts == nil {
+				continue
+			}
+			// test files are not production code: they must not show up as
+			// high-risk components / refactoring candidates
+			if file.GetIsTest() {
 				continue
 			}
 			// if no classes, treat file as a single row
@@ -1962,6 +2163,24 @@ func (v *HtmlReportGenerator) RegisterFilters() {
 		return pongo2.AsValue(result), nil
 	})
 
+	// gravatarUrl builds the avatar URL of an email address. Returns an empty
+	// string when there is no address, so the template falls back to initials.
+	// Usage: {{ committer.Email|gravatarUrl:80 }}
+	pongo2.RegisterFilter("gravatarUrl", func(in *pongo2.Value, param *pongo2.Value) (out *pongo2.Value, err *pongo2.Error) {
+		email := strings.ToLower(strings.TrimSpace(in.String()))
+		if email == "" || !strings.Contains(email, "@") {
+			return pongo2.AsValue(""), nil
+		}
+		size := 80
+		if param != nil && param.Integer() > 0 {
+			size = param.Integer()
+		}
+		sum := md5.Sum([]byte(email))
+		// d=404 so a missing avatar fails instead of returning a placeholder:
+		// the template then keeps its initials.
+		return pongo2.AsValue(fmt.Sprintf("https://www.gravatar.com/avatar/%x?s=%d&d=404", sum, size)), nil
+	})
+
 	// filter contributorColor: generates a consistent color based on name hash
 	pongo2.RegisterFilter("contributorColor", func(in *pongo2.Value, param *pongo2.Value) (out *pongo2.Value, err *pongo2.Error) {
 		name := in.String()
@@ -1974,20 +2193,21 @@ func (v *HtmlReportGenerator) RegisterFilters() {
 		h.Write([]byte(name))
 		hash := h.Sum32()
 
-		// Use a palette of pleasant colors
+		// Identity palette: cool hues only. Green, amber and red carry severity
+		// everywhere else in the report, so a contributor must never wear them.
 		colors := []string{
 			"#3b82f6", // blue
 			"#8b5cf6", // purple
 			"#ec4899", // pink
-			"#f59e0b", // amber
-			"#10b981", // emerald
 			"#06b6d4", // cyan
-			"#ef4444", // red
-			"#14b8a6", // teal
-			"#f97316", // orange
 			"#6366f1", // indigo
-			"#84cc16", // lime
+			"#14b8a6", // teal
 			"#a855f7", // violet
+			"#0ea5e9", // sky
+			"#d946ef", // fuchsia
+			"#64748b", // slate
+			"#7c3aed", // deep violet
+			"#0891b2", // deep cyan
 		}
 
 		colorIndex := int(hash) % len(colors)

--- a/internal/report/html_report_generator_test.go
+++ b/internal/report/html_report_generator_test.go
@@ -81,7 +81,7 @@ func TestBuildFilesJSONPruned_ContainsOutsideFunctions(t *testing.T) {
 		},
 	}
 
-	raw := buildFilesJSONPruned([]*pb.File{file}, "All")
+	raw := buildFilesJSONPruned([]*pb.File{file}, nil)
 	var decoded []map[string]interface{}
 	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
 		t.Fatalf("expected valid json, got error: %v", err)
@@ -191,7 +191,7 @@ func TestBuildFileDepsJSON_EmptySlicesNotNull(t *testing.T) {
 			},
 		},
 	}
-	raw := buildFileDepsJSON([]*pb.File{file}, "All", dict)
+	raw := buildFileDepsJSON([]*pb.File{file}, nil, dict)
 	if raw != "{}" {
 		t.Fatalf("expected empty json for no deps, got %s", raw)
 	}
@@ -220,7 +220,7 @@ func TestBuildFileDepsJSON_HashedKeys(t *testing.T) {
 			},
 		},
 	}
-	raw := buildFileDepsJSON([]*pb.File{fileA, fileB}, "All", dict)
+	raw := buildFileDepsJSON([]*pb.File{fileA, fileB}, nil, dict)
 	if !json.Valid([]byte(raw)) {
 		t.Fatalf("invalid json: %s", raw)
 	}
@@ -261,7 +261,7 @@ func TestBuildFolderDepsJSON_HashedKeys(t *testing.T) {
 			},
 		},
 	}
-	raw := buildFolderDepsJSON([]*pb.File{fileA, fileB}, "All", dict)
+	raw := buildFolderDepsJSON([]*pb.File{fileA, fileB}, nil, dict)
 	if raw == "" {
 		t.Fatalf("expected non-empty json for cross-folder deps")
 	}
@@ -328,7 +328,7 @@ func TestBuildFilesJSONPruned_PathHashStableAndDistinct(t *testing.T) {
 	first := makeFile("/tmp/repo-a/internal/analyzer/community_aggregator.go")
 	second := makeFile("/tmp/repo-b/internal/analyzer/community_aggregator.go")
 
-	raw := buildFilesJSONPruned([]*pb.File{first, second}, "All")
+	raw := buildFilesJSONPruned([]*pb.File{first, second}, nil)
 	var decoded []map[string]interface{}
 	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
 		t.Fatalf("expected valid json, got error: %v", err)
@@ -346,7 +346,7 @@ func TestBuildFilesJSONPruned_PathHashStableAndDistinct(t *testing.T) {
 		t.Fatalf("expected different pathHash for different absolute paths, got same value %q", hashA)
 	}
 
-	raw2 := buildFilesJSONPruned([]*pb.File{first, second}, "All")
+	raw2 := buildFilesJSONPruned([]*pb.File{first, second}, nil)
 	var decoded2 []map[string]interface{}
 	if err := json.Unmarshal([]byte(raw2), &decoded2); err != nil {
 		t.Fatalf("expected valid json on second call, got error: %v", err)

--- a/internal/report/language_pages_integration_test.go
+++ b/internal/report/language_pages_integration_test.go
@@ -24,6 +24,83 @@ func TestLanguageURLSlug(t *testing.T) {
 	assert.Equal(t, "PHP", languageURLSlug("PHP"))
 }
 
+// TestDirectoryURLSlug guards the naming of the per-folder report pages:
+// analyzed paths become file-name-safe tokens (index_dir_<slug>.html).
+func TestDirectoryURLSlug(t *testing.T) {
+	assert.Equal(t, "internal-analyzer", directoryURLSlug("internal/analyzer"))
+	assert.Equal(t, "internal-analyzer", directoryURLSlug("./internal/analyzer/"))
+	assert.Equal(t, "src", directoryURLSlug("src"))
+	assert.Equal(t, "my_app-v1-2", directoryURLSlug("my_app/v1.2"))
+	assert.Equal(t, "a-b", directoryURLSlug("a###b"))
+	assert.Equal(t, "some-folder", directoryURLSlug("some folder"))
+	assert.Equal(t, "a-b", directoryURLSlug("a\\b"))
+	assert.Equal(t, "root", directoryURLSlug("/"))
+	assert.Equal(t, "tmp-foo-bar", directoryURLSlug("/tmp/foo/bar"))
+
+	// no slug may leak a character that breaks a URL or a file name
+	for _, dir := range []string{"a b/c#d", "../sibling", "./x/../y"} {
+		slug := directoryURLSlug(dir)
+		assert.NotContains(t, slug, "/")
+		assert.NotContains(t, slug, "#")
+		assert.NotContains(t, slug, " ")
+		assert.NotContains(t, slug, ".")
+		assert.NotContains(t, slug, "--")
+		assert.False(t, strings.HasPrefix(slug, "-"), "slug %q must not start with a dash", slug)
+		assert.False(t, strings.HasSuffix(slug, "-"), "slug %q must not end with a dash", slug)
+	}
+}
+
+// TestUniqueSlug checks that two analyzed paths collapsing to the same slug
+// still produce two distinct pages.
+func TestUniqueSlug(t *testing.T) {
+	used := map[string]bool{}
+	assert.Equal(t, "src", uniqueSlug("src", used))
+	assert.Equal(t, "src-2", uniqueSlug("src", used))
+	assert.Equal(t, "src-3", uniqueSlug("src", used))
+}
+
+// TestBuildScopes checks the three navigation dimensions offered by the report:
+// the whole project, each language, each analyzed folder.
+func TestBuildScopes(t *testing.T) {
+	files := []*pb.File{
+		{Path: "/project/src/a.go", ProgrammingLanguage: "Golang"},
+		{Path: "/project/lib/b.php", ProgrammingLanguage: "PHP"},
+	}
+	pa := analyzer.ProjectAggregated{
+		ByProgrammingLanguage: map[string]analyzer.Aggregated{
+			"Golang": {ConcernedFiles: []*pb.File{files[0]}},
+			"PHP":    {ConcernedFiles: []*pb.File{files[1]}},
+		},
+		ByDirectory: map[string]analyzer.Aggregated{
+			"/project/src": {ConcernedFiles: []*pb.File{files[0]}},
+			"/project/lib": {ConcernedFiles: []*pb.File{files[1]}},
+		},
+	}
+
+	scopes := buildScopes(files, pa)
+	assert.Len(t, scopes, 5)
+
+	assert.Equal(t, "all", scopes[0].Kind)
+	assert.Equal(t, "", scopes[0].Suffix)
+	assert.Equal(t, 2, scopes[0].FileCount)
+
+	// languages come first, sorted, then folders, sorted
+	assert.Equal(t, []string{"_Golang", "_PHP", "_dir_project-lib", "_dir_project-src"},
+		[]string{scopes[1].Suffix, scopes[2].Suffix, scopes[3].Suffix, scopes[4].Suffix})
+	assert.Equal(t, "directory", scopes[3].Kind)
+	assert.Equal(t, "/project/lib", scopes[3].Label)
+	assert.Equal(t, 1, scopes[3].FileCount)
+
+	// each scope only keeps its own files
+	assert.True(t, scopes[4].keeps(files[0]))
+	assert.False(t, scopes[4].keeps(files[1]))
+	assert.True(t, scopes[0].keeps(files[1]))
+
+	// a single analyzed path produces no folder scope (ByDirectory stays empty)
+	pa.ByDirectory = map[string]analyzer.Aggregated{}
+	assert.Len(t, buildScopes(files, pa), 3)
+}
+
 // TestHtmlReportFullPipelineJavaCSharp runs the whole pipeline (parse with the
 // Java and C# engines, analyze, aggregate, generate the HTML report) and
 // verifies the report files for both languages.

--- a/internal/report/templates/html/busfactor.html
+++ b/internal/report/templates/html/busfactor.html
@@ -11,1072 +11,421 @@ AST Metrics - Bus Factor
 {% block content %}
 
 <style>
-    .dashboard-card {
-        background: white;
-        border: 1px solid #e2e8f0;
-        border-radius: 16px;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        position: relative;
+    /* Page-specific pieces only. Everything else comes from the shared design system. */
+    /* Horizontal stacked bar: one segment per contributor, leftover grey = everyone else */
+    .share-bar {
+        display: flex;
+        height: 14px;
+        border-radius: 999px;
         overflow: hidden;
+        background: #e8ecf1;
     }
 
-    .dashboard-card:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-        border-color: #cbd5e1;
+    .share-bar > span {
+        display: block;
+        height: 100%;
     }
 
-    .dashboard-card::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, #3b82f6, #8b5cf6);
-        opacity: 0;
-        transition: opacity 0.3s ease;
-    }
-
-    .dashboard-card:hover::before {
-        opacity: 1;
-    }
-
-    .metric-value {
+    .bf-figure {
         font-family: var(--font-mono);
+        font-size: 4.5rem;
+        line-height: 1;
+        font-weight: 700;
         letter-spacing: -0.05em;
+        color: #0f172a;
     }
 
-    @keyframes fadeInUp {
-        from {
-            opacity: 0;
-            transform: translateY(10px);
-        }
-
-        to {
-            opacity: 1;
-            transform: translateY(0);
-        }
-    }
-
-    .animate-fade-in-up {
-        animation: fadeInUp 0.5s ease-out backwards;
-    }
-
-    .stagger-1 {
-        animation-delay: 0.1s;
-    }
-
-    .stagger-2 {
-        animation-delay: 0.2s;
-    }
-
-    .stagger-3 {
-        animation-delay: 0.3s;
-    }
-
-    .stagger-4 {
-        animation-delay: 0.4s;
-    }
-
-    .stagger-5 {
-        animation-delay: 0.5s;
-    }
-
-    .contributor-avatar {
-        width: 36px;
-        height: 36px;
-        border-radius: 50%;
-        display: inline-flex;
+    .folder-chip {
+        display: flex;
         align-items: center;
-        justify-content: center;
-        font-weight: 600;
-        font-size: 14px;
-        color: white;
-        flex-shrink: 0;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        gap: 0.5rem;
+        min-width: 0;
+        padding: 0.625rem 0.75rem;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
     }
 
-    .contributor-avatar-small {
-        width: 28px;
-        height: 28px;
+    .folder-chip-name {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: #0f172a;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .mono-name {
+        font-family: var(--font-mono);
+    }
+
+    .tag-soft {
         font-size: 11px;
+        color: #64748b;
+        background: #f1f5f9;
+        border-radius: 999px;
+        padding: 0.15rem 0.55rem;
+        white-space: nowrap;
     }
 </style>
 
-<!-- Language tabs -->
-<div class="flex overflow-x-auto overflow-y-hidden border-b border-gray-200 whitespace-nowrap">
-    <a tabindex="-1" href="busfactor.html"
-        class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center {% if currentLanguage == 'All'%}text-blue-600 border-blue-500{% endif %} bg-transparent border-b-2 sm:px-4 -px-1 focus:outline-none">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-        </svg>
-        <span class="mx-1 text-sm sm:text-base">
-            All languages <span class="text-xs sm:text-sm">({{ projectAggregated.Combined.ConcernedFiles|length }}
-                files)</span>
-        </span>
-    </a>
+{% include "partials/language_tabs.html" with pageBase="busfactor" %}
 
-    {% for languageName, lang in projectAggregated.ByProgrammingLanguage %}
-    <a tabindex="0" href="busfactor_{{ languageName|langSlug }}.html"
-        class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center bg-transparent border-b-2 {% if currentLanguage == languageName %}text-blue-600 border-blue-500{% else %}text-gray-700 border-transparent{% endif %} sm:px-4 -px-1 hover:border-gray-400">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-        </svg>
-        <span class="mx-1 text-sm sm:text-base">
-            {{ languageName }} <span class="text-xs sm:text-sm">({{ lang.ConcernedFiles|length }} files)</span>
-        </span>
-    </a>
-    {% endfor %}
-</div>
+{% set busFactor = currentView.BusFactor %}
+{% set hasHistory = currentView.TopCommitters|length > 0 %}
 
-<!-- Global Metrics Section -->
-<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8">
-    <!-- Global Bus Factor Card -->
-    <div class="dashboard-card p-6 animate-fade-in-up stagger-1">
-        <h5 class="text-4xl font-bold text-gray-900 metric-value tracking-tight mb-2">
-            {{ currentView.BusFactor }}
-        </h5>
-        <p class="text-sm font-medium text-gray-500 mb-3">Global Bus Factor</p>
-        <p class="text-xs text-gray-800 border-t border-gray-100 pt-3">
-            Number of developers who account for 50% of commits
-        </p>
-    </div>
+<!-- The verdict -->
+<div class="page-hero animate-fade-in-up mt-8">
+    <div class="flex flex-wrap items-start justify-between gap-10">
+        <div class="min-w-0 flex-1">
+            {% if hasHistory %}
+            {% if busFactor <= 1 %}
+            <span class="level-pill level-pill--bad mb-5">
+                <span class="dot sev-bad"></span> High risk
+            </span>
+            <h1 class="verdict-title">
+                If one person stops, the project stops with them.<br>
+                <span class="verdict-muted">Half of the history is signed by a single contributor.</span>
+            </h1>
+            {% elif busFactor == 2 %}
+            <span class="level-pill level-pill--warn mb-5">
+                <span class="dot sev-warn"></span> Fragile
+            </span>
+            <h1 class="verdict-title">
+                Two people hold this project together.<br>
+                <span class="verdict-muted">If they both step away, the knowledge goes with them.</span>
+            </h1>
+            {% else %}
+            <span class="level-pill level-pill--good mb-5">
+                <span class="dot sev-good"></span> Knowledge is shared
+            </span>
+            <h1 class="verdict-title">
+                No single person owns this code.<br>
+                <span class="verdict-muted">{{ busFactor }} contributors write half of the commits.</span>
+            </h1>
+            {% endif %}
+            <p class="verdict-lead mt-4">
+                {% for committer in currentView.TopCommitters %}{% if forloop.First %}<strong>{{ committer.Name }}</strong>
+                signs <strong id="bf-lead-count" data-count="{{ committer.Count }}">{{ committer.Count }} commits</strong>
+                since the beginning of the project.{% endif %}{% endfor %}
+                <span id="bf-lead-folders"></span>
+            </p>
+            <div class="kpi-strip kpi-strip--divided mt-8">
+                <div>
+                    <div class="kpi-value" id="bf-kpi-contributors">&hellip;</div>
+                    <div class="kpi-label">contributors</div>
+                </div>
+                <div>
+                    <div class="kpi-value" id="bf-kpi-commits">&hellip;</div>
+                    <div class="kpi-label">commits in total</div>
+                </div>
+                <div>
+                    <div class="kpi-value" id="bf-kpi-folders">&hellip;</div>
+                    <div class="kpi-label">folders held by<br>a single person</div>
+                </div>
+            </div>
+            {% else %}
+            <span class="level-pill mb-5">
+                <span class="dot sev-none"></span> No git history
+            </span>
+            <h1 class="verdict-title">
+                There is no commit history to read here.<br>
+                <span class="verdict-muted">Who knows what cannot be measured.</span>
+            </h1>
+            <p class="verdict-lead mt-4">
+                None of the analyzed files carries commits AST Metrics could read, so knowledge concentration
+                stays unknown for this selection.
+            </p>
+            {% endif %}
+        </div>
 
-    <!-- Commit Trends Card -->
-    <div class="dashboard-card md:col-span-2 p-6 animate-fade-in-up stagger-2">
-        {% if currentView.ResultOfGitAnalysis %}
-        <div class="mb-3">
-            <h5 class="text-2xl font-bold text-gray-900 metric-value tracking-tight">
-                {{ currentView.CommitCountForPeriod | stringifyNumber }}
-            </h5>
-            <p class="text-sm text-gray-500">Commits (12m)</p>
-        </div>
-        <div class="card-graph w-full h-24 mb-3">
-            {{ currentView|lineChartGitActivity}}
-        </div>
-        <div class="overflow-x-auto">
-            <table class="w-full text-left border-collapse text-xs">
-                <thead>
-                    <tr class="text-xs text-gray-800 border-b border-gray-100">
-                        <th class="py-1 font-medium">Repo</th>
-                        <th class="py-1 font-medium">Total</th>
-                        <th class="py-1 font-medium">Imp.</th>
-                    </tr>
-                </thead>
-                <tbody class="text-xs text-gray-600">
-                    {% for commitAnalysis in currentView.ResultOfGitAnalysis %}
-                    <tr class="border-b border-gray-50 last:border-0 hover:bg-gray-50 transition-colors">
-                        <td class="py-1 font-medium text-gray-900 truncate max-w-[100px]"
-                            title="{{ commitAnalysis.ReportRootDir }}">
-                            {{ commitAnalysis.ReportRootDir|truncatechars:15 }}
-                        </td>
-                        <td class="py-1">{{ commitAnalysis.CountCommits }}</td>
-                        <td class="py-1">{{ commitAnalysis.CountCommitsForLanguage }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-        {% else %}
-        <div class="mb-3">
-            <h5 class="text-2xl font-bold text-gray-900 metric-value tracking-tight">
-                {{ currentView.CommitCountForPeriod | stringifyNumber }}
-            </h5>
-            <p class="text-sm text-gray-500">Commits</p>
-        </div>
-        <div class="card-graph h-24">
-            {{ currentView|lineChartGitActivity}}
+        {% if hasHistory %}
+        <div class="shrink-0 text-right">
+            <div class="bf-figure">{{ busFactor }}</div>
+            <div class="page-kicker mt-2">key {% if busFactor == 1 %}person{% else %}people{% endif %}</div>
+            <p class="text-xs text-slate-400 mt-3 max-w-[190px] ml-auto">
+                Number of developers who carry half of the commits.
+            </p>
         </div>
         {% endif %}
     </div>
 </div>
 
-<!-- Global Top Committers -->
-<div class="dashboard-card p-6 mt-6 animate-fade-in-up stagger-3">
-    <h3 class="text-xl font-bold text-gray-900 mb-4">Top Contributors (Global)</h3>
-    <div class="overflow-x-auto">
-        <table class="w-full text-left border-collapse">
-            <thead>
-                <tr class="text-xs text-gray-800 border-b border-gray-100">
-                    <th class="py-2 font-medium">Rank</th>
-                    <th class="py-2 font-medium">Contributor</th>
-                    <th class="py-2 font-medium text-right">Commits</th>
-                    <th class="py-2 font-medium text-right">Percentage</th>
-                </tr>
-            </thead>
-            <tbody class="text-sm text-gray-600">
-                {% for committer in currentView.TopCommitters %}
-                <tr class="border-b border-gray-50 last:border-0 hover:bg-gray-50 transition-colors">
-                    <td class="py-2 font-medium text-gray-900">{{ forloop.Counter }}</td>
-                    <td class="py-2 font-medium text-gray-900">
-                        <div class="flex items-center gap-2">
-                            <div class="contributor-avatar" style="background-color: {{ committer.Name|contributorColor }};">
-                                {{ committer.Name|contributorInitials }}
-                            </div>
-                            <span>{{ committer.Name }}</span>
-                        </div>
-                    </td>
-                    <td class="py-2 text-right">{{ committer.Count }}</td>
-                    <td class="py-2 text-right">
-                        <span class="bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full text-xs font-medium">
-                            {{ committer.Percentage|floatformat:1 }}%
-                        </span>
-                    </td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+{% if hasHistory %}
+<!-- Who writes the code -->
+<div class="soft-card mt-6 animate-fade-in-up stagger-1">
+    <div class="mb-4">
+        <h2 class="card-title">Who writes the code</h2>
+        <p class="card-sub">Share of commits since the beginning of the project.</p>
     </div>
-</div>
 
-{% set cm = currentView.Community %}
-{% set hasCommunityData = cm and cm.TopCommittersPerCommunity %}
-
-<!-- View toggle -->
-<div id="bf-view-toggle" class="flex flex-wrap items-center gap-3 mt-8 mb-4 text-xs font-medium text-gray-700">
-    <span class="text-gray-700">Aggregate by:</span>
-    <label class="flex items-center gap-1.5 cursor-pointer bg-gray-50 px-3 py-1.5 rounded-lg hover:bg-gray-100 transition-colors">
-        <input type="radio" name="bf-view" value="folder" checked class="w-3.5 h-3.5 text-blue-600">
-        <span>By folder</span>
-    </label>
-    <label class="flex items-center gap-1.5 bg-gray-50 px-3 py-1.5 rounded-lg transition-colors {% if hasCommunityData %}cursor-pointer hover:bg-gray-100{% else %}opacity-50 cursor-not-allowed{% endif %}">
-        <input type="radio" name="bf-view" value="community" class="w-3.5 h-3.5 text-blue-600" {% if not hasCommunityData %}disabled{% endif %}>
-        <span>By community</span>
-    </label>
-</div>
-
-<!-- Per-Folder Section -->
-<div id="bf-folder-section" class="mt-2">
-    <h2 class="text-2xl font-bold text-gray-900 mb-2">Bus Factor by Folder</h2>
-    <div class="text-gray-800">
-        Folder metrics are computed from git commits on files inside each directory.
+    <div class="share-bar">
+        {% for committer in currentView.TopCommitters %}
+        <span style="width: {{ committer.Percentage|floatformat:2 }}%; background-color: {{ committer.Name|contributorColor }};"
+            title="{{ committer.Name }}: {{ committer.Count }} commits"></span>
+        {% endfor %}
     </div>
-    <div class="mt-4 mb-2">
-        <div class="flex items-center justify-between gap-4 text-xs text-gray-700">
-            <label for="bf-granularity" class="font-medium text-gray-700">Granularity</label>
-            <span id="bf-granularity-label" class="text-gray-700">Normal</span>
-        </div>
-        <input id="bf-granularity" type="range" min="0" max="100" step="1" value="50" class="w-full accent-blue-600 mt-2">
-        <div class="flex items-center justify-between text-[11px] text-gray-600 mt-1">
-            <span>Compact</span>
-            <span>Normal</span>
-            <span>Detailed</span>
-        </div>
-    </div>
-    <p id="bf-folder-pruning-meta" class="text-xs text-gray-600 mt-2 mb-6"></p>
-    <div class="relative min-h-[96px]">
-        <div id="bf-folder-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"></div>
-        <div id="bf-folder-loading" class="absolute inset-0 z-10 flex items-center justify-center bg-white/80 rounded-xl">
-            <div class="flex items-center gap-2 text-sm text-gray-500 font-medium">
-                <svg class="w-4 h-4 animate-spin text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8v4a4 4 0 0 0-4 4H4z"></path>
-                </svg>
-                <span>Computing folder groups...</span>
+
+    <div class="mt-4" id="bf-contributor-list">
+        {% for committer in currentView.TopCommitters %}
+        <div class="data-row">
+            <span class="contributor-chip" style="background-color: {{ committer.Name|contributorColor }};">
+                {% set avatar = committer.Email|gravatarUrl:64 %}
+                {% if avatar %}<img src="{{ avatar }}" alt="" loading="lazy" decoding="async"
+                     onerror="this.remove()" class="contributor-chip-img">{% endif %}
+                {{ committer.Name|contributorInitials }}
+            </span>
+            <div class="min-w-0 flex-1">
+                <div class="row-name truncate">{{ committer.Name }}</div>
+                <div class="row-meta" data-bf-author="{{ committer.Name }}"></div>
             </div>
-        </div>
-    </div>
-    <div id="bf-folder-empty" class="dashboard-card p-6 hidden">
-        <p class="text-gray-600">No folder commit data available for this language.</p>
-    </div>
-</div>
-
-<!-- Per-Community Section -->
-<div id="bf-community-section" class="mt-8 hidden" data-has-community="{% if hasCommunityData %}1{% else %}0{% endif %}">
-    {% if hasCommunityData %}
-    <h2 class="text-2xl font-bold text-gray-900 mb-2">Bus Factor by Community</h2>
-
-    <div class="text-gray-800 mb-6">
-        Community ≠ folder. They behave more like centers of gravity that your code naturally orbits around.
-    </div>
-
-    <div id="bf-community-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {% for communityID, committers in cm.TopCommittersPerCommunity %}
-        <div class="dashboard-card p-5 animate-fade-in-up">
-            <div class="flex items-start justify-between mb-3">
-                <div class="flex-1">
-                    <h3 class="text-lg font-semibold text-gray-900 mb-1">
-                        {% for k, n in cm.DisplayNamePerComm %}{% if k == communityID %}{{ n }}{% endif %}{% endfor %}
-                    </h3>
-                    <p class="text-xs text-gray-500">Community {{ communityID }}</p>
-                </div>
-                <div class="text-right">
-                    <div class="text-2xl font-bold text-blue-600 metric-value">
-                        {% for k, bf in cm.BusFactorPerCommunity %}
-                        {% if k == communityID %}{{ bf }}{% endif %}
-                        {% endfor %}
-                    </div>
-                    <p class="text-xs text-gray-500">Bus Factor</p>
-                    <div class="mt-2 text-sm text-gray-600">
-                        <span class="font-medium">{{ committers|length }}</span>
-                        <span class="text-xs text-gray-800">contributors</span>
-                    </div>
-                </div>
-            </div>
-
-            <div class="mb-3">
-                <div class="flex items-end justify-between h-8 gap-0.5">
-                    {% for author, count in committers %}
-                    {% if forloop.Counter <= 10 %}
-                    <div class="flex-1 rounded-t opacity-80 hover:opacity-100 transition-opacity"
-                        style="height: {{ count }}px; max-height: 32px; background-color: {{ author|contributorColor }};"
-                        title="{{ author }}: {{ count }} commits">
-                    </div>
-                    {% endif %}
-                    {% endfor %}
-                </div>
-                <p class="text-xs text-gray-800 mt-1">Commit distribution</p>
-            </div>
-
-            <div class="border-t border-gray-100 pt-3">
-                <p class="text-xs font-medium text-gray-600 mb-2">Top Contributors</p>
-                <div class="space-y-1">
-                    {% for author, count in committers %}
-                    {% if forloop.Counter <= 5 %}
-                    <div class="flex justify-between items-center text-xs">
-                        <div class="flex items-center gap-2 flex-1 min-w-0">
-                            <div class="contributor-avatar contributor-avatar-small" style="background-color: {{ author|contributorColor }};">
-                                {{ author|contributorInitials }}
-                            </div>
-                            <span class="text-gray-900 truncate" title="{{ author }}">{{ author }}</span>
-                        </div>
-                        <span class="text-gray-700 bg-gray-100 px-2 py-0.5 rounded-full font-medium ml-2 flex-shrink-0">{{ count }}</span>
-                    </div>
-                    {% endif %}
-                    {% endfor %}
-                    {% if committers|length > 5 %}
-                    <p class="text-xs text-gray-800 mt-2">+ {{ committers|length|add:"-5" }} more</p>
-                    {% endif %}
-                </div>
-            </div>
+            <span class="row-value w-16">{{ committer.Count }}</span>
+            <span class="w-14 text-right shrink-0">
+                <span class="bg-slate-100 text-slate-700 px-2 py-0.5 rounded-full text-xs font-medium">
+                    {{ committer.Percentage|floatformat:1 }}%
+                </span>
+            </span>
         </div>
         {% endfor %}
     </div>
-    {% else %}
-    <div class="dashboard-card p-6">
-        <p class="text-gray-600">No community data available. Run community detection to see per-community bus factor metrics.</p>
+    <p class="row-meta mt-3" id="bf-others"></p>
+
+    <div class="mt-6 pt-5 border-t border-slate-100">
+        <div class="flex flex-wrap items-baseline justify-between gap-2">
+            <h3 class="section-title">Commit rhythm</h3>
+            <p class="text-xs text-slate-400">
+                {{ currentView.CommitCountForPeriod|stringifyNumber }} commits in the last 12 months
+            </p>
+        </div>
+        <div class="w-full h-32 mt-2">{{ currentView|lineChartGitActivity }}</div>
     </div>
-    {% endif %}
 </div>
+
+<!-- Where to start sharing -->
+<div class="soft-card mt-6 animate-fade-in-up stagger-2">
+    <div class="mb-2">
+        <h2 class="card-title">Where to start sharing</h2>
+        <p class="card-sub">The most active folders, held by a single person.</p>
+    </div>
+    <div id="bf-single-list"></div>
+    <p class="row-meta mt-3" id="bf-single-more"></p>
+    <div id="bf-single-empty" class="insight insight--good hidden mt-3">
+        <span class="dot sev-good"></span>
+        <span>Every folder with commits has at least <strong>two contributors</strong>.</span>
+    </div>
+</div>
+
+<!-- Knowledge per folder -->
+<div class="soft-card mt-6 mb-10 animate-fade-in-up stagger-3">
+    <div class="flex flex-wrap items-start justify-between gap-4 mb-4">
+        <div>
+            <h2 class="card-title">Knowledge per folder</h2>
+            <p class="card-sub">One chip per folder. Red = only one person knows it.</p>
+        </div>
+        <div class="flex items-center gap-4 text-xs text-slate-500">
+            <span class="flex items-center gap-1.5"><span class="dot sev-bad"></span> 1 person</span>
+            <span class="flex items-center gap-1.5"><span class="dot sev-warn"></span> 2 people</span>
+            <span class="flex items-center gap-1.5"><span class="dot sev-good"></span> 3 or more</span>
+        </div>
+    </div>
+    <div id="bf-folder-chips" class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-3"></div>
+    <p class="row-meta mt-3" id="bf-folder-more"></p>
+    <p id="bf-folder-empty" class="text-sm text-slate-500 hidden">
+        No folder carries commit data for this selection.
+    </p>
+</div>
+{% endif %}
 
 {% endblock %}
 
 {% block javascripts %}
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-    var folderSection = document.getElementById('bf-folder-section');
-    var communitySection = document.getElementById('bf-community-section');
-    var folderGrid = document.getElementById('bf-folder-grid');
-    var folderLoading = document.getElementById('bf-folder-loading');
-    var folderEmpty = document.getElementById('bf-folder-empty');
-    var pruningMeta = document.getElementById('bf-folder-pruning-meta');
-    var granularityInput = document.getElementById('bf-granularity');
-    var granularityLabelEl = document.getElementById('bf-granularity-label');
-    if (!folderSection || !communitySection || !folderGrid || !folderLoading || !folderEmpty || !pruningMeta || !granularityInput || !granularityLabelEl) return;
-
+document.addEventListener('DOMContentLoaded', function () {
     var files = (window.__AST_DATA__ && Array.isArray(window.__AST_DATA__.files)) ? window.__AST_DATA__.files : [];
-    var radios = document.querySelectorAll('input[name="bf-view"]');
-    var communityRadio = document.querySelector('input[name="bf-view"][value="community"]');
-    var folderRadio = document.querySelector('input[name="bf-view"][value="folder"]');
+    var chipsGrid = document.getElementById('bf-folder-chips');
+    if (!chipsGrid) return;
 
-    function normalizePath(path) {
+    var CHIP_LIMIT = 60;
+    var SINGLE_LIMIT = 8;
+
+    function normalize(path) {
         return String(path || '').replace(/\\/g, '/');
     }
 
-    function commonPrefix(paths) {
-        if (!paths.length) return '';
-        var parts0 = paths[0].split('/');
-        var prefix = '';
-        for (var depth = 0; depth < parts0.length - 1; depth++) {
-            var candidate = parts0.slice(0, depth + 1).join('/') + '/';
-            var allMatch = paths.every(function(p) { return p.indexOf(candidate) === 0; });
-            if (!allMatch) break;
+    function plural(count, word) {
+        return count + ' ' + word + (count === 1 ? '' : 's');
+    }
+
+    function el(tag, className, text) {
+        var node = document.createElement(tag);
+        if (className) node.className = className;
+        if (text !== undefined && text !== null) node.textContent = text;
+        return node;
+    }
+
+    // Folders are relative to the shared root of the analyzed files
+    var paths = files.map(function (file) { return normalize(file.path || file.shortPath || ''); }).filter(Boolean);
+    var prefix = '';
+    if (paths.length) {
+        var firstSegments = paths[0].split('/');
+        for (var depth = 0; depth < firstSegments.length - 1; depth++) {
+            var candidate = firstSegments.slice(0, depth + 1).join('/') + '/';
+            var shared = paths.every(function (path) { return path.indexOf(candidate) === 0; });
+            if (!shared) break;
             prefix = candidate;
         }
-        return prefix;
     }
 
-    function toFolderPath(path) {
-        var normalized = normalizePath(path);
-        var idx = normalized.lastIndexOf('/');
-        if (idx <= 0) return '/';
-        return normalized.slice(0, idx);
-    }
+    var folderCounts = {};   // folder -> { author -> commits }
+    var authorCounts = {};   // author -> commits
+    var authorFolders = {};  // author -> { folder -> true }
+    var totalCommits = 0;
 
-    function initials(name) {
-        var cleaned = String(name || '').trim();
-        if (!cleaned) return '?';
-        var parts = cleaned.split(/\s+/).filter(Boolean);
-        if (!parts.length) return '?';
-        if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-        return (parts[0][0] + parts[1][0]).toUpperCase();
-    }
-
-    function colorFor(name) {
-        var hash = 0;
-        var input = String(name || '');
-        for (var i = 0; i < input.length; i++) {
-            hash = ((hash << 5) - hash) + input.charCodeAt(i);
-            hash |= 0;
-        }
-        var hue = Math.abs(hash) % 360;
-        return 'hsl(' + hue + ', 65%, 45%)';
-    }
-
-    function computeBusFactor(sortedCommitters, totalCommits) {
-        if (totalCommits <= 0 || sortedCommitters.length === 0) return 0;
-        var boundary = Math.floor(totalCommits / 2);
-        var acc = 0;
-        var factor = 0;
-        for (var i = 0; i < sortedCommitters.length; i++) {
-            acc += sortedCommitters[i].count;
-            factor++;
-            if (acc >= boundary) break;
-        }
-        return factor;
-    }
-
-    function clamp(value, min, max) {
-        return Math.max(min, Math.min(max, value));
-    }
-
-    function granularityLabel(value) {
-        if (value <= 33) return 'Compact';
-        if (value >= 67) return 'Detailed';
-        return 'Normal';
-    }
-
-    function authorDiversity(counts) {
-        var keys = Object.keys(counts || {});
-        if (!keys.length) {
-            return { authorCount: 0, dominance: 0, entropyNorm: 0, concentration: 1 };
-        }
-
-        var total = 0;
-        var maxCount = 0;
-        keys.forEach(function(key) {
-            var value = counts[key] || 0;
-            total += value;
-            if (value > maxCount) maxCount = value;
-        });
-        if (total <= 0) {
-            return { authorCount: keys.length, dominance: 0, entropyNorm: 0, concentration: 1 };
-        }
-
-        var entropy = 0;
-        keys.forEach(function(key) {
-            var p = (counts[key] || 0) / total;
-            if (p > 0) entropy -= p * Math.log(p);
-        });
-        var entropyNorm = keys.length > 1 ? (entropy / Math.log(keys.length)) : 0;
-        entropyNorm = clamp(entropyNorm, 0, 1);
-        return {
-            authorCount: keys.length,
-            dominance: maxCount / total,
-            entropyNorm: entropyNorm,
-            concentration: 1 - entropyNorm
-        };
-    }
-
-    function cloneCounts(source) {
-        var copy = {};
-        Object.keys(source || {}).forEach(function(key) {
-            copy[key] = source[key];
-        });
-        return copy;
-    }
-
-    function mergeCounts(target, source) {
-        Object.keys(source || {}).forEach(function(key) {
-            target[key] = (target[key] || 0) + source[key];
-        });
-        return target;
-    }
-
-    function totalCounts(counts) {
-        return Object.keys(counts || {}).reduce(function(sum, key) {
-            return sum + (counts[key] || 0);
-        }, 0);
-    }
-
-    function toSortedCommitters(counts) {
-        return Object.keys(counts || {}).map(function(author) {
-            return { name: author, count: counts[author] };
-        }).sort(function(a, b) {
-            if (b.count !== a.count) return b.count - a.count;
-            return a.name.localeCompare(b.name);
-        });
-    }
-
-    function jensenShannon(countsA, totalA, countsB, totalB) {
-        if (totalA <= 0 || totalB <= 0) return 0;
-        var keys = {};
-        Object.keys(countsA || {}).forEach(function(key) {
-            if (countsA[key] > 0) keys[key] = true;
-        });
-        Object.keys(countsB || {}).forEach(function(key) {
-            if (countsB[key] > 0) keys[key] = true;
-        });
-        var klA = 0;
-        var klB = 0;
-        Object.keys(keys).forEach(function(key) {
-            var pa = (countsA[key] || 0) / totalA;
-            var pb = (countsB[key] || 0) / totalB;
-            var mid = 0.5 * (pa + pb);
-            if (pa > 0 && mid > 0) klA += pa * Math.log(pa / mid);
-            if (pb > 0 && mid > 0) klB += pb * Math.log(pb / mid);
-        });
-        return 0.5 * (klA + klB);
-    }
-
-    function newFolderNode(path, parent, depth) {
-        return {
-            path: path,
-            parent: parent || null,
-            depth: depth || 0,
-            childrenByName: {},
-            children: [],
-            selfCounts: {},
-            selfTotal: 0,
-            totalCounts: {},
-            totalCommits: 0,
-            leafProfiles: [],
-            collapseLoss: 0,
-            committersSelf: [],
-            committersTotal: []
-        };
-    }
-
-    function insertFolder(root, folderPath, counts) {
-        var node = root;
-        var segments = folderPath === '/' ? [] : folderPath.split('/').filter(Boolean);
-        segments.forEach(function(segment) {
-            if (!node.childrenByName[segment]) {
-                var childPath = node.path === '/' ? segment : node.path + '/' + segment;
-                node.childrenByName[segment] = newFolderNode(childPath, node, node.depth + 1);
-            }
-            node = node.childrenByName[segment];
-        });
-        mergeCounts(node.selfCounts, counts);
-    }
-
-    function finalizeTree(node) {
-        var names = Object.keys(node.childrenByName).sort();
-        node.children = names.map(function(name) { return node.childrenByName[name]; });
-
-        node.selfTotal = totalCounts(node.selfCounts);
-        node.totalCounts = cloneCounts(node.selfCounts);
-        node.totalCommits = node.selfTotal;
-        node.leafProfiles = [];
-        if (node.selfTotal > 0) {
-            node.leafProfiles.push({ counts: node.selfCounts, total: node.selfTotal });
-        }
-
-        node.children.forEach(function(child) {
-            finalizeTree(child);
-            mergeCounts(node.totalCounts, child.totalCounts);
-            node.totalCommits += child.totalCommits;
-            if (child.leafProfiles.length > 0) {
-                node.leafProfiles = node.leafProfiles.concat(child.leafProfiles);
-            }
-        });
-
-        node.committersSelf = toSortedCommitters(node.selfCounts);
-        node.committersTotal = toSortedCommitters(node.totalCounts);
-
-        var loss = 0;
-        if (node.totalCommits > 0 && node.leafProfiles.length > 0) {
-            node.leafProfiles.forEach(function(leaf) {
-                loss += leaf.total * jensenShannon(leaf.counts, leaf.total, node.totalCounts, node.totalCommits);
-            });
-        }
-        node.collapseLoss = loss;
-    }
-
-    function nodeDisplayPenalty(node, lambda, depthWeight) {
-        return lambda * (1 + (depthWeight * (node.depth || 0)));
-    }
-
-    function solvePruning(node, lambda, depthWeight) {
-        if (node.totalCommits <= 0) {
-            return { cost: 0, selection: [] };
-        }
-
-        var collapse = {
-            cost: node.collapseLoss + nodeDisplayPenalty(node, lambda, depthWeight),
-            selection: [{ node: node, mode: 'aggregate' }]
-        };
-
-        var expandCost = 0;
-        var expandSelection = [];
-        if (node.selfTotal > 0) {
-            expandCost += nodeDisplayPenalty(node, lambda, depthWeight);
-            expandSelection.push({ node: node, mode: 'self' });
-        }
-        node.children.forEach(function(child) {
-            var sub = solvePruning(child, lambda, depthWeight);
-            expandCost += sub.cost;
-            if (sub.selection.length > 0) {
-                expandSelection = expandSelection.concat(sub.selection);
-            }
-        });
-
-        if (expandSelection.length === 0) {
-            return collapse;
-        }
-        return collapse.cost <= expandCost ? collapse : { cost: expandCost, selection: expandSelection };
-    }
-
-    function selectionInfoLoss(selection) {
-        var loss = 0;
-        (selection || []).forEach(function(sel) {
-            if (sel.mode === 'aggregate') {
-                loss += sel.node.collapseLoss || 0;
-            }
-        });
-        return loss;
-    }
-
-    function selectionToStats(selection) {
-        return (selection || []).map(function(sel) {
-            var useAggregate = sel.mode === 'aggregate';
-            var totalCommits = useAggregate ? sel.node.totalCommits : sel.node.selfTotal;
-            var committers = useAggregate ? sel.node.committersTotal : sel.node.committersSelf;
-            var subtitle = 'Folder';
-            if (useAggregate && sel.node.children.length > 0) {
-                subtitle = 'Folder group';
-            } else if (!useAggregate && sel.node.children.length > 0) {
-                subtitle = 'Folder (direct files)';
-            }
-            return {
-                folder: sel.node.path || '/',
-                subtitle: subtitle,
-                totalCommits: totalCommits,
-                committers: committers,
-                busFactor: computeBusFactor(committers, totalCommits)
-            };
-        }).filter(function(item) {
-            return item.totalCommits > 0;
-        }).sort(function(a, b) {
-            if (b.totalCommits !== a.totalCommits) return b.totalCommits - a.totalCommits;
-            return a.folder.localeCompare(b.folder);
-        });
-    }
-
-    function enforceMinimumSelection(selection, minNodes) {
-        var out = (selection || []).slice();
-        while (out.length < minNodes) {
-            var bestIdx = -1;
-            var bestWeight = 0;
-            for (var i = 0; i < out.length; i++) {
-                var entry = out[i];
-                if (entry.mode !== 'aggregate') continue;
-                var expandableChildren = entry.node.children.filter(function(child) { return child.totalCommits > 0; });
-                var possible = expandableChildren.length + (entry.node.selfTotal > 0 ? 1 : 0);
-                if (possible <= 1) continue;
-                var weight = entry.node.totalCommits;
-                if (weight > bestWeight) {
-                    bestWeight = weight;
-                    bestIdx = i;
-                }
-            }
-            if (bestIdx === -1) break;
-
-            var picked = out[bestIdx];
-            out.splice(bestIdx, 1);
-
-            var replacements = [];
-            var remaining = minNodes - out.length;
-            if (picked.node.selfTotal > 0 && remaining > 0) {
-                replacements.push({ node: picked.node, mode: 'self' });
-                remaining--;
-            }
-
-            var children = picked.node.children
-                .filter(function(child) { return child.totalCommits > 0; })
-                .sort(function(a, b) { return b.totalCommits - a.totalCommits; });
-
-            var take = children.length;
-            if (remaining > 0) {
-                take = Math.min(children.length, Math.max(1, remaining));
-            } else {
-                take = Math.min(children.length, 1);
-            }
-            for (var c = 0; c < take; c++) {
-                replacements.push({ node: children[c], mode: 'aggregate' });
-            }
-            if (!replacements.length) break;
-            out = out.concat(replacements);
-        }
-        return out;
-    }
-
-    function autoPruneFolderGroups(folderCommitters, granularityValue) {
-        var root = newFolderNode('/', null, 0);
-        Object.keys(folderCommitters).forEach(function(folder) {
-            insertFolder(root, folder, folderCommitters[folder]);
-        });
-        finalizeTree(root);
-
-        if (root.totalCommits <= 0 || root.leafProfiles.length === 0) {
-            return {
-                stats: [],
-                leafCount: 0,
-                lambda: 0
-            };
-        }
-
-        var leafCount = root.leafProfiles.length;
-        var totalCommitsInTree = root.totalCommits;
-        var normalizedGranularity = clamp(Number(granularityValue), 0, 100);
-        if (!isFinite(normalizedGranularity)) normalizedGranularity = 50;
-        var detailBias = (normalizedGranularity - 50) / 50; // [-1..1]
-        var compactness = clamp((50 - normalizedGranularity) / 50, 0, 1);
-        var detailness = clamp((normalizedGranularity - 50) / 50, 0, 1);
-        var diversity = authorDiversity(root.totalCounts);
-        var concentration = clamp(diversity.concentration, 0, 1);
-
-        var baseTargetNodes = Math.max(8, Math.min(40, Math.round(6 + (3.2 * Math.log(leafCount + 1)))));
-        var targetScale = 1 + (detailBias * 0.55);
-        var concentrationTargetScale = 1 - (0.40 * concentration * (0.5 + compactness));
-        var targetNodes = Math.max(5, Math.min(56, Math.round(baseTargetNodes * targetScale * concentrationTargetScale)));
-        var minTarget = Math.max(6, Math.floor(targetNodes * 0.85));
-        var maxTarget = Math.max(minTarget + 2, Math.ceil(targetNodes * 1.15));
-
-        var depthWeight = clamp(0.35 * (1 - (detailBias * 0.55)) * (1 + (concentration * (0.25 + compactness * 0.45))), 0.12, 1.2);
-        var lambdaBoost = 1 + (concentration * (0.6 + compactness * 1.1));
-        var baseLambdaRaw = Math.max(0.05, Math.log(totalCommitsInTree + 1) * 0.6 * (1 - (detailBias * 0.65)) * lambdaBoost);
-        var baseLambda = Math.max(0.0001, baseLambdaRaw);
-        var minLambda = Math.max(0.0005, 0.01 * (0.6 + concentration * 2.2) * (1 + compactness * 1.4));
-        var maxLambda = Math.max(2048, baseLambda * 4096);
-
-        var candidates = [];
-        var seen = {};
-        function addCandidate(lambda) {
-            if (!isFinite(lambda) || lambda <= 0) return;
-            lambda = Math.max(minLambda, Math.min(maxLambda, lambda));
-            var key = lambda.toExponential(6);
-            if (seen[key]) return;
-            seen[key] = true;
-            var solved = solvePruning(root, lambda, depthWeight);
-            candidates.push({
-                lambda: lambda,
-                solution: solved,
-                count: solved.selection.length,
-                infoLoss: selectionInfoLoss(solved.selection)
-            });
-        }
-
-        addCandidate(baseLambda);
-        var probe = baseLambda;
-        for (var i = 0; i < 14; i++) {
-            probe = Math.max(minLambda, probe / 1.8);
-            addCandidate(probe);
-            if (probe <= minLambda) break;
-        }
-        probe = baseLambda;
-        for (var j = 0; j < 14; j++) {
-            probe = Math.min(maxLambda, probe * 1.8);
-            addCandidate(probe);
-            if (probe >= maxLambda) break;
-        }
-
-        var observed = candidates.map(function(c) { return c.lambda; });
-        var observedMin = Math.min.apply(null, observed);
-        var observedMax = Math.max.apply(null, observed);
-        var logMin = Math.log(observedMin);
-        var logMax = Math.log(observedMax);
-        for (var k = 0; k < 24; k++) {
-            var t = k / 23;
-            addCandidate(Math.exp(logMin + (logMax - logMin) * t));
-        }
-
-        candidates.sort(function(a, b) {
-            var missA = 0;
-            var missB = 0;
-            var overWeight = 1 + (compactness * 3.0) + (concentration * 1.5);
-            var underWeight = 1 + (detailness * 2.0);
-            if (a.count < minTarget) missA = (minTarget - a.count) * underWeight;
-            else if (a.count > maxTarget) missA = (a.count - maxTarget) * overWeight;
-            if (b.count < minTarget) missB = (minTarget - b.count) * underWeight;
-            else if (b.count > maxTarget) missB = (b.count - maxTarget) * overWeight;
-            if (missA !== missB) return missA - missB;
-
-            var distA = Math.abs(a.count - targetNodes);
-            var distB = Math.abs(b.count - targetNodes);
-            if (distA !== distB) return distA - distB;
-            if (a.infoLoss !== b.infoLoss) return a.infoLoss - b.infoLoss;
-            return a.lambda - b.lambda;
-        });
-
-        var best = candidates[0];
-        var minDisplayBase = Math.max(5, Math.min(18, Math.round(2.2 * Math.log(leafCount + 1))));
-        var minDisplayNodes = Math.max(4, Math.round(minDisplayBase * (1 + (detailBias * 0.45)) * (1 - concentration * 0.25)));
-        var floorApplied = false;
-        var finalSelection = best.solution.selection;
-        if (finalSelection.length < minDisplayNodes && leafCount > finalSelection.length) {
-            finalSelection = enforceMinimumSelection(finalSelection, minDisplayNodes);
-            floorApplied = true;
-        }
-
-        var stats = selectionToStats(finalSelection);
-
-        return {
-            stats: stats,
-            leafCount: leafCount,
-            lambda: best.lambda,
-            targetNodes: targetNodes,
-            floorApplied: floorApplied,
-            depthWeight: depthWeight,
-            granularity: normalizedGranularity,
-            dominance: diversity.dominance,
-            authorCount: diversity.authorCount
-        };
-    }
-
-    var allPaths = files
-        .map(function(f) { return normalizePath(f.path || f.shortPath || ''); })
-        .filter(Boolean);
-    var prefix = commonPrefix(allPaths);
-
-    var folderCommitters = {};
-    files.forEach(function(file) {
-        var path = normalizePath(file.path || file.shortPath || '');
+    files.forEach(function (file) {
+        var path = normalize(file.path || file.shortPath || '');
         if (!path) return;
-        var relPath = (prefix && path.indexOf(prefix) === 0) ? path.slice(prefix.length) : path;
-        var folder = toFolderPath(relPath);
-        if (!folderCommitters[folder]) folderCommitters[folder] = {};
-
+        var relative = (prefix && path.indexOf(prefix) === 0) ? path.slice(prefix.length) : path;
+        var cut = relative.lastIndexOf('/');
+        var folder = cut > 0 ? relative.slice(0, cut) : '.';
         var commits = (file.commits && Array.isArray(file.commits.commits)) ? file.commits.commits : [];
-        commits.forEach(function(commit) {
-            var author = commit && typeof commit.author === 'string' ? commit.author.trim() : '';
+        commits.forEach(function (commit) {
+            var author = (commit && typeof commit.author === 'string') ? commit.author.trim() : '';
             if (!author || author === 'noreply@github.com') return;
-            folderCommitters[folder][author] = (folderCommitters[folder][author] || 0) + 1;
+            if (!folderCounts[folder]) folderCounts[folder] = {};
+            folderCounts[folder][author] = (folderCounts[folder][author] || 0) + 1;
+            authorCounts[author] = (authorCounts[author] || 0) + 1;
+            if (!authorFolders[author]) authorFolders[author] = {};
+            authorFolders[author][folder] = true;
+            totalCommits++;
         });
     });
 
-    function renderFolderCards(items) {
-        folderGrid.innerHTML = '';
-        if (!items.length) {
-            folderEmpty.classList.remove('hidden');
-            return;
-        }
-        folderEmpty.classList.add('hidden');
+    var folders = Object.keys(folderCounts).map(function (folder) {
+        var counts = folderCounts[folder];
+        var contributors = Object.keys(counts);
+        var commits = contributors.reduce(function (sum, name) { return sum + counts[name]; }, 0);
+        return { folder: folder, contributors: contributors.length, commits: commits };
+    }).filter(function (item) {
+        return item.commits > 0;
+    }).sort(function (a, b) {
+        return (b.commits - a.commits) || a.folder.localeCompare(b.folder);
+    });
 
-        items.forEach(function(item, index) {
-            var card = document.createElement('div');
-            card.className = 'dashboard-card p-5 animate-fade-in-up';
-            card.style.animationDelay = Math.min(index * 0.03, 0.3).toFixed(2) + 's';
+    var authors = Object.keys(authorCounts).sort(function (a, b) {
+        return (authorCounts[b] - authorCounts[a]) || a.localeCompare(b);
+    });
+    var soloFolders = folders.filter(function (item) { return item.contributors === 1; });
 
-            var header = document.createElement('div');
-            header.className = 'flex items-start justify-between mb-3';
-
-            var left = document.createElement('div');
-            left.className = 'flex-1 min-w-0';
-            var title = document.createElement('h3');
-            title.className = 'text-lg font-semibold text-gray-900 mb-1 truncate';
-            title.textContent = item.folder;
-            title.title = item.folder;
-            var subtitle = document.createElement('p');
-            subtitle.className = 'text-xs text-gray-600';
-            subtitle.textContent = item.subtitle || 'Folder';
-            left.appendChild(title);
-            left.appendChild(subtitle);
-
-            var right = document.createElement('div');
-            right.className = 'text-right ml-2';
-            var value = document.createElement('div');
-            value.className = 'text-2xl font-bold text-blue-600 metric-value';
-            value.textContent = String(item.busFactor);
-            var valueLabel = document.createElement('p');
-            valueLabel.className = 'text-xs text-gray-600';
-            valueLabel.textContent = 'Bus Factor';
-            var contributors = document.createElement('div');
-            contributors.className = 'mt-2 text-sm text-gray-600';
-            var contributorCount = document.createElement('span');
-            contributorCount.className = 'font-medium';
-            contributorCount.textContent = String(item.committers.length);
-            var contributorLabel = document.createElement('span');
-            contributorLabel.className = 'text-xs text-gray-800 ml-1';
-            contributorLabel.textContent = 'contributors';
-            contributors.appendChild(contributorCount);
-            contributors.appendChild(contributorLabel);
-            right.appendChild(value);
-            right.appendChild(valueLabel);
-            right.appendChild(contributors);
-
-            header.appendChild(left);
-            header.appendChild(right);
-            card.appendChild(header);
-
-            var sparklineWrap = document.createElement('div');
-            sparklineWrap.className = 'mb-3';
-            var sparkline = document.createElement('div');
-            sparkline.className = 'flex items-end justify-between h-8 gap-0.5';
-            var top10 = item.committers.slice(0, 10);
-            var maxCount = top10.length ? top10[0].count : 1;
-            top10.forEach(function(c) {
-                var bar = document.createElement('div');
-                bar.className = 'flex-1 rounded-t opacity-80 hover:opacity-100 transition-opacity';
-                var height = Math.max(4, Math.round((c.count / maxCount) * 32));
-                bar.style.height = height + 'px';
-                bar.style.maxHeight = '32px';
-                bar.style.backgroundColor = colorFor(c.name);
-                bar.title = c.name + ': ' + c.count + ' commits';
-                sparkline.appendChild(bar);
-            });
-            var sparklineLabel = document.createElement('p');
-            sparklineLabel.className = 'text-xs text-gray-800 mt-1';
-            sparklineLabel.textContent = 'Commit distribution';
-            sparklineWrap.appendChild(sparkline);
-            sparklineWrap.appendChild(sparklineLabel);
-            card.appendChild(sparklineWrap);
-
-            var topWrap = document.createElement('div');
-            topWrap.className = 'border-t border-gray-100 pt-3';
-            var topTitle = document.createElement('p');
-            topTitle.className = 'text-xs font-medium text-gray-600 mb-2';
-            topTitle.textContent = 'Top Contributors';
-            var list = document.createElement('div');
-            list.className = 'space-y-1';
-            item.committers.slice(0, 5).forEach(function(c) {
-                var row = document.createElement('div');
-                row.className = 'flex justify-between items-center text-xs';
-
-                var leftRow = document.createElement('div');
-                leftRow.className = 'flex items-center gap-2 flex-1 min-w-0';
-                var avatar = document.createElement('div');
-                avatar.className = 'contributor-avatar contributor-avatar-small';
-                avatar.style.backgroundColor = colorFor(c.name);
-                avatar.textContent = initials(c.name);
-                var name = document.createElement('span');
-                name.className = 'text-gray-900 truncate';
-                name.textContent = c.name;
-                name.title = c.name;
-                leftRow.appendChild(avatar);
-                leftRow.appendChild(name);
-
-                var count = document.createElement('span');
-                count.className = 'text-gray-700 bg-gray-100 px-2 py-0.5 rounded-full font-medium ml-2 flex-shrink-0';
-                count.textContent = String(c.count);
-
-                row.appendChild(leftRow);
-                row.appendChild(count);
-                list.appendChild(row);
-            });
-            if (item.committers.length > 5) {
-                var more = document.createElement('p');
-                more.className = 'text-xs text-gray-800 mt-2';
-                more.textContent = '+ ' + (item.committers.length - 5) + ' more';
-                list.appendChild(more);
-            }
-            topWrap.appendChild(topTitle);
-            topWrap.appendChild(list);
-            card.appendChild(topWrap);
-
-            folderGrid.appendChild(card);
-        });
+    // --- Hero numbers -------------------------------------------------------
+    function setText(id, text) {
+        var node = document.getElementById(id);
+        if (node) node.textContent = text;
     }
 
-    var hasCommunityData = communitySection.getAttribute('data-has-community') === '1';
-    var hasFolderData = false;
+    setText('bf-kpi-contributors', String(authors.length));
+    setText('bf-kpi-commits', String(totalCommits));
+    setText('bf-kpi-folders', soloFolders.length + ' / ' + folders.length);
 
-    function setFolderLoading(isLoading) {
-        if (isLoading) {
-            folderLoading.classList.remove('hidden');
+    // "817 commits" becomes "817 of 821 commits" once the total is known
+    var leadCount = document.getElementById('bf-lead-count');
+    if (leadCount && totalCommits > 0) {
+        var signed = parseInt(leadCount.getAttribute('data-count'), 10);
+        if (isFinite(signed) && signed <= totalCommits) {
+            leadCount.textContent = signed + ' of ' + plural(totalCommits, 'commit');
+        }
+    }
+
+    if (folders.length) {
+        if (soloFolders.length === folders.length) {
+            setText('bf-lead-folders', 'None of the ' + plural(folders.length, 'folder') +
+                ' of the project has a second regular contributor.');
+        } else if (soloFolders.length > 0) {
+            setText('bf-lead-folders', soloFolders.length + ' of the ' + plural(folders.length, 'folder') +
+                ' rely on a single contributor.');
         } else {
-            folderLoading.classList.add('hidden');
+            setText('bf-lead-folders', 'Every one of the ' + plural(folders.length, 'folder') +
+                ' has at least two contributors.');
         }
     }
 
-    function renderFoldersForGranularity(value, options) {
-        var opts = options || {};
-        var doRender = function() {
-            var pruning = autoPruneFolderGroups(folderCommitters, value);
-            var folderStats = pruning.stats;
-            hasFolderData = folderStats.length > 0;
-            if (pruning.leafCount > 0) {
-                pruningMeta.textContent = 'Adaptive pruning: ' + folderStats.length + ' groups shown over ' +
-                    pruning.leafCount + ' folder leaves (target ≈ ' + pruning.targetNodes + ', lambda = ' +
-                    pruning.lambda.toFixed(2) + ', depthWeight = ' + pruning.depthWeight.toFixed(2) + ', ' +
-                    granularityLabel(pruning.granularity) + ', dominant ' + Math.round((pruning.dominance || 0) * 100) +
-                    '% across ' + (pruning.authorCount || 0) + ' author' + ((pruning.authorCount || 0) === 1 ? '' : 's') + ')' +
-                    (pruning.floorApplied ? ' [display floor applied]' : '') + '.';
-            } else {
-                pruningMeta.textContent = '';
-            }
-            renderFolderCards(folderStats);
-            if (typeof opts.done === 'function') opts.done();
-        };
-
-        if (opts.withLoading) {
-            setFolderLoading(true);
-            requestAnimationFrame(function() {
-                try {
-                    doRender();
-                } finally {
-                    setFolderLoading(false);
-                }
-            });
-            return;
-        }
-        doRender();
-    }
-
-    function setMode(mode) {
-        if (mode === 'community' && hasCommunityData) {
-            folderSection.classList.add('hidden');
-            communitySection.classList.remove('hidden');
-            return;
-        }
-        folderSection.classList.remove('hidden');
-        communitySection.classList.add('hidden');
-    }
-
-    radios.forEach(function(radio) {
-        radio.addEventListener('change', function() {
-            setMode(this.value);
-        });
+    // "active on N folders" under each contributor name
+    Array.prototype.forEach.call(document.querySelectorAll('[data-bf-author]'), function (node) {
+        var known = authorFolders[node.getAttribute('data-bf-author')];
+        var count = known ? Object.keys(known).length : 0;
+        node.textContent = count > 0 ? 'active on ' + plural(count, 'folder') : '';
     });
 
-    var bfGranularityRAF = null;
-    function scheduleGranularityRender() {
-        if (bfGranularityRAF) cancelAnimationFrame(bfGranularityRAF);
-        bfGranularityRAF = requestAnimationFrame(function() {
-            bfGranularityRAF = null;
-            var value = parseInt(granularityInput.value, 10);
-            if (!isFinite(value)) value = 50;
-            granularityLabelEl.textContent = granularityLabel(value);
-            renderFoldersForGranularity(value, { withLoading: false });
-        });
+    // Contributors not listed above (the table only shows the main ones)
+    var listedRows = document.querySelectorAll('#bf-contributor-list [data-bf-author]').length;
+    var othersNode = document.getElementById('bf-others');
+    if (othersNode && authors.length > listedRows) {
+        var others = authors.slice(listedRows);
+        var othersCommits = others.reduce(function (sum, name) { return sum + authorCounts[name]; }, 0);
+        othersNode.textContent = '+ ' + plural(others.length, 'other contributor') + ' · ' +
+            plural(othersCommits, 'commit');
     }
 
-    granularityInput.addEventListener('input', scheduleGranularityRender);
-    granularityInput.addEventListener('change', scheduleGranularityRender);
+    // --- Where to start sharing --------------------------------------------
+    var singleList = document.getElementById('bf-single-list');
+    var singleEmpty = document.getElementById('bf-single-empty');
+    if (!soloFolders.length) {
+        if (singleEmpty) singleEmpty.classList.remove('hidden');
+    } else {
+        soloFolders.slice(0, SINGLE_LIMIT).forEach(function (item) {
+            var share = totalCommits > 0 ? (item.commits / totalCommits) : 0;
+            var row = el('div', 'data-row');
+            row.appendChild(el('span', 'dot sev-bad'));
 
-    var initialGranularity = parseInt(granularityInput.value, 10);
-    if (!isFinite(initialGranularity)) initialGranularity = 50;
-    granularityLabelEl.textContent = granularityLabel(initialGranularity);
-    renderFoldersForGranularity(initialGranularity, {
-        withLoading: true,
-        done: function() {
-            var initialMode = 'folder';
-            if (!hasFolderData && hasCommunityData) {
-                initialMode = 'community';
-            }
-            if (!hasCommunityData && communityRadio) {
-                communityRadio.checked = false;
-            }
-            if (initialMode === 'folder' && folderRadio) folderRadio.checked = true;
-            if (initialMode === 'community' && communityRadio) communityRadio.checked = true;
-            setMode(initialMode);
+            var middle = el('div', 'min-w-0 flex-1');
+            middle.appendChild(el('div', 'row-name mono-name truncate', item.folder));
+            middle.appendChild(el('div', 'row-meta', '1 contributor · ' + plural(item.commits, 'commit') + ' in total'));
+            row.appendChild(middle);
+
+            // Qualitative label, derived only from the share of commits
+            var label = '';
+            if (share >= 0.15) label = 'the core';
+            else if (share >= 0.05) label = 'visible';
+            else if (item.commits > 0) label = 'good entry point';
+            if (label) row.appendChild(el('span', 'tag-soft', label));
+
+            row.appendChild(el('span', 'row-value w-14', String(item.commits)));
+            singleList.appendChild(row);
+        });
+
+        if (soloFolders.length > SINGLE_LIMIT) {
+            setText('bf-single-more', '+ ' + (soloFolders.length - SINGLE_LIMIT) +
+                ' more folders with a single contributor.');
         }
-    });
+    }
+
+    // --- Knowledge per folder ----------------------------------------------
+    if (!folders.length) {
+        var folderEmpty = document.getElementById('bf-folder-empty');
+        if (folderEmpty) folderEmpty.classList.remove('hidden');
+    } else {
+        folders.slice(0, CHIP_LIMIT).forEach(function (item) {
+            var severity = item.contributors === 1 ? 'sev-bad' : (item.contributors === 2 ? 'sev-warn' : 'sev-good');
+            var chip = el('div', 'folder-chip');
+            chip.title = item.folder + ': ' + plural(item.contributors, 'contributor') + ', ' +
+                plural(item.commits, 'commit');
+            chip.appendChild(el('span', 'dot ' + severity));
+            var body = el('div', 'min-w-0');
+            body.appendChild(el('div', 'folder-chip-name', item.folder));
+            body.appendChild(el('div', 'row-meta', plural(item.contributors, 'contributor')));
+            chip.appendChild(body);
+            chipsGrid.appendChild(chip);
+        });
+
+        if (folders.length > CHIP_LIMIT) {
+            setText('bf-folder-more', 'Showing the ' + CHIP_LIMIT + ' most active folders out of ' +
+                folders.length + '.');
+        }
+    }
+});
+
+// The commit rhythm chart is drawn before the stylesheet sizes its container:
+// ask it to measure again once everything is loaded.
+window.addEventListener('load', function () {
+    window.dispatchEvent(new Event('resize'));
 });
 </script>
 {% endblock %}

--- a/internal/report/templates/html/busfactor.html
+++ b/internal/report/templates/html/busfactor.html
@@ -60,7 +60,8 @@ AST Metrics - Bus Factor
 
     .tag-soft {
         font-size: 11px;
-        color: #64748b;
+        /* Slate 600, not 500: on the tinted pill 500 falls under 4.5:1 */
+        color: #475569;
         background: #f1f5f9;
         border-radius: 999px;
         padding: 0.15rem 0.55rem;
@@ -142,7 +143,7 @@ AST Metrics - Bus Factor
         <div class="shrink-0 text-right">
             <div class="bf-figure">{{ busFactor }}</div>
             <div class="page-kicker mt-2">key {% if busFactor == 1 %}person{% else %}people{% endif %}</div>
-            <p class="text-xs text-slate-400 mt-3 max-w-[190px] ml-auto">
+            <p class="text-xs text-slate-500 mt-3 max-w-[190px] ml-auto">
                 Number of developers who carry half of the commits.
             </p>
         </div>
@@ -192,7 +193,7 @@ AST Metrics - Bus Factor
     <div class="mt-6 pt-5 border-t border-slate-100">
         <div class="flex flex-wrap items-baseline justify-between gap-2">
             <h3 class="section-title">Commit rhythm</h3>
-            <p class="text-xs text-slate-400">
+            <p class="text-xs text-slate-500">
                 {{ currentView.CommitCountForPeriod|stringifyNumber }} commits in the last 12 months
             </p>
         </div>

--- a/internal/report/templates/html/classes.html
+++ b/internal/report/templates/html/classes.html
@@ -1,0 +1,733 @@
+{% extends "layout.html" %}
+
+{% block title %}
+Classes
+{% endblock %}
+
+{% block pageTitle %}
+AST Metrics - Classes
+{% endblock %}
+
+{% block content %}
+
+<style>
+  /* Preset chips (page specific) */
+  .preset-chip {
+    transition: all 0.15s ease;
+    border: 1px solid #e2e8f0;
+    background: white;
+    color: #64748b;
+  }
+  .preset-chip:hover { border-color: #93c5fd; color: #1d4ed8; }
+  .preset-chip.active {
+    border-color: #3b82f6;
+    background: #eff6ff;
+    color: #1d4ed8;
+    font-weight: 600;
+  }
+
+  /* Sortable headers (Alpine-managed, kept independent from the global .sortable helper) */
+  th.col-sort { cursor: pointer; user-select: none; white-space: nowrap; }
+  th.col-sort:hover { color: #1d4ed8; }
+  th.col-sort .sort-arrow { display: inline-block; width: 1em; opacity: 0.9; }
+
+  .table-row { transition: background-color 0.15s ease; cursor: pointer; }
+  .table-row:hover { background-color: #f8fafc; }
+
+  /* Slide-over detail panel */
+  .slide-over {
+    position: fixed;
+    top: 0; right: 0;
+    height: 100vh;
+    width: 100%;
+    max-width: 560px;
+    background: white;
+    border-left: 1px solid #e2e8f0;
+    box-shadow: -8px 0 24px rgba(15, 23, 42, 0.12);
+    z-index: 55;
+    display: flex;
+    flex-direction: column;
+  }
+</style>
+
+<div x-data="classesPage()" x-init="init()">
+
+  <!-- Verdict -->
+  <div class="page-hero animate-fade-in-up mb-6">
+    <div class="flex flex-wrap items-start justify-between gap-8">
+      <div class="min-w-0">
+        <p class="page-kicker mb-3">
+          {{ scopeLabel|upper }} ·
+          CLASSES AND STRUCTS
+        </p>
+        <h1 class="verdict-title">
+          <span x-text="verdictTitle"></span><br>
+          <span class="verdict-muted" x-text="verdictSubtitle"></span>
+        </h1>
+        <p class="verdict-lead mt-4" x-html="verdictLead"></p>
+      </div>
+      <div class="kpi-strip kpi-strip--divided shrink-0">
+        <div>
+          <div class="kpi-value" x-text="stats.total"></div>
+          <div class="kpi-label">classes</div>
+        </div>
+        <div>
+          <div class="kpi-value" :class="stats.below > 0 ? 'text-warn' : ''" x-text="stats.below"></div>
+          <div class="kpi-label" tabindex="0" data-tip="Classes whose Maintainability Index is under 85, the value below which changes start to hurt.">below&nbsp;the&nbsp;target ⓘ</div>
+        </div>
+        <div>
+          <div class="kpi-value" :class="stats.uncohesive > 0 ? 'text-warn' : ''" x-text="stats.uncohesive"></div>
+          <div class="kpi-label" tabindex="0" data-tip="Classes with LCOM4 above 1: their methods form several unrelated groups, a sign that two concepts share one class.">with&nbsp;split&nbsp;duties ⓘ</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {% include "partials/language_tabs.html" with pageBase="classes" %}
+
+  <!-- Toolbar: search, quick views, scope -->
+  <div class="flex flex-wrap items-center gap-x-4 gap-y-3 mb-5">
+    <div class="relative min-w-[220px] flex-1 max-w-sm">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+        class="w-4 h-4 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+      </svg>
+      <input type="search" x-model.debounce.200ms="query" placeholder="Search a class or a file..."
+        aria-label="Search a class or a file"
+        class="w-full bg-white border border-gray-200 rounded-full pl-9 pr-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent">
+    </div>
+    <div class="flex flex-wrap items-center gap-1.5">
+      <template x-for="p in presets" :key="p.key">
+        <button class="preset-chip px-2.5 py-1 rounded-full text-xs"
+          :class="{ 'active': activePreset === p.key }"
+          :data-tip="p.tip"
+          @click="applyPreset(p)"
+          x-text="p.label"></button>
+      </template>
+    </div>
+    <label class="inline-flex items-center gap-2 cursor-pointer text-xs text-gray-500">
+      <input type="checkbox" x-model="includeTests" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+      Include test classes
+    </label>
+    <span class="text-xs text-gray-400 ml-auto" x-text="filtered.length + ' shown'"></span>
+  </div>
+
+  <!-- Table -->
+  <div class="soft-card animate-fade-in-up stagger-1">
+    <div class="overflow-x-auto -mx-6 px-6">
+      <table class="w-full text-sm min-w-[860px]">
+        <thead>
+          <tr class="border-b border-gray-200">
+            <th class="px-3 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide col-sort"
+              :aria-sort="ariaSort('name')" @click="sortBy('name')" scope="col">
+              Class <span class="sort-arrow" x-text="arrow('name')"></span>
+            </th>
+            <template x-for="col in metricColumns" :key="col.key">
+              <th class="px-3 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide col-sort"
+                :aria-sort="ariaSort(col.key)" @click="sortBy(col.key)" scope="col">
+                <span :data-tip="col.tip" tabindex="0" x-text="col.label"></span>
+                <span class="sort-arrow" x-text="arrow(col.key)"></span>
+              </th>
+            </template>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100">
+          <template x-if="paged.length === 0">
+            <tr>
+              <td :colspan="metricColumns.length + 1" class="px-4 py-12 text-center text-gray-500 text-sm">
+                <template x-if="rows.length === 0">
+                  <span>No classes or structs were found in the analyzed code.</span>
+                </template>
+                <template x-if="rows.length > 0">
+                  <span>No class matches the current filters.</span>
+                </template>
+              </td>
+            </tr>
+          </template>
+          <template x-for="r in paged" :key="r.id">
+            <tr class="table-row" @click="openDetail(r)" @keydown.enter="openDetail(r)" tabindex="0"
+              :aria-label="'View details of ' + r.name">
+              <td class="px-3 py-3">
+                <div class="font-medium text-gray-900 flex items-center gap-2">
+                  <span x-text="r.shortName"></span>
+                  <span x-show="r.isTest" class="px-1.5 py-0.5 rounded bg-violet-50 text-violet-600 text-[10px] font-medium uppercase">test</span>
+                </div>
+                <div class="text-xs text-gray-400 truncate max-w-[320px]" x-text="r.file" :title="r.filePath"></div>
+              </td>
+              <td class="px-3 py-3 text-right"><span :class="badgeClass(miLevel(r.mi))" class="px-2 py-1 rounded-md text-xs font-medium inline-flex items-center gap-1"
+                :data-tip="miJudgment(r.mi)" tabindex="0"><span x-text="fmt(r.mi, 0)"></span></span></td>
+              <td class="px-3 py-3 text-right"><span :class="badgeClass(ccClassLevel(r.cc))" class="px-2 py-1 rounded-md text-xs font-medium inline-flex items-center gap-1"
+                :data-tip="ccJudgment(r.cc)" tabindex="0"><span x-text="fmt(r.cc, 0)"></span></span></td>
+              <td class="px-3 py-3 text-right"><span :class="badgeClass(lcomLevel(r.lcom4))" class="px-2 py-1 rounded-md text-xs font-medium inline-flex items-center gap-1"
+                :data-tip="lcomJudgment(r.lcom4)" tabindex="0"><span x-text="fmt(r.lcom4, 0)"></span></span></td>
+              <td class="px-3 py-3 text-right font-mono text-xs text-gray-700" x-text="fmt(r.ca, 0)"></td>
+              <td class="px-3 py-3 text-right font-mono text-xs text-gray-700" x-text="fmt(r.ce, 0)"></td>
+              <td class="px-3 py-3 text-right font-mono text-xs text-gray-700" x-text="fmt(r.lloc, 0)"></td>
+              <td class="px-3 py-3 text-right font-mono text-xs text-gray-700" x-text="fmt(r.methods, 0)"></td>
+              <td class="px-3 py-3 text-right font-mono text-xs text-gray-700" x-text="fmt(r.bugs, 3)"></td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div class="flex items-center justify-between mt-4 pt-4 border-t border-gray-100" x-show="filtered.length > pageSize">
+      <span class="text-xs text-gray-500"
+        x-text="`Showing ${page * pageSize + 1}-${Math.min((page + 1) * pageSize, filtered.length)} of ${filtered.length}`"></span>
+      <div class="flex items-center gap-2">
+        <button class="px-3 py-1.5 rounded-lg border border-gray-200 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+          :disabled="page === 0" @click="page--">Previous</button>
+        <button class="px-3 py-1.5 rounded-lg border border-gray-200 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+          :disabled="(page + 1) * pageSize >= filtered.length" @click="page++">Next</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Detail slide-over -->
+  <div x-show="detail" x-cloak>
+    <div class="fixed inset-0 bg-black/30 z-50" style="backdrop-filter: blur(2px);" @click="detail = null"></div>
+    <div class="slide-over" role="dialog" aria-modal="true" :aria-label="'Details of ' + (detail?.name || '')"
+      @keydown.escape.window="detail = null"
+      x-transition:enter="transition ease-out duration-200"
+      x-transition:enter-start="translate-x-full" x-transition:enter-end="translate-x-0"
+      x-transition:leave="transition ease-in duration-150"
+      x-transition:leave-start="translate-x-0" x-transition:leave-end="translate-x-full">
+      <template x-if="detail">
+        <div class="flex flex-col h-full">
+          <!-- Panel header -->
+          <div class="p-6 border-b border-gray-100">
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <h2 class="card-title break-words" x-text="detail.shortName"></h2>
+                <p class="card-sub break-words" x-text="detail.name"></p>
+                <p class="text-xs text-gray-500 mt-2 flex items-center gap-2 flex-wrap">
+                  <span class="px-2 py-0.5 rounded-full bg-gray-100 text-gray-600" x-text="detail.language"></span>
+                  <span x-show="detail.isTest" class="px-2 py-0.5 rounded-full bg-violet-50 text-violet-600 uppercase text-[10px] font-medium">test</span>
+                  <span x-text="detail.file"></span>
+                </p>
+              </div>
+              <button @click="detail = null" aria-label="Close details"
+                class="shrink-0 text-gray-400 hover:text-gray-600 p-1 rounded-lg hover:bg-gray-100 transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <a :href="explorerUrl + '?file=' + detail.pathHash"
+              class="inline-flex items-center gap-1.5 mt-4 text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline">
+              Open file in explorer
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+              </svg>
+            </a>
+          </div>
+
+          <!-- Panel body -->
+          <div class="flex-1 overflow-y-auto p-6 space-y-6">
+
+            <!-- One-sentence diagnosis -->
+            <div class="insight" :class="detailInsight.level !== 'none' ? 'insight--' + detailInsight.level : ''">
+              <span class="dot" :class="'sev-' + detailInsight.level"></span>
+              <span x-html="detailInsight.text"></span>
+            </div>
+
+            <!-- At a glance -->
+            <div class="grid grid-cols-3 gap-3">
+              <div class="stat-tile">
+                <div class="stat-tile-label">
+                  <span>Maintainable</span>
+                  <span class="dot" :class="'sev-' + dotLevel(miLevel(detail.mi))"></span>
+                </div>
+                <div class="stat-tile-value" :class="textClass(miLevel(detail.mi))" x-text="fmt(detail.mi, 0)"></div>
+                <div class="meter"><div class="meter-fill" :class="'sev-' + dotLevel(miLevel(detail.mi))"
+                  :style="`width: ${Math.max(0, Math.min(128, detail.mi || 0)) / 128 * 100}%`"></div></div>
+                <div class="stat-tile-target">MI, target &ge; 85</div>
+              </div>
+              <div class="stat-tile">
+                <div class="stat-tile-label">
+                  <span>Branching</span>
+                  <span class="dot" :class="'sev-' + dotLevel(ccClassLevel(detail.cc))"></span>
+                </div>
+                <div class="stat-tile-value" :class="textClass(ccClassLevel(detail.cc))" x-text="fmt(detail.cc, 0)"></div>
+                <div class="meter"><div class="meter-fill" :class="'sev-' + dotLevel(ccClassLevel(detail.cc))"
+                  :style="`width: ${Math.max(0, Math.min(100, (detail.cc || 0) / 60 * 100))}%`"></div></div>
+                <div class="stat-tile-target">paths, keep under 20</div>
+              </div>
+              <div class="stat-tile">
+                <div class="stat-tile-label">
+                  <span>Focus</span>
+                  <span class="dot" :class="'sev-' + dotLevel(lcomLevel(detail.lcom4))"></span>
+                </div>
+                <div class="stat-tile-value" :class="textClass(lcomLevel(detail.lcom4))" x-text="fmt(detail.lcom4, 0)"></div>
+                <div class="meter"><div class="meter-fill" :class="'sev-' + dotLevel(lcomLevel(detail.lcom4))"
+                  :style="`width: ${Math.max(0, Math.min(100, (detail.lcom4 || 0) / 5 * 100))}%`"></div></div>
+                <div class="stat-tile-target">LCOM4, 1 is ideal</div>
+              </div>
+            </div>
+
+            <!-- Maintainability -->
+            <div>
+              <h3 class="section-title mb-1">Ease of maintenance</h3>
+              <div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Index
+                    <span tabindex="0" data-tip="Composite of Halstead volume, cyclomatic complexity and lines of code. Higher is better (max 128)." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.mi, 1)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Without comments
+                    <span tabindex="0" data-tip="Same index computed while ignoring comments. A large gap with the main index means readability relies heavily on comments." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.miNoComments, 1)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Comment weight
+                    <span tabindex="0" data-tip="Contribution of comments to the Maintainability Index. Higher means comments help more." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.commentWeight, 1)"></span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Size -->
+            <div>
+              <h3 class="section-title mb-1">How much code</h3>
+              <div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Lines of code (LOC)
+                    <span tabindex="0" data-tip="Physical lines, including comments and blank lines." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.loc, 0)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Logical lines (LLOC)
+                    <span tabindex="0" data-tip="Statement lines only: the real amount of executable code." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.lloc, 0)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Comment lines (CLOC)
+                    <span tabindex="0" data-tip="Lines of comments." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.cloc, 0)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1">Methods</span>
+                  <span class="row-value" x-text="fmt(detail.methods, 0)"></span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Coupling -->
+            <div>
+              <h3 class="section-title mb-1">Links with the rest of the code</h3>
+              <div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Depended upon by (Ca)
+                    <span tabindex="0" data-tip="Afferent coupling: how many other components depend on this class. High Ca means changes here ripple through the codebase." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.ca, 0)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Depends on (Ce)
+                    <span tabindex="0" data-tip="Efferent coupling: how many other components this class depends on. High Ce makes the class fragile to external changes." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.ce, 0)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Instability
+                    <span tabindex="0" data-tip="Ce / (Ce + Ca), between 0 and 1. Near 0: stable, many things depend on it. Near 1: volatile, depends on many things. Neither is wrong by itself; stable classes should also be abstract." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.instability, 2)"></span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Halstead -->
+            <div>
+              <h3 class="section-title mb-0.5">Halstead measures</h3>
+              <p class="card-sub mb-1">Derived from the count of operators and operands. Relative indicators, not absolute truths.</p>
+              <div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Vocabulary
+                    <span tabindex="0" data-tip="Number of distinct operators and operands used." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.hVocabulary, 0)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Length
+                    <span tabindex="0" data-tip="Total number of operators and operands." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.hLength, 0)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Volume
+                    <span tabindex="0" data-tip="Size of the implementation in bits: length times log2(vocabulary)." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmtBig(detail.hVolume)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Difficulty
+                    <span tabindex="0" data-tip="How error-prone writing this code is, based on operator and operand reuse." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.hDifficulty, 1)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Effort
+                    <span tabindex="0" data-tip="Mental effort to implement or understand: difficulty times volume." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmtBig(detail.hEffort)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Time to program
+                    <span tabindex="0" data-tip="Theoretical implementation time: effort divided by 18 (Stroud number), in seconds." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmtTime(detail.hTime)"></span>
+                </div>
+                <div class="data-row">
+                  <span class="row-name flex-1 flex items-center gap-1.5">Delivered bugs
+                    <span tabindex="0" data-tip="Theoretical number of latent defects: volume / 3000. A relative indicator to compare classes." class="text-gray-300 text-xs">ⓘ</span></span>
+                  <span class="row-value" x-text="fmt(detail.bugs, 3)"></span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Methods -->
+            <div>
+              <h3 class="section-title mb-1">Methods <span x-text="'(' + detail.methodList.length + ')'"></span></h3>
+              <template x-if="detail.methodList.length === 0">
+                <p class="text-sm text-gray-500">No method detected.</p>
+              </template>
+              <div>
+                <template x-for="m in detail.methodList" :key="m.name">
+                  <div class="data-row">
+                    <span class="row-name flex-1 font-mono text-xs break-all" x-text="m.name"></span>
+                    <span :class="badgeClass(ccMethodLevel(m.cc))" class="px-2 py-0.5 rounded-md text-xs font-medium shrink-0 inline-flex items-center gap-1"
+                      :data-tip="'Cyclomatic complexity of this method. 1-5 simple, 6-10 moderate, 11-20 complex, above 20 very hard to test.'" tabindex="0">
+                      <span x-text="fmt(m.cc, 0)"></span>
+                    </span>
+                  </div>
+                </template>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block javascripts %}
+<script defer>
+  function classesPage() {
+    return {
+      rows: [],
+      query: '',
+      includeTests: false,
+      sortKey: 'mi',
+      sortAsc: true,
+      activePreset: 'maintainability',
+      page: 0,
+      pageSize: 50,
+      detail: null,
+      explorerUrl: 'explorer{{ scopeSuffix }}.html',
+
+      presets: [
+        { key: 'maintainability', label: 'Least maintainable', sort: 'mi', asc: true, tip: 'Classes with the lowest Maintainability Index first.' },
+        { key: 'largest', label: 'Largest', sort: 'lloc', asc: false, tip: 'Classes with the most logical lines of code first.' },
+        { key: 'complex', label: 'Most complex', sort: 'cc', asc: false, tip: 'Classes with the highest total cyclomatic complexity first.' },
+        { key: 'cohesion', label: 'Least cohesive', sort: 'lcom4', asc: false, tip: 'Classes with the highest LCOM4 first: they group unrelated responsibilities.' },
+        { key: 'coupled', label: 'Most depended upon', sort: 'ca', asc: false, tip: 'Classes with the highest afferent coupling first: changing them has the widest impact.' },
+        { key: 'buggy', label: 'Most bug-prone', sort: 'bugs', asc: false, tip: 'Classes with the highest theoretical bug count (Halstead) first.' },
+      ],
+
+      metricColumns: [
+        { key: 'mi', label: 'MI', tip: 'Maintainability Index (0-128). Higher is better: aim for 85 or more, below 65 is a refactoring candidate.' },
+        { key: 'cc', label: 'Cyclo.', tip: 'Cyclomatic complexity of the whole class (sum over methods). Above 20 gets hard to test, above 50 the class likely does too much.' },
+        { key: 'lcom4', label: 'LCOM4', tip: 'Cohesion: number of unrelated method groups. 1 is ideal; 2 or more suggests the class could be split.' },
+        { key: 'ca', label: 'Ca', tip: 'Afferent coupling: number of components depending on this class. Open a class to see its instability.' },
+        { key: 'ce', label: 'Ce', tip: 'Efferent coupling: number of components this class depends on.' },
+        { key: 'lloc', label: 'LLOC', tip: 'Logical lines of code: statement lines only.' },
+        { key: 'methods', label: 'Methods', tip: 'Number of methods in the class.' },
+        { key: 'bugs', label: 'Bugs', tip: 'Halstead delivered bugs: theoretical latent defects, useful to compare classes with each other.' },
+      ],
+
+      init() {
+        const files = (window.__AST_DATA__ || {}).files || [];
+        const out = [];
+        let id = 0;
+        for (const f of files) {
+          const classes = f?.stmts?.stmtClass || [];
+          for (const c of classes) {
+            const a = c?.stmts?.analyze || {};
+            const vol = a.volume || {};
+            const maint = a.maintainability || {};
+            const coup = a.coupling || {};
+            const coh = a.classCohesion || {};
+            const methodsRaw = c?.stmts?.stmtFunction || [];
+            const name = c?.name?.qualified || c?.name?.short || '(anonymous)';
+            out.push({
+              id: id++,
+              name: name,
+              shortName: c?.name?.short || name,
+              nameLower: name.toLowerCase(),
+              file: f.shortPath || f.path || '',
+              fileLower: (f.shortPath || f.path || '').toLowerCase(),
+              filePath: f.path || '',
+              pathHash: f.pathHash || '',
+              language: f.programmingLanguage || '',
+              isTest: !!f.isTest,
+              mi: num(maint.maintainabilityIndex),
+              miNoComments: num(maint.maintainabilityIndexWithoutComments),
+              commentWeight: num(maint.commentWeight),
+              cc: num(a.complexity?.cyclomatic),
+              lcom4: num(coh.lcom4),
+              instability: num(coup.instability),
+              ca: num(coup.afferent) ?? 0,
+              ce: num(coup.efferent) ?? 0,
+              loc: num(vol.loc),
+              lloc: num(vol.lloc),
+              cloc: num(vol.cloc),
+              hVocabulary: num(vol.halsteadVocabulary),
+              hLength: num(vol.halsteadLength),
+              hVolume: num(vol.halsteadVolume),
+              hDifficulty: num(vol.halsteadDifficulty),
+              hEffort: num(vol.halsteadEffort),
+              hTime: num(vol.halsteadTime),
+              bugs: num(vol.halsteadBugs),
+              methods: methodsRaw.length,
+              methodList: methodsRaw.map(m => ({
+                name: m?.name?.describer || m?.name?.qualified || m?.name?.short || '-',
+                cc: num(m?.stmts?.analyze?.complexity?.cyclomatic),
+              })).sort((x, y) => (y.cc ?? -1) - (x.cc ?? -1)),
+            });
+          }
+        }
+        this.rows = out;
+
+        function num(v) { return (typeof v === 'number' && !Number.isNaN(v)) ? v : null; }
+
+        // A link can ask for a given quick view, e.g. classes.html?view=cohesion
+        // from the dashboard summary.
+        try {
+          const asked = new URLSearchParams(window.location.search).get('view');
+          const preset = asked && this.presets.find(p => p.key === asked);
+          if (preset) this.applyPreset(preset);
+        } catch (e) { /* no query string support, keep the default view */ }
+
+        // Reset pagination whenever filters change
+        this.$watch('query', () => { this.page = 0; });
+        this.$watch('includeTests', () => { this.page = 0; });
+      },
+
+      // Everything the page currently talks about, search excluded
+      get scope() {
+        return this.includeTests ? this.rows : this.rows.filter(r => !r.isTest);
+      },
+
+      get filtered() {
+        const q = this.query.trim().toLowerCase();
+        let list = this.scope;
+        if (q) list = list.filter(r => r.nameLower.includes(q) || r.fileLower.includes(q));
+        const key = this.sortKey;
+        const dir = this.sortAsc ? 1 : -1;
+        return list.slice().sort((a, b) => {
+          if (key === 'name') return a.name.localeCompare(b.name) * dir;
+          const va = a[key], vb = b[key];
+          // null values always sink to the bottom, whatever the direction
+          if (va === null && vb === null) return 0;
+          if (va === null) return 1;
+          if (vb === null) return -1;
+          return (va - vb) * dir;
+        });
+      },
+
+      get paged() {
+        return this.filtered.slice(this.page * this.pageSize, (this.page + 1) * this.pageSize);
+      },
+
+      // --- verdict ---------------------------------------------------------
+      get stats() {
+        let below = 0, uncohesive = 0, split = 0, complex = 0, worst = null;
+        const list = this.scope;
+        for (const r of list) {
+          if (r.mi !== null && r.mi < 85) below++;
+          if (r.lcom4 !== null && r.lcom4 > 1) uncohesive++;
+          if (r.lcom4 !== null && r.lcom4 > 3) split++;
+          if (r.cc !== null && r.cc > 20) complex++;
+          if (r.mi !== null && (worst === null || r.mi < worst.mi)) worst = r;
+        }
+        return { total: list.length, below, uncohesive, split, complex, worst };
+      },
+
+      get verdictTitle() {
+        const s = this.stats;
+        if (s.total === 0) return 'No class to look at here.';
+        if (s.below === 0 && s.uncohesive === 0) return 'Your classes are consistently healthy.';
+        if (s.below === 0) return `${s.total} classes, and none of them is hard to maintain.`;
+        if (s.below > s.total / 2) return `Most of your ${s.total} classes are hard to maintain.`;
+        return `${s.total} classes, and ${s.below} of them carry the weight.`;
+      },
+
+      get verdictSubtitle() {
+        const s = this.stats;
+        if (s.total === 0) return 'The analyzer found no class or struct in this scope.';
+        if (s.below === 0 && s.uncohesive === 0) return 'Nothing here needs a second look.';
+        if (s.below === 0) return `${s.uncohesive} still mix unrelated responsibilities.`;
+        if (s.below > s.total / 2) {
+          const ok = s.total - s.below;
+          return `Only ${ok} ${ok === 1 ? 'sits' : 'sit'} at or above the target of 85.`;
+        }
+        return 'The rest stays inside the usual ranges.';
+      },
+
+      get verdictLead() {
+        const s = this.stats;
+        if (s.total === 0) return 'Nothing was measured: no class or struct was found in this scope.';
+        const parts = [];
+        if (s.below > 0) {
+          parts.push(`<strong>${s.below} ${s.below === 1 ? 'class is' : 'classes are'}</strong> below the maintainability target of 85`);
+        } else {
+          parts.push('every class is at or above the maintainability target of 85');
+        }
+        if (s.split > 0) {
+          parts.push(`<strong>${s.split}</strong> ${s.split === 1 ? 'mixes' : 'mix'} more than three responsibilities`);
+        } else if (s.uncohesive > 0) {
+          parts.push(`<strong>${s.uncohesive}</strong> ${s.uncohesive === 1 ? 'holds' : 'hold'} two or more unrelated groups of methods`);
+        }
+        if (s.complex > 0) {
+          parts.push(`<strong>${s.complex}</strong> ${s.complex === 1 ? 'goes' : 'go'} past 20 decision paths`);
+        }
+        let text = this.sentence(parts) + '.';
+        text = text.charAt(0).toUpperCase() + text.slice(1);
+        if (s.worst && s.worst.mi < 85) {
+          text += ` The hardest one to work with is <code class="ident">${this.esc(s.worst.shortName)}</code>, at MI <strong>${s.worst.mi.toFixed(0)}</strong>.`;
+        }
+        return text;
+      },
+
+      get detailInsight() {
+        return this.detail ? this.insightOf(this.detail) : { level: 'none', text: '' };
+      },
+
+      insightOf(r) {
+        if (r.mi === null && r.cc === null && r.lcom4 === null) {
+          return { level: 'none', text: 'No metric could be computed for this class.' };
+        }
+        const level = this.healthOf(r);
+        const parts = [];
+        if (r.mi !== null && r.mi < 85) {
+          parts.push(`<strong>MI ${r.mi.toFixed(0)}</strong> sits below the 85 target`);
+        }
+        if (r.lcom4 !== null && r.lcom4 > 1) {
+          parts.push(`<strong>${r.lcom4} unrelated groups of methods</strong> share the class`);
+        }
+        if (r.cc !== null && r.cc > 20) {
+          parts.push(`its ${r.methods} methods total <strong>${r.cc} decision paths</strong>`);
+        }
+        if (parts.length === 0) {
+          const mi = r.mi !== null ? `<strong>MI ${r.mi.toFixed(0)}</strong>` : 'No maintainability issue';
+          return { level: 'good', text: `${mi}, ${r.methods} ${r.methods === 1 ? 'method' : 'methods'}, one responsibility: this class reads as a single unit.` };
+        }
+        let text = this.sentence(parts) + '.';
+        return { level: level, text: text.charAt(0).toUpperCase() + text.slice(1) };
+      },
+
+      healthOf(r) {
+        if ((r.mi !== null && r.mi < 65) || (r.cc !== null && r.cc > 50) || (r.lcom4 !== null && r.lcom4 > 3)) return 'bad';
+        if ((r.mi !== null && r.mi < 85) || (r.cc !== null && r.cc > 20) || (r.lcom4 !== null && r.lcom4 > 1)) return 'warn';
+        return 'good';
+      },
+
+      sentence(parts) {
+        if (parts.length === 0) return '';
+        if (parts.length === 1) return parts[0];
+        return parts.slice(0, -1).join(', ') + ', and ' + parts[parts.length - 1];
+      },
+
+      esc(s) {
+        return String(s === null || s === undefined ? '' : s)
+          .replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+      },
+
+      // sorting
+      sortBy(key) {
+        if (this.sortKey === key) { this.sortAsc = !this.sortAsc; }
+        else {
+          this.sortKey = key;
+          // metrics where "high" is the interesting value default to descending
+          this.sortAsc = (key === 'name' || key === 'mi');
+        }
+        this.activePreset = null;
+        this.page = 0;
+      },
+      applyPreset(p) {
+        this.sortKey = p.sort;
+        this.sortAsc = p.asc;
+        this.activePreset = p.key;
+        this.page = 0;
+      },
+      arrow(key) { return this.sortKey === key ? (this.sortAsc ? '↑' : '↓') : ''; },
+      ariaSort(key) { return this.sortKey === key ? (this.sortAsc ? 'ascending' : 'descending') : 'none'; },
+
+      // formatting
+      fmt(v, digits) {
+        if (v === null || v === undefined) return '-';
+        return Number.isInteger(v) && digits === 0 ? String(v) : v.toFixed(digits);
+      },
+      fmtBig(v) {
+        if (v === null || v === undefined) return '-';
+        if (v >= 1e6) return (v / 1e6).toFixed(1) + ' M';
+        if (v >= 1e3) return (v / 1e3).toFixed(1) + ' K';
+        return v.toFixed(v < 10 ? 1 : 0);
+      },
+      fmtTime(seconds) {
+        if (seconds === null || seconds === undefined) return '-';
+        if (seconds < 60) return seconds.toFixed(0) + ' s';
+        if (seconds < 3600) return (seconds / 60).toFixed(0) + ' min';
+        if (seconds < 86400) return (seconds / 3600).toFixed(1) + ' h';
+        return (seconds / 86400).toFixed(1) + ' d';
+      },
+
+      // levels: 'good' | 'warn' | 'high' | 'bad' | 'none'
+      miLevel(v) { if (v === null) return 'none'; if (v >= 85) return 'good'; if (v >= 65) return 'warn'; return 'bad'; },
+      ccClassLevel(v) { if (v === null) return 'none'; if (v <= 10) return 'good'; if (v <= 20) return 'warn'; if (v <= 50) return 'high'; return 'bad'; },
+      ccMethodLevel(v) { if (v === null) return 'none'; if (v <= 5) return 'good'; if (v <= 10) return 'warn'; if (v <= 20) return 'high'; return 'bad'; },
+      lcomLevel(v) { if (v === null || v === 0) return 'none'; if (v <= 1) return 'good'; if (v <= 2) return 'warn'; if (v <= 3) return 'high'; return 'bad'; },
+
+      // the shared design system knows three severities: good, warn, bad
+      dotLevel(level) { return level === 'high' ? 'bad' : level; },
+
+      miJudgment(v) {
+        if (v === null) return 'No maintainability data for this class.';
+        if (v >= 85) return `MI ${v.toFixed(0)}: comfortably maintainable (target is 85 or more).`;
+        if (v >= 65) return `MI ${v.toFixed(0)}: below the 85 target, keep an eye on it.`;
+        return `MI ${v.toFixed(0)}: below 65, this class is a refactoring candidate.`;
+      },
+      ccJudgment(v) {
+        if (v === null) return 'No complexity data for this class.';
+        if (v <= 10) return `Cyclomatic ${v}: simple, easy to test.`;
+        if (v <= 20) return `Cyclomatic ${v}: moderate; consider extracting logic.`;
+        if (v <= 50) return `Cyclomatic ${v}: complex; testing every path is getting hard.`;
+        return `Cyclomatic ${v}: very complex; this class probably has too many responsibilities.`;
+      },
+      lcomJudgment(v) {
+        if (v === null || v === 0) return 'No cohesion data (class without measurable methods).';
+        if (v <= 1) return 'LCOM4 1: cohesive, the class forms a single unit.';
+        if (v <= 2) return `LCOM4 ${v}: two unrelated groups of methods; the class may hide two concepts.`;
+        return `LCOM4 ${v}: ${v} unrelated groups of methods; strong sign the class should be split.`;
+      },
+
+      badgeClass(level) {
+        return {
+          good: 'bg-green-100 text-green-700',
+          warn: 'bg-amber-100 text-amber-700',
+          high: 'bg-orange-100 text-orange-700',
+          bad: 'bg-rose-100 text-rose-700',
+          none: 'bg-slate-100 text-slate-500',
+        }[level] || 'bg-slate-100 text-slate-500';
+      },
+      textClass(level) {
+        return {
+          good: 'text-good',
+          warn: 'text-warn',
+          high: 'text-warn',
+          bad: 'text-bad',
+          none: 'text-none',
+        }[level] || 'text-none';
+      },
+
+      openDetail(r) { this.detail = r; },
+    }
+  }
+</script>
+{% endblock %}

--- a/internal/report/templates/html/classes.html
+++ b/internal/report/templates/html/classes.html
@@ -89,7 +89,7 @@ AST Metrics - Classes
   <div class="flex flex-wrap items-center gap-x-4 gap-y-3 mb-5">
     <div class="relative min-w-[220px] flex-1 max-w-sm">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
-        class="w-4 h-4 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2">
+        class="w-4 h-4 text-gray-500 absolute left-3 top-1/2 -translate-y-1/2">
         <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
       </svg>
       <input type="search" x-model.debounce.200ms="query" placeholder="Search a class or a file..."
@@ -109,7 +109,7 @@ AST Metrics - Classes
       <input type="checkbox" x-model="includeTests" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
       Include test classes
     </label>
-    <span class="text-xs text-gray-400 ml-auto" x-text="filtered.length + ' shown'"></span>
+    <span class="text-xs text-gray-500 ml-auto" x-text="filtered.length + ' shown'"></span>
   </div>
 
   <!-- Table -->
@@ -152,7 +152,7 @@ AST Metrics - Classes
                   <span x-text="r.shortName"></span>
                   <span x-show="r.isTest" class="px-1.5 py-0.5 rounded bg-violet-50 text-violet-600 text-[10px] font-medium uppercase">test</span>
                 </div>
-                <div class="text-xs text-gray-400 truncate max-w-[320px]" x-text="r.file" :title="r.filePath"></div>
+                <div class="text-xs text-gray-500 truncate max-w-[320px]" x-text="r.file" :title="r.filePath"></div>
               </td>
               <td class="px-3 py-3 text-right"><span :class="badgeClass(miLevel(r.mi))" class="px-2 py-1 rounded-md text-xs font-medium inline-flex items-center gap-1"
                 :data-tip="miJudgment(r.mi)" tabindex="0"><span x-text="fmt(r.mi, 0)"></span></span></td>
@@ -208,7 +208,7 @@ AST Metrics - Classes
                 </p>
               </div>
               <button @click="detail = null" aria-label="Close details"
-                class="shrink-0 text-gray-400 hover:text-gray-600 p-1 rounded-lg hover:bg-gray-100 transition-colors">
+                class="shrink-0 text-gray-500 hover:text-gray-600 p-1 rounded-lg hover:bg-gray-100 transition-colors">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
                 </svg>

--- a/internal/report/templates/html/classification.html
+++ b/internal/report/templates/html/classification.html
@@ -22,39 +22,6 @@
         font-family: var(--font-family);
     }
 
-    .dashboard-card {
-        background: var(--card-bg);
-        border: 1px solid var(--border-color);
-        border-radius: 24px;
-        padding: 2rem;
-        margin-bottom: 2rem;
-        transition: box-shadow 0.2s cubic-bezier(0.2, 0, 0, 1);
-    }
-
-    .dashboard-card:hover {
-        box-shadow: var(--card-shadow);
-        border-color: transparent;
-    }
-
-    .hero-title {
-        font-family: 'Google Sans Display', sans-serif;
-        font-size: 2.25rem;
-        font-weight: 400;
-        color: var(--text-primary);
-        margin-bottom: 1rem;
-        letter-spacing: -0.5px;
-    }
-
-    .hero-subtitle {
-        font-size: 1.125rem;
-        color: var(--text-secondary);
-        max-width: 800px;
-        line-height: 1.6;
-        margin-bottom: 3rem;
-    }
-    /* Modal removed */
-
-
     .steps-container {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
@@ -513,35 +480,19 @@
         to { opacity: 1; transform: translateY(0); }
     }
 
-    /* Tab Navigation */
-    .architecture-tabs {
-        display: flex;
-        gap: 0;
-        margin-bottom: 1.5rem;
-        border-bottom: 2px solid #e2e8f0;
-    }
-
+    /* View switcher: a segmented control whose active state the JS toggles */
     .architecture-tab {
-        padding: 0.75rem 1.5rem;
-        font-size: 0.875rem;
-        font-weight: 500;
-        color: #64748b;
         background: none;
         border: none;
-        border-bottom: 2px solid transparent;
-        margin-bottom: -2px;
         cursor: pointer;
-        transition: all 0.2s;
-        font-family: var(--font-family);
-    }
-
-    .architecture-tab:hover {
-        color: #1e293b;
+        font-family: inherit;
     }
 
     .architecture-tab.active {
-        color: #3b82f6;
-        border-bottom-color: #3b82f6;
+        background: white;
+        color: #0f172a;
+        font-weight: 600;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
     }
 
     /* Overview Diagram */
@@ -555,10 +506,13 @@
     {% set filteredPredictions = projectAggregated.Predictions|filterTestFiles:files %}
     
     {% if filteredPredictions|length == 0 %}
-    <div class="empty-state">
-        <p class="empty-state-title">No predictions found</p>
-        <p class="empty-state-text">
-            The language is probably not yet supported. Feel free to contribute to the project by adding a new classifier model.
+    <div class="page-hero animate-fade-in-up">
+        <p class="page-kicker mb-3">Architecture &middot; roles inferred from the code</p>
+        <h1 class="verdict-title">No role could be inferred here.</h1>
+        <p class="verdict-lead mt-4">
+            This view needs a classifier model for the language being analyzed, and none is available yet.
+            Contributions are welcome: adding a model is enough to light this page up.
+            <a href="https://github.com/Halleck45/ast-metrics/" class="text-blue-600 hover:underline font-medium">See the project on GitHub</a>.
         </p>
     </div>
     {% else %}
@@ -572,21 +526,40 @@
 
 
 
-    <!-- Hero Section -->
-<div class="mb-8 animate-fade-in-up">
-    <h1 class="text-4xl font-bold text-gray-900 mb-3" style="letter-spacing: -0.02em;">Architecture Map</h1>
-    <p class="text-base text-gray-600 font-light">
-        Visualize your codebase through its architectural roles. This map highlights structure, dependencies, and imbalances across layers.
-    </p>
-    <p class="mt-2 text-base text-gray-600 font-bold">
-        Categories are statistically determined and may not always be accurate. Only the trends are important.
-    </p>
+    <!-- Verdict -->
+<div class="page-hero animate-fade-in-up mb-6">
+    <div class="flex flex-wrap items-start justify-between gap-8">
+        <div class="min-w-0">
+            <p class="page-kicker mb-3">Architecture &middot; roles inferred from the code</p>
+            <h1 class="verdict-title max-w-3xl">
+                {{ totalComponents }} components, sorted by the role they play.
+                <span class="verdict-muted block">Read the shape, not the labels.</span>
+            </h1>
+            <p class="verdict-lead mt-4">
+                Each class is assigned a role from how it is written and what it depends on. The roles are
+                inferred statistically, so an individual label can be wrong: what matters is the balance
+                between layers, and the dependencies that cross them the wrong way.
+            </p>
+        </div>
+        <div class="kpi-strip kpi-strip--divided shrink-0">
+            <div>
+                <div class="kpi-value">{{ totalComponents }}</div>
+                <div class="kpi-label">components<br>classified</div>
+            </div>
+            <div>
+                <div class="kpi-value">{{ groupedByFamily|length }}</div>
+                <div class="kpi-label">architectural<br>families</div>
+            </div>
+        </div>
+    </div>
 </div>
 
-<!-- Tab Navigation -->
-<div class="architecture-tabs">
-    <button class="architecture-tab active" data-tab="overview" onclick="switchTab('overview')">Overview</button>
-    <button class="architecture-tab" data-tab="details" onclick="switchTab('details')">Details by class</button>
+<!-- View switcher -->
+<div class="flex justify-center mb-6">
+    <div class="seg" role="tablist" aria-label="Architecture view">
+        <button role="tab" class="architecture-tab seg-item active" data-tab="overview" onclick="switchTab('overview')">Overview</button>
+        <button role="tab" class="architecture-tab seg-item" data-tab="details" onclick="switchTab('details')">Details by class</button>
+    </div>
 </div>
 
 <!-- Overview Tab -->

--- a/internal/report/templates/html/communities.html
+++ b/internal/report/templates/html/communities.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block pageTitle %}Communities - {{ currentLanguage }}{% endblock %}
+{% block pageTitle %}Communities - {{ scopeLabel }}{% endblock %}
 {% block content %}
 
 <style>
@@ -50,39 +50,7 @@
 {% else %}
 
 
-<!-- start: language tabs-->
-<div class="flex overflow-x-auto overflow-y-hidden border-b border-gray-200 whitespace-nowrap ">
-
-    <a
-            href="communities.html"
-            class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center {% if currentLanguage == "All" %}text-blue-600 border-blue-500{% endif %} bg-transparent border-b-2 sm:px-4 -px-1 focus:outline-none">
-    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-    </svg>
-
-    <span class="mx-1 text-sm sm:text-base">
-                All languages <span class="text-xs sm:text-sm">({{ projectAggregated.Combined.ConcernedFiles|length }} files)</span>
-            </span>
-    </a>
-
-    <!-- start: language tab -->
-    {% for languageName, lang in projectAggregated.ByProgrammingLanguage %}
-    <a
-            href="communities_{{ languageName|langSlug }}.html"
-            class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center bg-transparent border-b-2 {% if currentLanguage == languageName %}text-blue-600 border-blue-500{% else %}text-gray-700   border-transparent{% endif %} sm:px-4 -px-1 hover:border-gray-400">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-        </svg>
-
-        <span class="mx-1 text-sm sm:text-base">
-                    {{ languageName }} <span class="text-xs sm:text-sm">({{ lang.ConcernedFiles|length }} files)</span>
-                </span>
-    </a>
-    {% endfor %}
-    <!-- end: language tab -->
-
-</div>
-<!-- end: language tabs-->
+{% include "partials/language_tabs.html" with pageBase="communities" %}
 
 
 <div class="dashboard-card p-6 mb-8 mt-8 animate-fade-in-up">
@@ -145,11 +113,50 @@
     /* Architecture tabs */
     .arch-tab { border-bottom: 2px solid transparent; transition: all 0.15s ease; }
     .arch-tab:hover { color: #1f2937; border-color: #d1d5db; }
-    .arch-tab.active { color: #2563eb; border-color: #2563eb; font-weight: 500; }
+    /* The view switcher is a segmented control; the JS toggles `active`. */
+    .arch-tab.active {
+        background: white;
+        color: #0f172a;
+        font-weight: 600;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    }
     .arch-panel { display: none; }
     .arch-panel.active { display: block; }
 </style>
 
+
+<!-- Verdict -->
+<div class="page-hero animate-fade-in-up mb-6">
+    <p class="page-kicker mb-3">Communities &middot; detected from the dependency graph</p>
+    <h1 class="verdict-title max-w-4xl">
+        <span id="metric-verdict-main">{% if cm.MaxSize <= 1 %}Your code shows no natural grouping.{% else %}Your code splits into {{ cm.CommunitiesCount }} natural group{{ cm.CommunitiesCount|pluralize }}.{% endif %}</span>
+        <span class="verdict-muted block" id="metric-verdict-note">{% if cm.MaxSize <= 1 %}Every namespace stands on its own: the dependency graph is too sparse to reveal modules.{% else %}The largest one holds {{ cm.MaxSize }} node{{ cm.MaxSize|pluralize }}.{% endif %}</span>
+    </h1>
+    <p class="verdict-lead mt-4">
+        A community is a set of namespaces that depend on each other more than on the rest of the code.
+        They are computed from the graph, not from folder names, so they show the architecture as it
+        actually is. <strong id="metric-boundary-count">{{ cm.BoundaryNodes|length }}</strong> nodes sit on
+        a boundary between two groups.
+    </p>
+    <div class="kpi-strip kpi-strip--divided mt-8">
+        <div>
+            <div class="kpi-value" id="metric-avg-size">{{ cm.AvgSize|floatformat:1 }}</div>
+            <div class="kpi-label">nodes per group<br>on average</div>
+        </div>
+        <div>
+            <div class="kpi-value" id="metric-density">{{ cm.GraphDensity|floatformat:3 }}</div>
+            <div class="kpi-label">graph density
+                <span tabindex="0" data-tip="Share of the possible dependencies that actually exist. Low means a sparse, loosely connected graph." class="text-slate-300">&#9432;</span>
+            </div>
+        </div>
+        <div>
+            <div class="kpi-value" id="metric-modularity">{{ cm.ModularityQ|floatformat:2 }}</div>
+            <div class="kpi-label">separation quality
+                <span tabindex="0" data-tip="Modularity Q, from 0 to 1. Higher means the groups are cleanly separated from each other." class="text-slate-300">&#9432;</span>
+            </div>
+        </div>
+    </div>
+</div>
 
 <!-- Community detection settings -->
 <div class="flex flex-wrap items-center gap-8 mb-4 px-1">
@@ -220,19 +227,15 @@
         </div>
     </div>
     <style>@keyframes spin { to { transform: rotate(360deg); } }</style>
-    <div class="flex items-center justify-between mb-4">
-        <h2 class="leading-none text-3xl font-bold text-gray-900 pb-2">Architecture</h2>
-        <div id="arch-export" class="text-sm text-gray-600">
-            <button id="export-clustered" class="px-2 py-1 border rounded mr-1">Export PNG</button>
+    <div class="flex flex-wrap items-center justify-between gap-3 mb-5">
+        <div class="seg" role="tablist" aria-label="Community view">
+            <button role="tab" class="arch-tab seg-item active" data-arch-tab="clustered">Clusters</button>
+            <button role="tab" class="arch-tab seg-item" data-arch-tab="graph">Graph</button>
+            <button role="tab" class="arch-tab seg-item" data-arch-tab="layered">Layers</button>
+            <button role="tab" class="arch-tab seg-item" data-arch-tab="sankey">Flows</button>
+            <button role="tab" class="arch-tab seg-item" data-arch-tab="purity">Purity</button>
         </div>
-    </div>
-    <!-- Tab bar -->
-    <div class="flex border-b border-gray-200 mb-4 gap-1">
-        <button class="arch-tab active px-4 py-2 text-sm text-gray-600" data-arch-tab="clustered">Clustered Dependencies</button>
-        <button class="arch-tab px-4 py-2 text-sm text-gray-600" data-arch-tab="graph">Graph</button>
-        <button class="arch-tab px-4 py-2 text-sm text-gray-600" data-arch-tab="layered">Layered Map</button>
-        <button class="arch-tab px-4 py-2 text-sm text-gray-600" data-arch-tab="sankey">Sankey</button>
-        <button class="arch-tab px-4 py-2 text-sm text-gray-600" data-arch-tab="purity">Purity</button>
+        <button id="export-clustered" class="text-sm text-gray-500 hover:text-gray-900 px-3 py-1.5 rounded-full hover:bg-slate-100 transition-colors">Export PNG</button>
     </div>
     <!-- Tab panels -->
     <div id="arch-panel-graph" class="arch-panel">
@@ -393,35 +396,6 @@
 
 
 {% include "partials/suggestions.html" with suggestions=currentView.Suggestions subtitle="Automatically inferred from coupling, purity and boundary nodes" emptyText="No suggestions — the architecture looks healthy based on current heuristics." %}
-
-<!-- Metrics (summary cards) -->
-<div class="grid grid-cols-5 gap-4 mb-8 mt-8">
-    <div class="dashboard-card p-5">
-        <div class="leading-none text-3xl font-bold text-gray-900 pb-2" id="metric-comm-count">{{ cm.CommunitiesCount }}</div>
-        <div class="text-base font-normal text-gray-500 ">Number of detected communities (modules)</div>
-        <div class="mt-2 text-xs text-gray-500">communities_count</div>
-    </div>
-    <div class="dashboard-card p-5">
-        <div class="leading-none text-3xl font-bold text-gray-900 pb-2" id="metric-modularity">{{ cm.ModularityQ|floatformat:2 }}</div>
-        <div class="text-base font-normal text-gray-500">Community separation quality (0–1)</div>
-        <div class="mt-2 text-xs text-gray-500">modularity_q</div>
-    </div>
-    <div class="dashboard-card p-5">
-        <div class="leading-none text-3xl font-bold text-gray-900 pb-2" id="metric-avg-size">{{ cm.AvgSize|floatformat:1 }}</div>
-        <div class="text-base font-normal text-gray-500">Average number of nodes per community</div>
-        <div class="mt-2 text-xs text-gray-500">avg_size</div>
-    </div>
-    <div class="dashboard-card p-5">
-        <div class="leading-none text-3xl font-bold text-gray-900 pb-2" id="metric-max-size">{{ cm.MaxSize }}</div>
-        <div class="text-base font-normal text-gray-500">Largest community size (nodes)</div>
-        <div class="mt-2 text-xs text-gray-500">max_size</div>
-    </div>
-    <div class="dashboard-card p-5">
-        <div class="leading-none text-3xl font-bold text-gray-900 pb-2" id="metric-density">{{ cm.GraphDensity|floatformat:3 }}</div>
-        <div class="text-base font-normal text-gray-500">Edge density of the dependency graph</div>
-        <div class="mt-2 text-xs text-gray-500">graph_density</div>
-    </div>
-</div>
 
 <!-- ============================================================ -->
 <!-- JS Community Engine: computes communities client-side for     -->
@@ -976,10 +950,24 @@
 
     function updateMetricCards(cm) {
         var el;
-        el = document.getElementById('metric-comm-count'); if (el) el.textContent = cm.communitiesCount;
         el = document.getElementById('metric-modularity'); if (el) el.textContent = cm.modularityQ.toFixed(2);
         el = document.getElementById('metric-avg-size'); if (el) el.textContent = cm.avgSize.toFixed(1);
-        el = document.getElementById('metric-max-size'); if (el) el.textContent = cm.maxSize;
+
+        // Recompose the verdict sentence: a graph where no group grows past one
+        // node has not revealed any module, and should say so.
+        var plural = function(n) { return n === 1 ? '' : 's'; };
+        el = document.getElementById('metric-verdict-main');
+        if (el) {
+            el.textContent = cm.maxSize <= 1
+                ? 'Your code shows no natural grouping.'
+                : 'Your code splits into ' + cm.communitiesCount + ' natural group' + plural(cm.communitiesCount) + '.';
+        }
+        el = document.getElementById('metric-verdict-note');
+        if (el) {
+            el.textContent = cm.maxSize <= 1
+                ? 'Every namespace stands on its own: the dependency graph is too sparse to reveal modules.'
+                : 'The largest one holds ' + cm.maxSize + ' node' + plural(cm.maxSize) + '.';
+        }
         el = document.getElementById('metric-density'); if (el) el.textContent = cm.graphDensity.toFixed(3);
     }
 
@@ -1477,12 +1465,12 @@
                 }
 
                 var cats = [
-                    { key: 'coupling', label: 'Coupling', color: 'amber', icon: '<path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m9.86-2.54 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"/>',
-                      explanation: 'This community depends on many others. Introduce a facade or API boundary to reduce direct dependencies and stabilize interactions.' },
-                    { key: 'purity', label: 'Purity', color: 'blue', icon: '<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z"/>',
-                      explanation: 'This community aggregates several concerns. Consider splitting it into smaller, cohesive modules aligned by domain or namespace.' },
-                    { key: 'boundary', label: 'Boundary', color: 'purple', icon: '<path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"/>',
-                      explanation: 'These nodes connect multiple communities. Consider introducing anti-corruption layers or clarifying ownership to reduce boundary crossings.' }
+                    { key: 'coupling', label: 'Reaching outward', color: 'amber', icon: '<path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m9.86-2.54 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"/>',
+                      explanation: 'Most of what these groups depend on lives outside them, so a change elsewhere reaches them.' },
+                    { key: 'purity', label: 'Mixed concerns', color: 'blue', icon: '<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z"/>',
+                      explanation: 'These groups are large and hold namespaces that have little to do with each other.' },
+                    { key: 'boundary', label: 'On the boundary', color: 'purple', icon: '<path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"/>',
+                      explanation: 'These nodes sit between several groups, and traffic between groups goes through them.' }
                 ];
 
                 cats.forEach(function(cat) {

--- a/internal/report/templates/html/compare.html
+++ b/internal/report/templates/html/compare.html
@@ -1,140 +1,87 @@
 {% extends "layout.html" %}
 
 {% block title %}
-    Compare
+Compare
 {% endblock %}
 
 {% block pageTitle %}
-    AST Metrics - Overview
+AST Metrics - Compare
 {% endblock %}
 
 {% block content %}
 
-    <!-- start: language tabs-->
-    <div class="flex overflow-x-auto overflow-y-hidden border-b border-gray-200 whitespace-nowrap ">
+{% set cmp = currentView.Comparaison %}
 
-        <a 
-            href="compare.html"
-            class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center {% if currentLanguage == "All" %}text-blue-600 border-blue-500{% endif %} bg-transparent border-b-2 sm:px-4 -px-1 focus:outline-none">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-            </svg>
+{% if not cmp %}
+<div class="page-hero animate-fade-in-up">
+    <p class="page-kicker mb-3">Comparison</p>
+    <h1 class="verdict-title">No branch to compare with.</h1>
+    <p class="verdict-lead mt-4">
+        Run the analysis with <code class="ident">--compare-with &lt;branch&gt;</code> to see how the metrics
+        moved between two states of the code.
+    </p>
+</div>
+{% else %}
 
-            <span class="mx-1 text-sm sm:text-base">
-                All languages <span class="text-xs sm:text-sm">({{ projectAggregated.Combined.ConcernedFiles|length }} files)</span>
-            </span>
-        </a>
+{% include "partials/language_tabs.html" with pageBase="compare" %}
 
-        <!-- start: language tab -->
-            {% for languageName, lang in projectAggregated.ByProgrammingLanguage %}
-            <a 
-                href="compare_{{ languageName|langSlug }}.html"
-                class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center bg-transparent border-b-2 {% if currentLanguage == languageName %}text-blue-600 border-blue-500{% else %}text-gray-700   border-transparent{% endif %} sm:px-4 -px-1 hover:border-gray-400">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-                </svg>
-    
-                <span class="mx-1 text-sm sm:text-base">
-                    {{ languageName }} <span class="text-xs sm:text-sm">({{ lang.ConcernedFiles|length }} files)
+<!-- Verdict -->
+<div class="page-hero animate-fade-in-up mb-6">
+    <div class="flex flex-wrap items-start justify-between gap-8">
+        <div class="min-w-0">
+            <p class="page-kicker mb-3">Compared with {{ cmp.ComparedBranch }}</p>
+            <h1 class="verdict-title max-w-3xl">
+                {% if cmp.NbModifiedFiles > 0 %}
+                {{ cmp.NbModifiedFiles|stringifyNumber }} file{% if cmp.NbModifiedFiles > 1 %}s{% endif %} changed
+                in a way that moves the metrics.
+                {% else %}
+                Nothing changed enough to move the metrics.
+                {% endif %}
+                <span class="verdict-muted block">
+                    {% if cmp.Loc > 0 %}The codebase grew by {{ cmp.Loc|stringifyNumber }} lines.{% elif cmp.Loc < 0 %}The codebase shrank.{% else %}Its size is unchanged.{% endif %}
                 </span>
-            </a>
-            {% endfor %}
-        <!-- end: language tab -->
-
+            </h1>
+            <p class="verdict-lead mt-4">
+                Only significant changes are listed: files whose metrics actually differ from
+                <strong>{{ cmp.ComparedBranch }}</strong>.
+                {% if cmp.NbModifiedFilesIncludingNegligible > 0 %}
+                {{ cmp.NbModifiedFilesIncludingNegligible|stringifyNumber }} other files were touched without
+                any measurable effect.
+                {% endif %}
+            </p>
+        </div>
+        <div class="kpi-strip kpi-strip--divided shrink-0">
+            <div>
+                <div class="kpi-value">
+                    {% include "componentComparaisonOperator.html" with diff=cmp.Loc %}{{ cmp.Loc|stringifyNumber }}
+                </div>
+                <div class="kpi-label">lines of code</div>
+            </div>
+            <div>
+                <div class="kpi-value">{{ cmp.NbNewFiles|stringifyNumber }}</div>
+                <div class="kpi-label">new files</div>
+            </div>
+            <div>
+                <div class="kpi-value">{{ cmp.NbClasses|stringifyNumber }}</div>
+                <div class="kpi-label">new classes</div>
+            </div>
+            <div>
+                <div class="kpi-value">{{ cmp.NbMethods|stringifyNumber }}</div>
+                <div class="kpi-label">new methods</div>
+            </div>
+        </div>
     </div>
-    <!-- end: language tabs-->
+</div>
 
-    <!-- start: line of 4 cards -->
-    <div class="grid grid-cols-4 gap-4 mt-4">
-
-        <!-- start: card -->
-        <div class="max-w-2xl px-8 py-4 bg-white rounded-lg shadow-md ">
-            <div class="mt-2">
-                <div>
-                    <h5 class="leading-none text-3xl font-bold text-gray-900 pb-2">
-                        {% include "componentComparaisonOperator.html" with diff=currentView.Comparaison.Loc %}
-                        {{ currentView.Comparaison.Loc|stringifyNumber }}
-                    </h5>
-                    <p class="text-base font-normal text-gray-500 ">
-                        Lines of code
-                    </p>
-                </div>
-            </div>
-        </div>
-        <!-- end: card -->
-
-        <!-- start: card -->
-        <div class="max-w-2xl px-8 py-4 bg-white rounded-lg shadow-md ">
-            <div class="mt-2">
-                <div>
-                    <h5 class="leading-none text-3xl font-bold text-gray-900 pb-2">
-                        {{ currentView.Comparaison.NbModifiedFiles|stringifyNumber }}
-                    </h5>
-                    <p class="text-base font-normal text-gray-500 ">
-                        Modified files
-                    </p>
-                    <p class="border-t border-gray-200 mt-2 italic text-sm text-gray-600 pt-4 text-justify">
-                        {% if currentView.Comparaison.NbModifiedFilesIncludingNegligible + currentView.Comparaison.NbModifiedFiles != currentView.Comparaison.NbModifiedFiles %}
-                        {{ currentView.Comparaison.NbModifiedFilesIncludingNegligible + currentView.Comparaison.NbModifiedFiles|stringifyNumber }} modifications in commits, 
-                        but only {{ currentView.Comparaison.NbModifiedFiles|stringifyNumber }} are significant.
-                        {% endif %}
-                        {{ currentView.Comparaison.NbNewFiles|stringifyNumber }} new files.
-                    </p>
-                </div>
-            </div>
-        </div>
-        <!-- end: card -->
-
-        <!-- start: card -->
-        <div class="max-w-2xl px-8 py-4 bg-white rounded-lg shadow-md ">
-            <div class="mt-2">
-                <div>
-                    <h5 class="leading-none text-3xl font-bold text-gray-900 pb-2">
-                        {{ currentView.Comparaison.NbClasses|stringifyNumber }}
-                    </h5>
-                    <p class="text-base font-normal text-gray-500 ">
-                        New classes
-                    </p>
-                </div>
-            </div>
-        </div>
-        <!-- end: card -->
-
-        <!-- start: card -->
-        <div class="max-w-2xl px-8 py-4 bg-white rounded-lg shadow-md ">
-            <div class="mt-2">
-                <div>
-                    <h5 class="leading-none text-3xl font-bold text-gray-900 pb-2">
-                        {{ currentView.Comparaison.NbMethods|stringifyNumber }}
-                    </h5>
-                    <p class="text-base font-normal text-gray-500 ">
-                        New methods
-                    </p>
-                </div>
-            </div>
-        </div>
-        <!-- end: card -->
+<!-- Per-file changes -->
+<div class="soft-card animate-fade-in-up stagger-1">
+    <div class="mb-4">
+        <h2 class="card-title">What moved, file by file</h2>
+        <p class="card-sub">Each row shows the metric before and after. Click a column header to sort.</p>
     </div>
+    {% include "componentTableCompareBranch.html" with detailled=true linesToDisplay=100 %}
+</div>
 
-    <!-- start: line of 1 cards -->
-    <div class="grid grid-cols-1 gap-4 mt-4">
+{% endif %}
 
-        <!-- start: card -->
-        <div class="w-full px-8 py-4 bg-white rounded-lg shadow-md ">
-            <div class="mt-2">
-                <div>
-                    <h5 class="leading-none text-3xl font-bold text-gray-900 pb-2">
-                        Comparing with 
-                        <code class="bg-gray-100 text-gray-800 px-2 py-1 rounded">{{ currentView.Comparaison.ComparedBranch }}</code>
-                    </h5>
-                </div>
-                <div class="mt-4">
-                    {% include "componentTableCompareBranch.html" with detailled=true linesToDisplay=100 %}
-                </div>
-            </div>
-        </div>
-        <!-- end: card -->
-    </div>
-    <!-- end: line of 1 cards -->
-    
 {% endblock %}

--- a/internal/report/templates/html/componentBubbleChart.html
+++ b/internal/report/templates/html/componentBubbleChart.html
@@ -30,7 +30,7 @@
                 <div style="position:absolute;bottom:25%;left:30%;width:22%;height:22%;border-radius:50%;background:#e2e8f0;animation:bubble-pulse 1.5s ease-in-out 0.4s infinite;"></div>
                 <div style="position:absolute;bottom:30%;right:20%;width:14%;height:14%;border-radius:50%;background:#e2e8f0;animation:bubble-pulse 1.5s ease-in-out 0.6s infinite;"></div>
             </div>
-            <p class="mt-4 text-sm text-gray-400 font-medium">Computing layout...</p>
+            <p class="mt-4 text-sm text-gray-500 font-medium">Computing layout...</p>
         </div>
         <style>
             @keyframes bubble-spin { to { transform: rotate(360deg); } }
@@ -58,7 +58,7 @@
         <div class="flex items-center gap-2">
             <span>Size = Lines of code</span>
         </div>
-        <div class="flex items-center gap-2 text-gray-400">
+        <div class="flex items-center gap-2 text-gray-500">
             <span>Test files are excluded</span>
         </div>
     </div>

--- a/internal/report/templates/html/componentBubbleChart.html
+++ b/internal/report/templates/html/componentBubbleChart.html
@@ -58,6 +58,9 @@
         <div class="flex items-center gap-2">
             <span>Size = Lines of code</span>
         </div>
+        <div class="flex items-center gap-2 text-gray-400">
+            <span>Test files are excluded</span>
+        </div>
     </div>
 </div>
 
@@ -68,14 +71,16 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!window.PIXI) return;
 
         var _d = window.__AST_DATA__ || {};
-        var filesRaw = _d.files || [];
+        // Test files are not production code: exclude them from the chart
+        // (protojson only emits isTest when it is true)
+        var filesRaw = (_d.files || []).filter(function(f) { return f && !f.isTest; });
         if (!filesRaw.length) return;
 
         var n2c = _d.nodeToCommunity || {};
 
-        var explorerUrl = 'explorer.html';
+        var explorerUrl = 'explorer{{ scopeSuffix }}.html';
         try {
-            explorerUrl = JSON.parse(document.getElementById('bubble-explorer-url').textContent || '"explorer.html"');
+            explorerUrl = JSON.parse(document.getElementById('bubble-explorer-url').textContent || '"explorer{{ scopeSuffix }}.html"');
         } catch(e) {}
 
         // Find common prefix to strip from absolute paths

--- a/internal/report/templates/html/componentTableRisks.html
+++ b/internal/report/templates/html/componentTableRisks.html
@@ -3,39 +3,33 @@
         <thead>
             <tr class="border-b border-gray-200">
                 {% if detailled == true %}
-                    <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-left">Lang.</th>
+                    <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-left">Language</th>
                 {% endif %}
                 <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-left">Component</th>
                 {% if detailled == true %}
-                    <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
-                        <acronym title="Cyclomatic complexity is the number of decision points in a program" class="cursor-help">
-                            Cyclomatic
-                        </acronym>
+                    <th scope="col" title="Cyclomatic complexity: the number of branches the component can take."
+                        class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
+                        Decision points
                     </th>
-                    <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
-                        <acronym title="Halstead effort is calculated as the average effort required to implement a software programe." class="cursor-help">
-                            Effort
-                        </acronym>
+                    <th scope="col" title="Halstead effort: an estimate of the mental effort needed to write the component, computed from its operators and operands."
+                        class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
+                        Halstead effort
                     </th>
-                    <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
-                        <acronym title="Lines of code (LOC)" class="cursor-help">
-                            LOC
-                        </acronym>
+                    <th scope="col" title="Lines of code (LOC), comments and blank lines included."
+                        class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
+                        Lines
                     </th>
-                    <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
-                        <acronym title="Efferent coupling: number of external dependencies" class="cursor-help">
-                            C<sub>e</sub>
-                        </acronym>
+                    <th scope="col" title="Efferent coupling (Ce): how many other components this one uses."
+                        class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
+                        Depends on
                     </th>
-                    <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
-                        <acronym title="Afferent coupling: number of times the component is used by other components" class="cursor-help">
-                            C<sub>a</sub>
-                        </acronym>
+                    <th scope="col" title="Afferent coupling (Ca): how many other components use this one."
+                        class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
+                        Used by
                     </th>
-                    <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
-                        <acronym title="0 (stable) to 1 (unstable) - The ratio of efferent coupling (Ce) to total coupling (Ce + Ca)" class="cursor-help">
-                            Instability
-                        </acronym>
+                    <th scope="col" title="Instability: Ce / (Ce + Ca). 0 means nothing here points outside, 1 means everything does."
+                        class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-right">
+                        Instability
                     </th>
                 {% endif %}
             </tr>
@@ -45,13 +39,11 @@
             {% if entries|length == 0 %}
             <tr>
                 <td class="px-4 py-12 text-center" colspan="{% if detailled == true %}8{% else %}1{% endif %}">
-                    <div class="empty-state">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 text-green-300 mx-auto mb-3">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-4.902Z" />
-                        </svg>
-                        <p class="text-sm font-medium text-gray-500">No high-risk components found</p>
-                        <p class="text-xs text-gray-500 mt-1">Your codebase looks healthy!</p>
-                    </div>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 text-green-300 mx-auto mb-3">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-4.902Z" />
+                    </svg>
+                    <p class="text-sm font-medium text-gray-500">Nothing to list here</p>
+                    <p class="text-xs text-gray-500 mt-1">No component was measured in this scope.</p>
                 </td>
             </tr>
             {% endif %}
@@ -60,7 +52,7 @@
                 {% set file = e.File %}
                 {% set class = e.Class %}
                 {% set name = e.Name %}
-                <tr class="table-row">
+                <tr class="hover:bg-slate-50 transition-colors">
                     {% if detailled == true %}
                         <td class="px-4 py-3 whitespace-nowrap">
                             <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-gray-100 text-gray-700">
@@ -70,9 +62,9 @@
                     {% endif %}
                     <td class="px-4 py-3">
                         <div class="max-w-md">
-                            <acronym title="{{ name }}" class="text-sm font-semibold text-gray-900 cursor-help hover:text-blue-600 transition-colors">
+                            <span title="{{ name }}" class="text-sm font-semibold text-gray-900">
                                 {{ name }}
-                            </acronym>
+                            </span>
                         </div>
                     </td>
                     {% if detailled == true %}

--- a/internal/report/templates/html/dependencies.html
+++ b/internal/report/templates/html/dependencies.html
@@ -1,51 +1,10 @@
 {% extends "layout.html" %}
-{% block pageTitle %}Dependencies - {{ currentLanguage }}{% endblock %}
+{% block pageTitle %}Dependencies - {{ scopeLabel }}{% endblock %}
 {% block content %}
 
 <style>
-    .dashboard-card {
-        background: white;
-        border: 1px solid #e2e8f0;
-        border-radius: 16px;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        position: relative;
-        overflow: hidden;
-    }
-
-    .dashboard-card:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-        border-color: #cbd5e1;
-    }
-
-    .dashboard-card::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, #3b82f6, #8b5cf6);
-        opacity: 0;
-        transition: opacity 0.3s ease;
-    }
-
-    .dashboard-card:hover::before {
-        opacity: 1;
-    }
-
-    @keyframes fadeIn {
-        from { opacity: 0; transform: translateY(10px); }
-        to { opacity: 1; transform: translateY(0); }
-    }
-
-    .animate-fade-in-up {
-        animation: fadeIn 0.5s ease-out backwards;
-    }
-
-    #dep-graph-wrapper {
-        background: white;
-    }
+    /* Page-specific only: the graph surface, its tooltip and the view switch.
+       Everything else comes from the shared components in layout.html. */
     #dep-graph-canvas {
         width: 100%;
         min-height: 600px;
@@ -74,32 +33,39 @@
         word-break: break-all;
     }
     .dep-tooltip.visible { opacity: 1; }
+
+    /* Discreet segmented control for "By file / By folder" */
+    .dep-seg {
+        display: inline-flex;
+        background: #f1f5f9;
+        border-radius: 10px;
+        padding: 3px;
+        gap: 2px;
+    }
+    .dep-seg label {
+        cursor: pointer;
+        font-size: 12px;
+        font-weight: 500;
+        color: #64748b;
+        padding: 0.3rem 0.7rem;
+        border-radius: 8px;
+        white-space: nowrap;
+        transition: background-color 0.15s ease, color 0.15s ease;
+    }
+    .dep-seg label input { position: absolute; opacity: 0; width: 0; height: 0; }
+    .dep-seg label:hover { color: #334155; }
+    .dep-seg label:has(input:checked) {
+        background: white;
+        color: #0f172a;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    }
+    .dep-seg label:focus-within { outline: 2px solid #3b82f6; outline-offset: 1px; }
+
+    @keyframes dep-spin { to { transform: rotate(360deg); } }
 </style>
 
 <!-- language tabs -->
-<div class="flex overflow-x-auto overflow-y-hidden border-b border-gray-200 whitespace-nowrap">
-    <a href="dependencies.html"
-       class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center {% if currentLanguage == 'All' %}text-blue-600 border-blue-500{% endif %} bg-transparent border-b-2 sm:px-4 -px-1 focus:outline-none">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-        </svg>
-        <span class="mx-1 text-sm sm:text-base">
-            All languages <span class="text-xs sm:text-sm">({{ projectAggregated.Combined.ConcernedFiles|length }} files)</span>
-        </span>
-    </a>
-
-    {% for languageName, lang in projectAggregated.ByProgrammingLanguage %}
-    <a href="dependencies_{{ languageName|langSlug }}.html"
-       class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center bg-transparent border-b-2 {% if currentLanguage == languageName %}text-blue-600 border-blue-500{% else %}text-gray-700 border-transparent{% endif %} sm:px-4 -px-1 hover:border-gray-400">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-        </svg>
-        <span class="mx-1 text-sm sm:text-base">
-            {{ languageName }} <span class="text-xs sm:text-sm">({{ lang.ConcernedFiles|length }} files)</span>
-        </span>
-    </a>
-    {% endfor %}
-</div>
+{% include "partials/language_tabs.html" with pageBase="dependencies" %}
 <!-- end language tabs -->
 
 
@@ -114,71 +80,87 @@
 
 <div id="dep-content" class="hidden">
 
-    <!-- KPI row -->
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8 mb-8">
-        <div class="dashboard-card p-6 animate-fade-in-up">
-            <p class="text-sm font-medium text-gray-500 uppercase tracking-wider">Files with dependencies</p>
-            <p id="kpi-files" class="text-3xl font-bold text-gray-900 mt-2">0</p>
-        </div>
-        <div class="dashboard-card p-6 animate-fade-in-up" style="animation-delay:.1s">
-            <p class="text-sm font-medium text-gray-500 uppercase tracking-wider">Dependency edges</p>
-            <p id="kpi-edges" class="text-3xl font-bold text-gray-900 mt-2">0</p>
-        </div>
-        <div class="dashboard-card p-6 animate-fade-in-up" style="animation-delay:.2s">
-            <p class="text-sm font-medium text-gray-500 uppercase tracking-wider">Avg coupling / file</p>
-            <p id="kpi-avg" class="text-3xl font-bold text-gray-900 mt-2">0</p>
-        </div>
-    </div>
-
-    <!-- Legend -->
-    <div class="dashboard-card p-4 mb-6 animate-fade-in-up" style="animation-delay:.3s">
-        <div class="flex flex-wrap gap-6 items-center text-sm text-gray-600">
-            <span class="font-medium text-gray-700">Legend:</span>
-            <span class="flex items-center gap-2"><span class="inline-block w-3 h-3 rounded-full" style="background:#0d9488"></span> Mostly efferent (depends on others)</span>
-            <span class="flex items-center gap-2"><span class="inline-block w-3 h-3 rounded-full" style="background:#7c3aed"></span> Mostly afferent (depended on by others)</span>
-            <span class="flex items-center gap-2"><span class="inline-block w-3 h-3 rounded-full" style="background:#3b82f6"></span> Balanced</span>
-            <span class="flex items-center gap-2"><svg width="20" height="10"><line x1="0" y1="5" x2="14" y2="5" stroke="#94a3b8" stroke-width="1.5"/><polygon points="14,2 20,5 14,8" fill="#94a3b8"/></svg> Dependency direction</span>
-        </div>
-    </div>
-
-    <!-- View mode toggle -->
-    <div id="dep-view-toggle" class="flex flex-wrap items-center gap-3 mb-4 text-xs font-medium text-gray-600">
-        <span class="text-gray-400">View:</span>
-        <label class="flex items-center gap-1.5 cursor-pointer bg-gray-50 px-3 py-1.5 rounded-lg hover:bg-gray-100 transition-colors">
-            <input type="radio" name="dep-view" value="files" class="w-3.5 h-3.5 text-blue-600">
-            <span>By file</span>
-        </label>
-        <label id="dep-view-folder-label" class="flex items-center gap-1.5 cursor-pointer bg-gray-50 px-3 py-1.5 rounded-lg hover:bg-gray-100 transition-colors">
-            <input type="radio" name="dep-view" value="folders" class="w-3.5 h-3.5 text-blue-600">
-            <span>By folder</span>
-        </label>
-    </div>
-
-    <!-- Breadcrumb for drill-down -->
-    <div id="dep-breadcrumb" class="hidden mb-4 flex items-center gap-2 text-sm text-gray-600">
-        <a href="#" id="dep-breadcrumb-root" class="text-blue-600 hover:underline font-medium">All Folders</a>
-        <span class="text-gray-400">&rsaquo;</span>
-        <span id="dep-breadcrumb-current" class="font-medium text-gray-800"></span>
-    </div>
-
-    <!-- Graph container -->
-    <div id="dep-graph-wrapper" class="dashboard-card p-2 animate-fade-in-up" style="animation-delay:.4s;position:relative;background:white;">
-        <div id="dep-graph-canvas" style="width:100%;min-height:600px;"></div>
-        <!-- Loading skeleton -->
-        <div id="dep-graph-loading" class="absolute inset-0 flex flex-col items-center justify-center bg-white" style="z-index:10;border-radius:16px;">
-            <div class="relative" style="width:160px;height:160px;">
-                <div style="position:absolute;inset:0;border-radius:50%;border:3px solid #e2e8f0;"></div>
-                <div style="position:absolute;inset:0;border-radius:50%;border:3px solid transparent;border-top-color:#3b82f6;animation:dep-spin 0.8s linear infinite;"></div>
-                <svg viewBox="0 0 100 100" style="position:absolute;inset:15%;width:70%;height:70%;opacity:0.15;">
-                    <circle cx="30" cy="30" r="8" fill="#94a3b8"/><circle cx="70" cy="25" r="6" fill="#94a3b8"/><circle cx="50" cy="65" r="10" fill="#94a3b8"/><circle cx="20" cy="70" r="5" fill="#94a3b8"/><circle cx="80" cy="60" r="7" fill="#94a3b8"/>
-                    <line x1="30" y1="30" x2="70" y2="25" stroke="#cbd5e1" stroke-width="1.5"/><line x1="30" y1="30" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/><line x1="70" y1="25" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/><line x1="50" y1="65" x2="80" y2="60" stroke="#cbd5e1" stroke-width="1.5"/><line x1="20" y1="70" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/>
-                </svg>
+    <!-- Verdict -->
+    <div class="page-hero animate-fade-in-up mt-8">
+        <div class="flex flex-wrap items-start justify-between gap-8">
+            <div class="min-w-0">
+                <p class="page-kicker mb-3">HOW THE FILES DEPEND ON EACH OTHER{% if scopeKind != "all" %} &middot; {{ scopeLabel|upper }}{% endif %}</p>
+                <h1 class="verdict-title" id="dep-verdict-title">Reading the dependency graph&hellip;</h1>
+                <p class="verdict-lead mt-4" id="dep-verdict-lead"></p>
             </div>
-            <p class="mt-4 text-sm text-gray-400 font-medium">Building dependency graph...</p>
+            <div class="kpi-strip kpi-strip--divided shrink-0">
+                <div>
+                    <div class="kpi-value" id="kpi-files">0</div>
+                    <div class="kpi-label">linked files</div>
+                </div>
+                <div>
+                    <div class="kpi-value" id="kpi-edges">0</div>
+                    <div class="kpi-label">links</div>
+                </div>
+                <div>
+                    <div class="kpi-value" id="kpi-avg">0</div>
+                    <div class="kpi-label">links per file</div>
+                </div>
+            </div>
         </div>
-        <style>
-            @keyframes dep-spin { to { transform: rotate(360deg); } }
-        </style>
+    </div>
+
+    <!-- Graph -->
+    <div class="soft-card mt-6 animate-fade-in-up stagger-1">
+        <div class="flex flex-wrap items-center justify-between gap-4 mb-4">
+            <div class="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-gray-500">
+                <span class="flex items-center gap-2"><span class="dot" style="background:#0d9488"></span> Mostly uses others</span>
+                <span class="flex items-center gap-2"><span class="dot" style="background:#7c3aed"></span> Mostly used</span>
+                <span class="flex items-center gap-2"><span class="dot" style="background:#3b82f6"></span> Balanced</span>
+                <span class="text-gray-400">size = number of links</span>
+            </div>
+            <div id="dep-view-toggle" class="dep-seg">
+                <label><input type="radio" name="dep-view" value="files"><span>By file</span></label>
+                <label id="dep-view-folder-label"><input type="radio" name="dep-view" value="folders"><span>By folder</span></label>
+            </div>
+        </div>
+
+        <!-- Breadcrumb for drill-down -->
+        <div id="dep-breadcrumb" class="hidden mb-3 flex items-center gap-2 text-sm text-gray-600">
+            <a href="#" id="dep-breadcrumb-root" class="text-blue-600 hover:underline font-medium">All folders</a>
+            <span class="text-gray-400">&rsaquo;</span>
+            <span id="dep-breadcrumb-current" class="font-medium text-gray-800"></span>
+        </div>
+
+        <!-- Graph container -->
+        <div id="dep-graph-wrapper" style="position:relative;background:white;border-radius:14px;overflow:hidden;">
+            <div id="dep-graph-canvas" style="width:100%;min-height:600px;"></div>
+            <!-- Loading skeleton -->
+            <div id="dep-graph-loading" class="absolute inset-0 flex flex-col items-center justify-center bg-white" style="z-index:10;">
+                <div class="relative" style="width:160px;height:160px;">
+                    <div style="position:absolute;inset:0;border-radius:50%;border:3px solid #e2e8f0;"></div>
+                    <div style="position:absolute;inset:0;border-radius:50%;border:3px solid transparent;border-top-color:#3b82f6;animation:dep-spin 0.8s linear infinite;"></div>
+                    <svg viewBox="0 0 100 100" style="position:absolute;inset:15%;width:70%;height:70%;opacity:0.15;">
+                        <circle cx="30" cy="30" r="8" fill="#94a3b8"/><circle cx="70" cy="25" r="6" fill="#94a3b8"/><circle cx="50" cy="65" r="10" fill="#94a3b8"/><circle cx="20" cy="70" r="5" fill="#94a3b8"/><circle cx="80" cy="60" r="7" fill="#94a3b8"/>
+                        <line x1="30" y1="30" x2="70" y2="25" stroke="#cbd5e1" stroke-width="1.5"/><line x1="30" y1="30" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/><line x1="70" y1="25" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/><line x1="50" y1="65" x2="80" y2="60" stroke="#cbd5e1" stroke-width="1.5"/><line x1="20" y1="70" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/>
+                    </svg>
+                </div>
+                <p class="mt-4 text-sm text-gray-400 font-medium">Building dependency graph...</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Where the coupling sits -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
+        <div class="soft-card animate-fade-in-up stagger-2">
+            <div class="mb-3">
+                <h2 class="card-title">Handle with care</h2>
+                <p class="card-sub">Many files depend on these. A change here propagates.</p>
+            </div>
+            <div id="dep-afferent-list"></div>
+        </div>
+        <div class="soft-card animate-fade-in-up stagger-3">
+            <div class="mb-3">
+                <h2 class="card-title">Heavily wired</h2>
+                <p class="card-sub">These files need many others to work.</p>
+            </div>
+            <div id="dep-efferent-list"></div>
+        </div>
     </div>
 </div>
 
@@ -229,11 +211,144 @@ document.addEventListener('DOMContentLoaded', function() {
         });
         var nodesFile = Object.values(nodeMapFile);
         var totalFilesKPI = nodesFile.length;
-        var avgCoupling = totalFilesKPI > 0 ? ((nodesFile.reduce(function(s,n) { return s + n.eff + n.aff; }, 0)) / totalFilesKPI).toFixed(1) : 0;
+        var avgCoupling = totalFilesKPI > 0 ? ((nodesFile.reduce(function(s,n) { return s + n.eff + n.aff; }, 0)) / totalFilesKPI).toFixed(1) : '0.0';
 
         document.getElementById('kpi-files').textContent = totalFilesKPI;
         document.getElementById('kpi-edges').textContent = totalEdgesFile;
         document.getElementById('kpi-avg').textContent = avgCoupling;
+
+        // ---- Verdict + coupling lists -------------------------------------
+        function esc(s) {
+            return String(s).replace(/[&<>"]/g, function(c) {
+                return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+            });
+        }
+        function baseName(p) {
+            var parts = String(p).split('/').filter(Boolean);
+            return parts.length ? parts[parts.length - 1] : String(p);
+        }
+        // Keeps the last folders only: absolute paths are unreadable in a list
+        function dirOf(p) {
+            var parts = String(p).split('/').filter(Boolean);
+            parts.pop();
+            if (!parts.length) return '';
+            return parts.length > 3 ? '…/' + parts.slice(-3).join('/') : parts.join('/');
+        }
+        function identOf(node) {
+            return '<code class="ident">' + esc(baseName(resolve(node.id))) + '</code>';
+        }
+        function plural(n, word) {
+            return n + ' ' + word + (n === 1 ? '' : 's');
+        }
+        // Human fraction of the project touched by a change in one file.
+        function fractionPhrase(ratio) {
+            if (!(ratio > 0)) return '';
+            if (ratio >= 0.85) return 'almost the whole project';
+            var d = Math.round(1 / ratio);
+            var words = {
+                2: 'half the project', 3: 'a third of the project', 4: 'a quarter of the project',
+                5: 'a fifth of the project', 6: 'a sixth of the project', 7: 'a seventh of the project',
+                8: 'an eighth of the project', 9: 'a ninth of the project', 10: 'a tenth of the project'
+            };
+            if (d <= 1) return 'the whole project';
+            if (words[d]) return 'about ' + words[d];
+            return 'less than a tenth of the project';
+        }
+
+        var byAff = nodesFile.slice().sort(function(a, b) { return b.aff - a.aff || a.id.localeCompare(b.id); });
+        var byEff = nodesFile.slice().sort(function(a, b) { return b.eff - a.eff || a.id.localeCompare(b.id); });
+        var maxAff = byAff.length ? byAff[0].aff : 0;
+        var maxEff = byEff.length ? byEff[0].eff : 0;
+
+        // A file is a hotspot when it is depended on by a meaningful share of
+        // the graph, and is close to the most depended-on file (handles ties).
+        var hotspotFloor = Math.max(4, Math.ceil(totalFilesKPI * 0.10));
+        var hotspots = byAff.filter(function(n) {
+            return n.aff >= hotspotFloor && n.aff >= maxAff * 0.5;
+        });
+
+        var titleEl = document.getElementById('dep-verdict-title');
+        var leadEl = document.getElementById('dep-verdict-lead');
+        var titleHtml, leadHtml;
+
+        if (totalEdgesFile === 0) {
+            titleHtml = 'Nothing links these files together.'
+                + '<br><span class="verdict-muted">No dependency to untangle.</span>';
+            leadHtml = totalFilesKPI > 0
+                ? 'AST Metrics found <strong>' + plural(totalFilesKPI, 'file') + '</strong> but no reference from one to another. Imports may be dynamic, or these files simply stand alone.'
+                : 'No dependency could be resolved from imports or class references.';
+        } else if (totalFilesKPI <= 2) {
+            titleHtml = 'Only ' + plural(totalFilesKPI, 'file') + ' take part in the graph.'
+                + '<br><span class="verdict-muted">Too small to say anything about coupling.</span>';
+            leadHtml = 'They share <strong>' + plural(totalEdgesFile, 'link') + '</strong>. Analyze more of the codebase to see the real shape of the dependencies.';
+        } else if (hotspots.length === 0) {
+            titleHtml = 'No single file holds the graph together.'
+                + '<br><span class="verdict-muted">The dependencies are evenly spread.</span>';
+            leadHtml = 'The most depended-on file, ' + identOf(byAff[0]) + ', is used by <strong>'
+                + plural(maxAff, 'file') + '</strong> out of <strong>' + totalFilesKPI
+                + ' linked</strong>: no single change ripples far.';
+        } else if (hotspots.length <= 2) {
+            var names = hotspots.map(identOf).join(' and ');
+            titleHtml = 'The graph is healthy, except around ' + names + '.'
+                + '<br><span class="verdict-muted">Everything else stays loosely coupled.</span>';
+            if (hotspots.length === 1) {
+                var frac = fractionPhrase(hotspots[0].aff / totalFilesKPI);
+                leadHtml = '<strong>' + plural(hotspots[0].aff, 'file') + '</strong> depend on it directly'
+                    + (frac ? ': changing it moves ' + frac + '.' : '.');
+            } else {
+                leadHtml = 'They are used directly by <strong>' + hotspots[0].aff + '</strong> and <strong>'
+                    + plural(hotspots[1].aff, 'file') + '</strong>, out of <strong>' + totalFilesKPI
+                    + ' linked files</strong>. A change in either one travels far.';
+            }
+        } else {
+            titleHtml = plural(hotspots.length, 'file') + ' sit at the centre of the graph.'
+                + '<br><span class="verdict-muted">Most changes ripple through them.</span>';
+            var fracTop = fractionPhrase(byAff[0].aff / totalFilesKPI);
+            leadHtml = 'The most exposed, ' + identOf(byAff[0]) + ', is used by <strong>'
+                + plural(byAff[0].aff, 'file') + '</strong>'
+                + (fracTop ? ': touching it moves ' + fracTop + '.' : '.');
+        }
+
+        titleEl.innerHTML = titleHtml;
+        leadEl.innerHTML = leadHtml;
+
+        // Severity by volume of coupling
+        function sevOf(count) {
+            if (count >= 15) return 'sev-bad';
+            if (count >= 6) return 'sev-warn';
+            return 'sev-none';
+        }
+
+        function renderCouplingList(containerId, ranked, key, maxValue, withDot) {
+            var el = document.getElementById(containerId);
+            if (!el) return;
+            var rows = ranked.filter(function(n) { return n[key] > 0; }).slice(0, 8);
+            if (!rows.length) {
+                el.innerHTML = '<p class="text-sm text-gray-400 py-3">No file in this category.</p>';
+                return;
+            }
+            var html = rows.map(function(n) {
+                var full = resolve(n.id);
+                var value = n[key];
+                var width = maxValue > 0 ? Math.max(4, Math.round(value / maxValue * 100)) : 0;
+                var sev = sevOf(value);
+                var folder = dirOf(full);
+                return '<a href="explorer{{ scopeSuffix }}.html?file=' + encodeURIComponent(n.id) + '" class="data-row" title="' + esc(full) + '">'
+                    + (withDot ? '<span class="dot ' + sev + '"></span>' : '')
+                    + '<div class="min-w-0 flex-1">'
+                    + '<div class="row-name truncate">' + esc(baseName(full)) + '</div>'
+                    + '<div class="row-meta truncate">' + (folder ? esc(folder) : '&nbsp;') + '</div>'
+                    + '</div>'
+                    + '<div class="w-24 shrink-0"><div class="meter" style="margin-top:0"><div class="meter-fill ' + sev + '" style="width:' + width + '%"></div></div></div>'
+                    + '<span class="row-value w-8">' + value + '</span>'
+                    + '</a>';
+            }).join('');
+            el.innerHTML = html;
+        }
+
+        renderCouplingList('dep-afferent-list', byAff, 'aff', maxAff, false);
+        renderCouplingList('dep-efferent-list', byEff, 'eff', maxEff, true);
+        // ------------------------------------------------------------------
 
         // State machine
         var state = { mode: 'files', expandedFolder: null };
@@ -269,7 +384,7 @@ document.addEventListener('DOMContentLoaded', function() {
             return 0x888888;
         }
 
-        // Color: teal=efferent, purple=afferent, blue=balanced
+        // Color: teal=mostly uses others, purple=mostly used, blue=balanced
         function nodeColor(eff, aff) {
             var total = eff + aff;
             if (total === 0) return '#3b82f6';
@@ -284,15 +399,15 @@ document.addEventListener('DOMContentLoaded', function() {
             var parts = p.split('/');
             var name = parts[parts.length - 1];
             if (!name) name = parts[parts.length - 2] || p;
-            if (name.length > max) name = name.substring(0, max - 1) + '\u2026';
+            if (name.length > max) name = name.substring(0, max - 1) + '…';
             return name;
         }
 
         function shortFolderLabel(p, max) {
             max = max || 25;
             var parts = p.split('/').filter(Boolean);
-            var name = parts.length > 2 ? '\u2026/' + parts.slice(-2).join('/') : p;
-            if (name.length > max) name = name.substring(0, max - 1) + '\u2026';
+            var name = parts.length > 2 ? '…/' + parts.slice(-2).join('/') : p;
+            if (name.length > max) name = name.substring(0, max - 1) + '…';
             return name;
         }
 
@@ -561,7 +676,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 d._color = color;
 
                 nc.on('pointerover', function(ev) {
-                    tooltip.innerHTML = '<strong>' + resolve(d.id) + '</strong><br>Efferent: ' + d.eff + ' &middot; Afferent: ' + d.aff;
+                    tooltip.innerHTML = '<strong>' + resolve(d.id) + '</strong><br>Uses ' + d.eff + ' &middot; Used by ' + d.aff;
                     tooltip.classList.add('visible');
                     var gp = ev.global || ev.data.global;
                     tooltip.style.left = gp.x + 'px';
@@ -599,7 +714,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 });
 
                 nc.on('pointertap', function() {
-                    window.location.href = 'explorer.html?file=' + encodeURIComponent(d.id);
+                    window.location.href = 'explorer{{ scopeSuffix }}.html?file=' + encodeURIComponent(d.id);
                 });
 
                 nodesContainer.addChild(nc);
@@ -702,7 +817,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 d._color = color;
 
                 nc.on('pointerover', function(ev) {
-                    tooltip.innerHTML = '<strong>' + resolve(d.id) + '</strong><br>Files: ' + d.fileCount + '<br>Efferent: ' + d.eff + ' &middot; Afferent: ' + d.aff;
+                    tooltip.innerHTML = '<strong>' + resolve(d.id) + '</strong><br>Files: ' + d.fileCount + '<br>Uses ' + d.eff + ' &middot; Used by ' + d.aff;
                     tooltip.classList.add('visible');
                     var gp = ev.global || ev.data.global;
                     tooltip.style.left = gp.x + 'px';
@@ -796,6 +911,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // Radio buttons for view mode
         var hasFolderData = (folderDeps && folderDeps.folders && Object.keys(folderDeps.folders).length > 0);
+        var folderLabel = document.getElementById('dep-view-folder-label');
+        if (!hasFolderData && folderLabel) {
+            folderLabel.style.display = 'none';
+            state.mode = 'files';
+        }
 
         // Check the correct radio based on initial state
         var radios = document.querySelectorAll('input[name="dep-view"]');

--- a/internal/report/templates/html/dependencies.html
+++ b/internal/report/templates/html/dependencies.html
@@ -46,7 +46,8 @@
         cursor: pointer;
         font-size: 12px;
         font-weight: 500;
-        color: #64748b;
+        /* Slate 600, not 500: on the tinted track 500 falls under 4.5:1 */
+        color: #475569;
         padding: 0.3rem 0.7rem;
         border-radius: 8px;
         white-space: nowrap;
@@ -112,7 +113,7 @@
                 <span class="flex items-center gap-2"><span class="dot" style="background:#0d9488"></span> Mostly uses others</span>
                 <span class="flex items-center gap-2"><span class="dot" style="background:#7c3aed"></span> Mostly used</span>
                 <span class="flex items-center gap-2"><span class="dot" style="background:#3b82f6"></span> Balanced</span>
-                <span class="text-gray-400">size = number of links</span>
+                <span class="text-gray-500">size = number of links</span>
             </div>
             <div id="dep-view-toggle" class="dep-seg">
                 <label><input type="radio" name="dep-view" value="files"><span>By file</span></label>
@@ -123,7 +124,7 @@
         <!-- Breadcrumb for drill-down -->
         <div id="dep-breadcrumb" class="hidden mb-3 flex items-center gap-2 text-sm text-gray-600">
             <a href="#" id="dep-breadcrumb-root" class="text-blue-600 hover:underline font-medium">All folders</a>
-            <span class="text-gray-400">&rsaquo;</span>
+            <span class="text-gray-500">&rsaquo;</span>
             <span id="dep-breadcrumb-current" class="font-medium text-gray-800"></span>
         </div>
 
@@ -140,7 +141,7 @@
                         <line x1="30" y1="30" x2="70" y2="25" stroke="#cbd5e1" stroke-width="1.5"/><line x1="30" y1="30" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/><line x1="70" y1="25" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/><line x1="50" y1="65" x2="80" y2="60" stroke="#cbd5e1" stroke-width="1.5"/><line x1="20" y1="70" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/>
                     </svg>
                 </div>
-                <p class="mt-4 text-sm text-gray-400 font-medium">Building dependency graph...</p>
+                <p class="mt-4 text-sm text-gray-500 font-medium">Building dependency graph...</p>
             </div>
         </div>
     </div>
@@ -324,7 +325,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (!el) return;
             var rows = ranked.filter(function(n) { return n[key] > 0; }).slice(0, 8);
             if (!rows.length) {
-                el.innerHTML = '<p class="text-sm text-gray-400 py-3">No file in this category.</p>';
+                el.innerHTML = '<p class="text-sm text-gray-500 py-3">No file in this category.</p>';
                 return;
             }
             var html = rows.map(function(n) {

--- a/internal/report/templates/html/explorer.html
+++ b/internal/report/templates/html/explorer.html
@@ -38,9 +38,9 @@ AST Metrics - Explorer
         <div class="animate-fade-in-up">
           <div class="flex items-start justify-between gap-6">
             <div class="min-w-0">
-              <p class="text-xs text-gray-400 mb-2 truncate" x-text="breadcrumb" x-show="breadcrumb"></p>
+              <p class="text-xs text-gray-500 mb-2 truncate" x-text="breadcrumb" x-show="breadcrumb"></p>
               <h1 class="verdict-title break-words" style="font-size: 1.75rem;" x-text="fileName"></h1>
-              <p class="text-xs text-gray-400 mt-2" x-text="fileMeta"></p>
+              <p class="text-xs text-gray-500 mt-2" x-text="fileMeta"></p>
             </div>
             <button @click="openGlossary = true"
               class="shrink-0 inline-flex items-center gap-2 px-3.5 py-2 rounded-xl border border-gray-200 hover:bg-gray-50 hover:border-gray-300 transition-colors text-sm font-medium text-gray-600">
@@ -138,7 +138,7 @@ AST Metrics - Explorer
             </div>
             <div x-show="hasDeps">
               <div id="file-deps-diagram" class="w-full" style="min-height: 320px;"></div>
-              <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-[11px] text-gray-400">
+              <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-[11px] text-gray-500">
                 <span class="flex items-center gap-1.5"><span class="dot" style="background:#3b82f6;"></span> This
                   file</span>
                 <span class="flex items-center gap-1.5"><span class="dot" style="background:#0d9488;"></span> Files it
@@ -147,7 +147,7 @@ AST Metrics - Explorer
                   use it</span>
               </div>
             </div>
-            <div x-show="!hasDeps" class="text-sm text-gray-400 text-center py-16">
+            <div x-show="!hasDeps" class="text-sm text-gray-500 text-center py-16">
               No other analyzed file is linked to this one.
             </div>
           </div>
@@ -159,11 +159,11 @@ AST Metrics - Explorer
                 <h2 class="card-title">Contents</h2>
                 <p class="card-sub">What is declared in this file, class by class.</p>
               </div>
-              <span class="text-xs text-gray-400 shrink-0 mt-1" x-text="contentsSummary"></span>
+              <span class="text-xs text-gray-500 shrink-0 mt-1" x-text="contentsSummary"></span>
             </div>
 
             <div x-show="!contentGroups.length && !looseFunctions.length"
-              class="text-sm text-gray-400 text-center py-16">
+              class="text-sm text-gray-500 text-center py-16">
               No class and no function declared here.
             </div>
 
@@ -185,7 +185,7 @@ AST Metrics - Explorer
                     <span class="w-8 shrink-0 text-right font-mono text-sm font-semibold" :class="'text-' + m.level" x-text="m.cyclo"></span>
                   </div>
                 </template>
-                <div x-show="!c.methods.length" class="py-2 text-xs text-gray-400" style="padding-left: 1rem;">No
+                <div x-show="!c.methods.length" class="py-2 text-xs text-gray-500" style="padding-left: 1rem;">No
                   method.</div>
               </div>
             </template>
@@ -204,7 +204,7 @@ AST Metrics - Explorer
               </div>
             </template>
 
-            <p class="text-[11px] text-gray-400 mt-4" x-show="contentGroups.length || looseFunctions.length">
+            <p class="text-[11px] text-gray-500 mt-4" x-show="contentGroups.length || looseFunctions.length">
               The number on the right is the count of decision paths.
             </p>
           </div>
@@ -214,7 +214,7 @@ AST Metrics - Explorer
         <div class="soft-card animate-fade-in-up stagger-4">
           <div class="flex items-start justify-between gap-4 mb-2">
             <div>
-              <h2 class="card-title">Detected risks <span class="font-normal text-gray-400"
+              <h2 class="card-title">Detected risks <span class="font-normal text-gray-500"
                   x-text="'(' + risks.length + ')'"></span></h2>
               <p class="card-sub">Rules broken in this file, worst first.</p>
             </div>
@@ -230,7 +230,7 @@ AST Metrics - Explorer
           </div>
 
           <div x-show="risks.length > 0 && visibleRisks().length === 0"
-            class="text-sm text-gray-400 py-8 text-center">
+            class="text-sm text-gray-500 py-8 text-center">
             Nothing above the high threshold. Untick <strong>High only</strong> to see the rest.
           </div>
 
@@ -244,7 +244,7 @@ AST Metrics - Explorer
                     x-text="severityLevel(r.severity)"></span>
                 </div>
                 <p class="text-sm text-gray-600 mt-1" x-text="r.details"></p>
-                <p class="text-xs text-gray-400 mt-1" x-show="r.hint">
+                <p class="text-xs text-gray-500 mt-1" x-show="r.hint">
                   <span class="font-medium text-gray-500">Fix</span> <span x-text="r.hint"></span>
                 </p>
               </div>
@@ -262,7 +262,7 @@ AST Metrics - Explorer
     <div class="relative soft-card w-full max-w-3xl p-8 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-6 pb-4 border-b border-gray-200">
         <h2 class="card-title" style="font-size: 1.25rem;">Reading guide</h2>
-        <button class="text-gray-400 hover:text-gray-600 transition-colors p-1 rounded-lg hover:bg-gray-100"
+        <button class="text-gray-500 hover:text-gray-600 transition-colors p-1 rounded-lg hover:bg-gray-100"
           @click="openGlossary=false" aria-label="Close reading guide">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
             class="w-5 h-5">

--- a/internal/report/templates/html/explorer.html
+++ b/internal/report/templates/html/explorer.html
@@ -10,459 +10,260 @@ AST Metrics - Explorer
 
 {% block content %}
 
-<style>
-  .dashboard-card {
-    background: white;
-    border: 1px solid #e2e8f0;
-    border-radius: 16px;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .dashboard-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-    border-color: #cbd5e1;
-  }
-
-  .dashboard-card::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 4px;
-    background: linear-gradient(90deg, #3b82f6, #8b5cf6);
-    opacity: 0;
-    transition: opacity 0.3s ease;
-  }
-
-  .dashboard-card:hover::before {
-    opacity: 1;
-  }
-
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-      transform: translateY(10px);
-    }
-
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  @keyframes slideIn {
-    from {
-      opacity: 0;
-      transform: translateX(-10px);
-    }
-
-    to {
-      opacity: 1;
-      transform: translateX(0);
-    }
-  }
-
-  .animate-fade-in-up {
-    animation: fadeIn 0.5s ease-out backwards;
-  }
-
-  .animate-slide-in {
-    animation: slideIn 0.3s ease-out backwards;
-  }
-
-  /* Metric cards */
-  .metric-card {
-    transition: all 0.2s ease;
-  }
-
-  .metric-card:hover {
-    transform: translateY(-1px);
-  }
-
-  /* Empty state */
-  .empty-state {
-    opacity: 0.6;
-  }
-
-  /* Badge improvements */
-  .badge-modern {
-    font-weight: 500;
-    letter-spacing: 0.01em;
-  }
-</style>
-
 <div x-data="explorer()" x-init="init()" @sidebar-select-file.window="selectByPath($event.detail)">
   <div :inert="openGlossary" :aria-hidden="openGlossary ? 'true' : 'false'">
-    <!-- Hero Section -->
-    <div class="mb-8 animate-fade-in-up">
-      <h1 class="text-4xl font-bold text-gray-900 mb-3" style="letter-spacing: -0.02em;">File Explorer</h1>
-      <p class="text-base text-gray-600 font-light">Browse, analyze, and understand your codebase structure. Use the sidebar to select a file.</p>
-    </div>
 
-      <!-- Details panel -->
-      <div>
-        <div class="dashboard-card p-8 animate-fade-in-up">
-          <template x-if="!selected">
-            <div class="empty-state text-center py-16 px-4">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                stroke="currentColor" class="w-16 h-16 text-gray-200 mx-auto mb-4">
-                <path stroke-linecap="round" stroke-linejoin="round"
-                  d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-              </svg>
-              <h2 class="text-lg font-semibold text-gray-900 mb-2">No file selected</h2>
-              <p class="text-sm text-gray-900 max-w-sm mx-auto">Select a file from the tree to view detailed metrics,
-                risks, and guidance</p>
+    <!-- Nothing selected yet -->
+    <template x-if="!selected">
+      <div class="soft-card animate-fade-in-up text-center py-16 px-6">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+          stroke="currentColor" class="w-12 h-12 text-gray-200 mx-auto mb-5">
+          <path stroke-linecap="round" stroke-linejoin="round"
+            d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.564 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+        </svg>
+        <h1 class="verdict-title" style="font-size: 1.5rem;">Pick a file to read it.</h1>
+        <p class="verdict-lead mt-3 mx-auto" style="max-width: 46ch;">
+          Choose any file in the <strong>Files</strong> explorer to see how easy it is to maintain, what it talks to and
+          what lives inside it. Press <span class="whitespace-nowrap"><code class="ident">Ctrl</code> + <code
+              class="ident">B</code></span> if the file panel is closed.
+        </p>
+      </div>
+    </template>
+
+    <!-- File sheet -->
+    <template x-if="selected">
+      <div class="space-y-6">
+
+        <!-- Path, name, reading guide -->
+        <div class="animate-fade-in-up">
+          <div class="flex items-start justify-between gap-6">
+            <div class="min-w-0">
+              <p class="text-xs text-gray-400 mb-2 truncate" x-text="breadcrumb" x-show="breadcrumb"></p>
+              <h1 class="verdict-title break-words" style="font-size: 1.75rem;" x-text="fileName"></h1>
+              <p class="text-xs text-gray-400 mt-2" x-text="fileMeta"></p>
             </div>
-          </template>
-          <template x-if="selected">
+            <button @click="openGlossary = true"
+              class="shrink-0 inline-flex items-center gap-2 px-3.5 py-2 rounded-xl border border-gray-200 hover:bg-gray-50 hover:border-gray-300 transition-colors text-sm font-medium text-gray-600">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4">
+                <path d="M11.25 3.042A8.25 8.25 0 1 0 19.46 11.25h-1.577a6.75 6.75 0 1 1-6.633-8.208z" />
+                <path
+                  d="M12.75 6.75a.75.75 0 0 0-1.5 0v6a.75.75 0 0 0 1.5 0zM12 16.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5z" />
+              </svg>
+              Reading guide
+            </button>
+          </div>
+        </div>
+
+        <!-- What we make of it -->
+        <div class="insight animate-fade-in-up stagger-1" :class="'insight--' + insight.level">
+          <span class="dot" :class="'sev-' + insight.level"></span>
+          <span x-html="insight.text"></span>
+        </div>
+
+        <!-- The four numbers -->
+        <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 animate-fade-in-up stagger-2">
+          <div class="stat-tile">
+            <div class="stat-tile-label">
+              <span>Ease of maintenance
+                <span tabindex="0" class="text-gray-300 text-xs"
+                  data-tip="Maintainability index, from 0 to 128. It mixes size, complexity and comments. Above 85 the code reads without effort.">ⓘ</span>
+              </span>
+              <span class="dot" :class="'sev-' + miLevel"></span>
+            </div>
+            <div class="stat-tile-value" x-text="miDisplay"></div>
+            <div class="meter">
+              <div class="meter-fill" :class="'sev-' + miLevel" :style="`width: ${miPct(miValue)}%`"></div>
+            </div>
+            <div class="stat-tile-target">target ≥ 85</div>
+          </div>
+
+          <div class="stat-tile">
+            <div class="stat-tile-label">
+              <span>Decision paths
+                <span tabindex="0" class="text-gray-300 text-xs"
+                  data-tip="Cyclomatic complexity: how many independent routes run through the code. Every route is one more case to test.">ⓘ</span>
+              </span>
+              <span class="dot" :class="'sev-' + cycloLevel"></span>
+            </div>
+            <div class="stat-tile-value" x-text="fmtNumber(fileCyclomatic)"></div>
+            <div class="meter">
+              <div class="meter-fill" :class="'sev-' + cycloLevel" :style="`width: ${cycloPct}%`"></div>
+            </div>
+            <div class="stat-tile-target">
+              <span :class="'text-' + cycloLevel" x-text="cycloQualifier"></span> · target &lt; 5 per method
+            </div>
+          </div>
+
+          <div class="stat-tile">
+            <div class="stat-tile-label">
+              <span>Responsibilities
+                <span tabindex="0" class="text-gray-300 text-xs"
+                  data-tip="LCOM4: how many groups of methods never touch the same data. Two groups in one class usually means two classes.">ⓘ</span>
+              </span>
+              <span class="dot" :class="'sev-' + lcomLevel"></span>
+            </div>
+            <div class="stat-tile-value" x-text="lcomDisplay"></div>
+            <div class="meter">
+              <div class="meter-fill" :class="'sev-' + lcomLevel" :style="`width: ${lcomPct}%`"></div>
+            </div>
+            <div class="stat-tile-target">ideal 1 group</div>
+          </div>
+
+          <div class="stat-tile">
+            <div class="stat-tile-label">
+              <span>Lines of code
+                <span tabindex="0" class="text-gray-300 text-xs"
+                  data-tip="Logical lines: statements only, blank lines and comments excluded.">ⓘ</span>
+              </span>
+              <span class="dot" :class="'sev-' + llocLevel"></span>
+            </div>
+            <div class="stat-tile-value" x-text="llocDisplay"></div>
+            <div class="meter">
+              <div class="meter-fill" :class="'sev-' + llocLevel" :style="`width: ${llocPct}%`"></div>
+            </div>
+            <div class="stat-tile-target">
+              <span :class="'text-' + llocLevel" x-text="llocQualifier"></span> · target &lt; 200 lines
+            </div>
+          </div>
+        </div>
+
+        <!-- Around it, inside it -->
+        <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 items-start animate-fade-in-up stagger-3">
+
+          <!-- Neighborhood -->
+          <div class="soft-card">
+            <div class="mb-4">
+              <h2 class="card-title">Neighborhood</h2>
+              <p class="card-sub" x-text="neighborhoodSub"></p>
+            </div>
+            <div x-show="hasDeps">
+              <div id="file-deps-diagram" class="w-full" style="min-height: 320px;"></div>
+              <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-[11px] text-gray-400">
+                <span class="flex items-center gap-1.5"><span class="dot" style="background:#3b82f6;"></span> This
+                  file</span>
+                <span class="flex items-center gap-1.5"><span class="dot" style="background:#0d9488;"></span> Files it
+                  uses</span>
+                <span class="flex items-center gap-1.5"><span class="dot" style="background:#7c3aed;"></span> Files that
+                  use it</span>
+              </div>
+            </div>
+            <div x-show="!hasDeps" class="text-sm text-gray-400 text-center py-16">
+              No other analyzed file is linked to this one.
+            </div>
+          </div>
+
+          <!-- Contents -->
+          <div class="soft-card">
+            <div class="flex items-start justify-between gap-4 mb-2">
+              <div>
+                <h2 class="card-title">Contents</h2>
+                <p class="card-sub">What is declared in this file, class by class.</p>
+              </div>
+              <span class="text-xs text-gray-400 shrink-0 mt-1" x-text="contentsSummary"></span>
+            </div>
+
+            <div x-show="!contentGroups.length && !looseFunctions.length"
+              class="text-sm text-gray-400 text-center py-16">
+              No class and no function declared here.
+            </div>
+
+            <template x-for="c in contentGroups" :key="c.key">
+              <div class="mt-4">
+                <div class="data-row">
+                  <div class="min-w-0 flex-1">
+                    <div class="row-name truncate" x-text="c.name" :title="c.qualified"></div>
+                    <div class="row-meta" x-text="c.meta"></div>
+                  </div>
+                  <span class="shrink-0 px-2 py-1 rounded-md text-xs font-medium" :class="miBadgeClass(c.mi)">
+                    MI <span x-text="formatMI(c.mi)"></span>
+                  </span>
+                </div>
+                <template x-for="m in c.methods" :key="m.key">
+                  <div class="data-row" style="padding-left: 1rem;">
+                    <div class="min-w-0 flex-1 font-mono text-xs text-gray-600 truncate" x-text="m.name"
+                      :title="m.qualified"></div>
+                    <span class="w-8 shrink-0 text-right font-mono text-sm font-semibold" :class="'text-' + m.level" x-text="m.cyclo"></span>
+                  </div>
+                </template>
+                <div x-show="!c.methods.length" class="py-2 text-xs text-gray-400" style="padding-left: 1rem;">No
+                  method.</div>
+              </div>
+            </template>
+
+            <template x-if="looseFunctions.length">
+              <div class="mt-6">
+                <div class="section-title mb-1" x-text="contentGroups.length ? 'Standalone functions' : 'Functions'">
+                </div>
+                <template x-for="m in looseFunctions" :key="m.key">
+                  <div class="data-row">
+                    <div class="min-w-0 flex-1 font-mono text-xs text-gray-600 truncate" x-text="m.name"
+                      :title="m.qualified"></div>
+                    <span class="w-8 shrink-0 text-right font-mono text-sm font-semibold" :class="'text-' + m.level" x-text="m.cyclo"></span>
+                  </div>
+                </template>
+              </div>
+            </template>
+
+            <p class="text-[11px] text-gray-400 mt-4" x-show="contentGroups.length || looseFunctions.length">
+              The number on the right is the count of decision paths.
+            </p>
+          </div>
+        </div>
+
+        <!-- Risks -->
+        <div class="soft-card animate-fade-in-up stagger-4">
+          <div class="flex items-start justify-between gap-4 mb-2">
             <div>
-              <!-- Header -->
-              <div class="mb-8 pb-6 border-b border-gray-100">
-                <div class="flex items-start justify-between gap-4">
-                  <div class="flex-1 min-w-0">
-                    <h2 class="text-2xl font-bold text-gray-900 mb-3 break-words" style="letter-spacing: -0.02em;"
-                      x-text="selected.shortPath || selected.path"></h2>
-                    <div class="flex flex-wrap items-center gap-2">
-                      <span
-                        class="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-700 text-xs font-medium badge-modern">
-                        <span class="mr-1.5" x-text="selected.programmingLanguage || 'Unknown'"></span>
-                      </span>
-                      <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium badge-modern"
-                        :class="risks.length > 0 ? 'bg-amber-100 text-amber-700' : 'bg-green-100 text-green-700'">
-                        <span x-text="risks.length"></span> risk<span x-text="risks.length !== 1 ? 's' : ''"></span>
-                      </span>
-                      <span
-                        class="inline-flex items-center px-3 py-1 rounded-full bg-blue-50 text-blue-700 text-xs font-medium badge-modern">
-                        Score: <span class="ml-1 font-semibold" x-text="fileRiskScore(selected).toFixed(1)"></span>
-                      </span>
-                      <span
-                        class="inline-flex items-center px-3 py-1 rounded-full bg-slate-100 text-slate-700 text-xs font-medium badge-modern"
-                        x-show="(selected.commits?.count)||0 > 0">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2"
-                          stroke="currentColor" class="size-3 mr-1">
-                          <path stroke-linecap="round" stroke-linejoin="round"
-                            d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-                        </svg>
-                        <span x-text="(selected.commits?.count)||0"></span> commits
-                      </span>
-                    </div>
-                  </div>
-                  <button @click="openGlossary=true"
-                    class="shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-gray-200 hover:bg-gray-50 hover:border-gray-300 transition-colors text-sm font-medium text-gray-700">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4">
-                      <path d="M11.25 3.042A8.25 8.25 0 1 0 19.46 11.25h-1.577a6.75 6.75 0 1 1-6.633-8.208z" />
-                      <path
-                        d="M12.75 6.75a.75.75 0 0 0-1.5 0v6a.75.75 0 0 0 1.5 0zM12 16.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5z" />
-                    </svg>
-                    Guide
-                  </button>
+              <h2 class="card-title">Detected risks <span class="font-normal text-gray-400"
+                  x-text="'(' + risks.length + ')'"></span></h2>
+              <p class="card-sub">Rules broken in this file, worst first.</p>
+            </div>
+            <label class="inline-flex items-center gap-2 cursor-pointer shrink-0 mt-1 text-sm text-gray-500">
+              <input type="checkbox" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                x-model="filters.onlyHigh" />
+              High only
+            </label>
+          </div>
+
+          <div x-show="risks.length === 0" class="flex items-center gap-2 text-sm text-gray-500 py-8 justify-center">
+            <span class="dot sev-good"></span> No rule broken in this file.
+          </div>
+
+          <div x-show="risks.length > 0 && visibleRisks().length === 0"
+            class="text-sm text-gray-400 py-8 text-center">
+            Nothing above the high threshold. Untick <strong>High only</strong> to see the rest.
+          </div>
+
+          <template x-for="r in visibleRisks()" :key="(r.id || '') + r.title">
+            <div class="data-row items-start">
+              <span class="dot mt-1.5" :class="'sev-' + riskLevel(r.severity)"></span>
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-2 flex-wrap">
+                  <span class="text-sm font-medium text-gray-900" x-text="r.title"></span>
+                  <span class="text-xs font-medium" :class="'text-' + riskLevel(r.severity)"
+                    x-text="severityLevel(r.severity)"></span>
                 </div>
+                <p class="text-sm text-gray-600 mt-1" x-text="r.details"></p>
+                <p class="text-xs text-gray-400 mt-1" x-show="r.hint">
+                  <span class="font-medium text-gray-500">Fix</span> <span x-text="r.hint"></span>
+                </p>
               </div>
-
-              <!-- Overview KPIs -->
-              <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 mb-8">
-                <div class="metric-card bg-gradient-to-br from-white to-gray-50 p-5 rounded-xl border border-gray-100">
-                  <div class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">Maintainability</div>
-                  <div class="flex items-baseline justify-between mb-3">
-                    <span class="text-3xl font-bold text-gray-900" style="letter-spacing: -0.03em;"
-                      x-text="formatMI(worstMI)"></span>
-                    <span :class="miBadgeClass(worstMI)" class="badge-modern"><span
-                        x-text="formatMI(worstMI)"></span></span>
-                  </div>
-                  <div class="h-2 w-full rounded-full bg-gray-200 overflow-hidden">
-                    <div class="h-2 rounded-full transition-all duration-500" :class="miBarClass(worstMI)"
-                      :style="`width: ${miPct(worstMI)}%`"></div>
-                  </div>
-                  <p class="mt-2 text-xs text-gray-500">Target ≥ 85</p>
-                </div>
-                <div class="metric-card bg-gradient-to-br from-white to-gray-50 p-5 rounded-xl border border-gray-100">
-                  <div class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">Cyclomatic</div>
-                  <div class="text-3xl font-bold text-gray-900 mb-2" style="letter-spacing: -0.03em;"
-                    x-text="fmtNumber(fileCyclomatic)"></div>
-                  <p class="text-xs font-medium" :class="complexityTextClass(fileCyclomatic)">
-                    <span x-text="complexityBand(fileCyclomatic)"></span>
-                  </p>
-                  <p class="mt-1 text-xs text-gray-500">File-level</p>
-                </div>
-                <div class="metric-card bg-gradient-to-br from-white to-gray-50 p-5 rounded-xl border border-gray-100">
-                  <div class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">LCOM4</div>
-                  <div class="text-3xl font-bold text-gray-900 mb-2" style="letter-spacing: -0.03em;"
-                    x-text="avgLCOM4Display"></div>
-                  <p class="text-xs text-gray-500">Lower is better</p>
-                </div>
-                <div class="metric-card bg-gradient-to-br from-white to-gray-50 p-5 rounded-xl border border-gray-100">
-                  <div class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">LLOC</div>
-                  <div class="text-3xl font-bold text-gray-900 mb-2" style="letter-spacing: -0.03em;"
-                    x-text="fileLLocDisplay"></div>
-                  <p class="text-xs text-gray-500">Logical lines</p>
-                </div>
-              </div>
-
-              <!-- File Dependency Diagram -->
-              <div x-show="selected && fileDeps[selected.pathHash] && ((fileDeps[selected.pathHash].efferent||[]).length || (fileDeps[selected.pathHash].afferent||[]).length)" class="mb-6">
-                <div class="dashboard-card p-6">
-                  <div class="flex items-center justify-between mb-4">
-                    <h3 class="text-lg font-bold text-gray-900">File Dependencies</h3>
-                    <div class="flex items-center gap-4 text-xs">
-                      <span class="flex items-center gap-1.5"><span class="inline-block w-3 h-3 rounded-full" style="background:#3b82f6;"></span> Current file</span>
-                      <span class="flex items-center gap-1.5"><span class="inline-block w-3 h-3 rounded-full" style="background:#0d9488;"></span> Depends on (efferent)</span>
-                      <span class="flex items-center gap-1.5"><span class="inline-block w-3 h-3 rounded-full" style="background:#7c3aed;"></span> Depended by (afferent)</span>
-                    </div>
-                  </div>
-                  <div id="file-deps-diagram" class="w-full" style="min-height:360px;"></div>
-                </div>
-              </div>
-
-              <!-- Panels -->
-              <div class="space-y-6">
-                <!-- Classes/Structs & Functions/Methods -->
-                <div>
-                  <div class="dashboard-card p-6">
-                    <div class="flex items-center justify-between mb-6">
-                      <h3 class="text-lg font-bold text-gray-900">Classes/Structs</h3>
-                      <span class="text-sm text-gray-500 font-medium" x-text="classes.length + ' total'"></span>
-                    </div>
-                    <div class="overflow-x-auto -mx-6 px-6">
-                      <table class="w-full text-sm">
-                        <thead>
-                          <tr class="border-b border-gray-200">
-                            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                              Name</th>
-                            <th
-                              class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                              MI</th>
-                            <th
-                              class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                              Cyclomatic</th>
-                            <th
-                              class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                              Instability</th>
-                            <th
-                              class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                              LCOM4</th>
-                            <th
-                              class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                              LLOC</th>
-                            <th
-                              class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                              Bugs</th>
-                          </tr>
-                        </thead>
-                        <tbody class="divide-y divide-gray-100">
-                          <template x-if="classes.length === 0">
-                            <tr>
-                              <td colspan="7" class="px-4 py-8 text-center text-gray-500">No classes/structs in this file</td>
-                            </tr>
-                          </template>
-                          <template x-for="c in classes" :key="c.name?.qualified || c.name?.short || Math.random()">
-                            <tr class="hover:bg-gray-50 transition-colors">
-                              <td class="px-4 py-3 font-medium text-gray-900" x-text="c.name ? c.name.qualified : '-' ">
-                              </td>
-                              <td class="px-4 py-3 text-right"><span :class="miBadgeClass(miRaw(c))"
-                                  class="badge-modern px-2 py-1 rounded-md text-xs" x-text="mi(c)"></span></td>
-                              <td class="px-4 py-3 text-right">
-                                <span class="px-2 py-1 rounded-md text-xs font-medium badge-modern"
-                                  :class="complexityBadgeClass(c?.stmts?.analyze?.complexity?.cyclomatic)"
-                                  x-text="c?.stmts?.analyze?.complexity?.cyclomatic ?? '-' "></span>
-                              </td>
-                              <td class="px-4 py-3 text-right text-gray-700 font-mono text-xs"
-                                x-text="fmtNumber(c.stmts?.analyze?.coupling?.instability)"></td>
-                              <td class="px-4 py-3 text-right text-gray-700 font-mono text-xs"
-                                x-text="fmtNumber(c.stmts?.analyze?.classCohesion?.lcom4)"></td>
-                              <td class="px-4 py-3 text-right text-gray-700 font-mono text-xs"
-                                x-text="c.stmts?.analyze?.volume?.lloc ?? '-' "></td>
-                              <td class="px-4 py-3 text-right text-gray-700 font-mono text-xs"
-                                x-text="fmtFixed(c.stmts?.analyze?.volume?.halsteadBugs,4)"></td>
-                            </tr>
-                          </template>
-                        </tbody>
-                      </table>
-                    </div>
-
-                    <h4 class="font-semibold text-gray-900 mt-8 mb-4">Functions/Methods</h4>
-                    <div class="overflow-x-auto -mx-6 px-6">
-                      <table class="w-full text-sm">
-                        <thead>
-                          <tr class="border-b border-gray-200">
-                            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                              Signature</th>
-                            <th
-                              class="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                              Cyclomatic</th>
-                          </tr>
-                        </thead>
-                        <tbody class="divide-y divide-gray-100">
-                          <template x-if="methods.length === 0">
-                            <tr>
-                              <td colspan="2" class="px-4 py-6 text-center text-gray-500">No functions/methods detected</td>
-                            </tr>
-                          </template>
-                          <template x-for="m in methods" :key="m.name?.qualified || m.name?.short || Math.random()">
-                            <tr class="hover:bg-gray-50 transition-colors">
-                              <td class="px-4 py-2.5 font-mono text-xs text-gray-700"
-                                x-text="m.name ? (m.name.describer || m.name.qualified || m.name.short) : '-' "></td>
-                              <td class="px-4 py-2.5 text-right">
-                                <span class="px-2 py-1 rounded-md text-xs font-medium badge-modern"
-                                  :class="complexityBadgeClass(m.stmts?.analyze?.complexity?.cyclomatic)"
-                                  x-text="m.stmts?.analyze?.complexity?.cyclomatic ?? '-' "></span>
-                              </td>
-                            </tr>
-                          </template>
-                        </tbody>
-                      </table>
-                    </div>
-
-                    <div class="mt-6 p-4 bg-blue-50 rounded-lg border border-blue-100">
-                      <p class="text-xs text-blue-800">
-                        <span class="font-semibold">💡 Tip:</span> Higher MI is better. Lower cyclomatic complexity
-                        keeps code simpler. LCOM4 close to 1 means cohesive classes/structs.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                <!-- Risks -->
-                <div>
-                  <div class="dashboard-card p-6">
-                    <div class="flex items-center justify-between mb-6">
-                      <h3 class="text-lg font-bold text-gray-900">Detected Risks <span
-                          class="text-base font-normal text-gray-500" x-text="'(' + risks.length + ')'"></span></h3>
-                      <div class="flex items-center gap-3 text-sm">
-                        <label class="inline-flex items-center gap-2 cursor-pointer">
-                          <input type="checkbox" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                            x-model="filters.onlyHigh" />
-                          <span class="text-gray-600">High only</span>
-                        </label>
-                        <label class="inline-flex items-center gap-2 cursor-pointer">
-                          <input type="checkbox" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                            x-model="filters.groupByCategory" />
-                          <span class="text-gray-600">Group</span>
-                        </label>
-                      </div>
-                    </div>
-
-                    <template x-if="risks.length === 0">
-                      <div class="text-center py-12">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                          stroke="currentColor" class="w-12 h-12 text-green-300 mx-auto mb-3">
-                          <path stroke-linecap="round" stroke-linejoin="round"
-                            d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-4.902Z" />
-                        </svg>
-                        <p class="text-sm font-medium text-gray-500">No risks detected</p>
-                        <p class="text-xs text-gray-500 mt-1">This file looks healthy!</p>
-                      </div>
-                    </template>
-
-                    <!-- Grouped view -->
-                    <template x-if="filters.groupByCategory && groupedRisksKeys.length">
-                      <div class="space-y-6">
-                        <template x-for="cat in groupedRisksKeys" :key="cat">
-                          <div>
-                            <div class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-3"
-                              x-text="cat || 'Uncategorized'"></div>
-                            <div class="space-y-3">
-                              <template x-for="r in groupedRisks[cat]">
-                                <div class="border rounded-xl p-4 hover:shadow-sm transition-all"
-                                  :class="riskCardClass(r) + ' bg-white'">
-                                  <div class="flex items-start justify-between gap-4">
-                                    <div class="flex-1 min-w-0">
-                                      <div class="flex items-center gap-2 mb-2">
-                                        <span class="text-sm font-semibold text-gray-900" x-text="r.title"></span>
-                                        <span class="px-2 py-1 rounded-md text-xs font-medium badge-modern"
-                                          :class="severityBadgeClass(r.severity)"
-                                          x-text="severityLevel(r.severity)"></span>
-                                      </div>
-                                      <p class="text-sm text-gray-600 mb-2" x-text="r.details"></p>
-                                      <template x-if="r.hint">
-                                        <div class="text-xs text-gray-500 bg-gray-50 rounded-lg p-2 mt-2">
-                                          <span class="font-semibold text-gray-700">💡 Fix:</span> <span
-                                            x-text="r.hint"></span>
-                                        </div>
-                                      </template>
-                                    </div>
-                                    <div class="text-right shrink-0">
-                                      <div class="text-xs font-medium text-gray-500 mb-1">Severity</div>
-                                      <div class="h-2 w-24 rounded-full bg-gray-200 overflow-hidden">
-                                        <div class="h-2 rounded-full transition-all duration-300"
-                                          :class="severityBarClass(r.severity)"
-                                          :style="`width: ${severityPct(r.severity)}%`"></div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </template>
-                            </div>
-                          </div>
-                        </template>
-                      </div>
-                    </template>
-
-                    <!-- Flat list -->
-                    <template x-if="!filters.groupByCategory && risksSorted.length">
-                      <div class="space-y-3">
-                        <template x-for="r in risksSorted">
-                          <div class="border rounded-xl p-4 hover:shadow-sm transition-all"
-                            :class="riskCardClass(r) + ' bg-white'">
-                            <div class="flex items-start justify-between gap-4">
-                              <div class="flex-1 min-w-0">
-                                <div class="flex items-center gap-2 mb-2">
-                                  <span class="text-sm font-semibold text-gray-900" x-text="r.title"></span>
-                                  <span class="px-2 py-1 rounded-md text-xs font-medium badge-modern"
-                                    :class="severityBadgeClass(r.severity)" x-text="severityLevel(r.severity)"></span>
-                                </div>
-                                <p class="text-sm text-gray-600 mb-2" x-text="r.details"></p>
-                                <template x-if="r.hint">
-                                  <div class="text-xs text-gray-500 bg-gray-50 rounded-lg p-2 mt-2">
-                                    <span class="font-semibold text-gray-700">💡 Fix:</span> <span
-                                      x-text="r.hint"></span>
-                                  </div>
-                                </template>
-                              </div>
-                              <div class="text-right shrink-0">
-                                <div class="text-xs font-medium text-gray-500 mb-1">Severity</div>
-                                <div class="h-2 w-24 rounded-full bg-gray-200 overflow-hidden">
-                                  <div class="h-2 rounded-full transition-all duration-300"
-                                    :class="severityBarClass(r.severity)" :style="`width: ${severityPct(r.severity)}%`">
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </template>
-                      </div>
-                    </template>
-
-                    <div class="mt-6 p-4 bg-amber-50 rounded-lg border border-amber-100" x-show="risks.length > 0">
-                      <p class="text-xs text-amber-800">
-                        <span class="font-semibold">📋 Note:</span> Risks are sorted by severity. Use the hints to plan
-                        your refactoring strategy.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-
-
             </div>
           </template>
         </div>
       </div>
+    </template>
   </div>
 
-  <!-- Glossary modal -->
+  <!-- Reading guide -->
   <div x-show="openGlossary" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4"
     style="backdrop-filter: blur(4px);">
     <div class="absolute inset-0 bg-black/40" @click="openGlossary=false"></div>
-    <div class="relative dashboard-card w-full max-w-3xl p-8 max-h-[90vh] overflow-y-auto">
+    <div class="relative soft-card w-full max-w-3xl p-8 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-6 pb-4 border-b border-gray-200">
-        <h3 class="text-xl font-bold text-gray-900">Metric Guide</h3>
-        <button class="text-gray-500 hover:text-gray-600 transition-colors p-1 rounded-lg hover:bg-gray-100"
-          @click="openGlossary=false">
+        <h2 class="card-title" style="font-size: 1.25rem;">Reading guide</h2>
+        <button class="text-gray-400 hover:text-gray-600 transition-colors p-1 rounded-lg hover:bg-gray-100"
+          @click="openGlossary=false" aria-label="Close reading guide">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
             class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
@@ -471,34 +272,34 @@ AST Metrics - Explorer
       </div>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
         <div class="p-4 bg-gray-50 rounded-xl">
-          <div class="font-semibold text-gray-900 mb-2">Maintainability Index (MI)</div>
-          <p class="text-gray-600 text-sm leading-relaxed">0–128. Higher is better. Aggregates complexity, size, and
-            churn. Aim ≥ 85.</p>
+          <div class="font-semibold text-gray-900 mb-2">Ease of maintenance</div>
+          <p class="text-gray-600 leading-relaxed">Maintainability index, 0 to 128. Higher is better: it mixes size,
+            complexity and comment density. Above 85 the file reads without effort.</p>
         </div>
         <div class="p-4 bg-gray-50 rounded-xl">
-          <div class="font-semibold text-gray-900 mb-2">Cyclomatic complexity</div>
-          <p class="text-gray-600 text-sm leading-relaxed">Number of independent paths. ≤ 10 is usually OK. Keep low to
-            ease testing.</p>
+          <div class="font-semibold text-gray-900 mb-2">Decision paths</div>
+          <p class="text-gray-600 leading-relaxed">Cyclomatic complexity: the number of independent routes through the
+            code. Each one is another case to test. Under 5 per method stays comfortable.</p>
         </div>
         <div class="p-4 bg-gray-50 rounded-xl">
-          <div class="font-semibold text-gray-900 mb-2">LCOM4</div>
-          <p class="text-gray-600 text-sm leading-relaxed">Class cohesion. 1 means cohesive. Higher implies split
-            responsibilities.</p>
+          <div class="font-semibold text-gray-900 mb-2">Responsibilities</div>
+          <p class="text-gray-600 leading-relaxed">LCOM4: groups of methods that never share data. One group means one
+            job. Several groups means several classes waiting to be extracted.</p>
         </div>
         <div class="p-4 bg-gray-50 rounded-xl">
-          <div class="font-semibold text-gray-900 mb-2">LLOC</div>
-          <p class="text-gray-600 text-sm leading-relaxed">Logical lines of code. Measures size. Prefer smaller units.
-          </p>
+          <div class="font-semibold text-gray-900 mb-2">Lines of code</div>
+          <p class="text-gray-600 leading-relaxed">Logical lines: statements only, blank lines and comments excluded.
+            It is the honest measure of how much there is to read.</p>
         </div>
         <div class="p-4 bg-gray-50 rounded-xl">
-          <div class="font-semibold text-gray-900 mb-2">Instability</div>
-          <p class="text-gray-600 text-sm leading-relaxed">0–1. Outgoing deps ratio. Close to 0 for stable modules,
-            close to 1 for volatile.</p>
+          <div class="font-semibold text-gray-900 mb-2">Neighborhood</div>
+          <p class="text-gray-600 leading-relaxed">Files this one imports, and files that import it. Many incoming
+            arrows mean every change here ripples outwards.</p>
         </div>
         <div class="p-4 bg-gray-50 rounded-xl">
-          <div class="font-semibold text-gray-900 mb-2">Halstead Bugs</div>
-          <p class="text-gray-600 text-sm leading-relaxed">Theoretical bugs density from Halstead volume. Use as a
-            relative indicator.</p>
+          <div class="font-semibold text-gray-900 mb-2">Severity of a risk</div>
+          <p class="text-gray-600 leading-relaxed">How far the file is from the rule threshold, not how urgent it is.
+            Critical and high are worth a look; low is often noise.</p>
         </div>
       </div>
     </div>
@@ -514,26 +315,50 @@ AST Metrics - Explorer
       // state
       files: [],
       risksByPath: {},
-      filters: { onlyHigh: false, groupByCategory: true },
+      filters: { onlyHigh: false },
       selected: null,
       risks: [],
       classes: [],
       methods: [],
 
-      // derived KPIs
-      worstMI: 0,
+      // header
+      breadcrumb: '',
+      fileName: '',
+      fileMeta: '',
+
+      // metrics
+      miValue: null,
+      miDisplay: '-',
+      miLevel: 'none',
       fileCyclomatic: 0,
       avgMethodCyclomatic: 0,
-      avgLCOM4Display: '-',
-      fileLLocDisplay: '-',
+      cycloLevel: 'none',
+      cycloQualifier: '',
+      cycloPct: 0,
+      lcomValue: null,
+      maxLcom: null,
+      lcomDisplay: '-',
+      lcomLevel: 'none',
+      lcomPct: 0,
+      llocValue: null,
+      llocDisplay: '-',
+      llocLevel: 'none',
+      llocQualifier: '',
+      llocPct: 0,
 
-      // risks grouping
-      groupedRisks: {},
-      groupedRisksKeys: [],
+      // diagnosis
+      insight: { level: 'none', text: '' },
+
+      // contents
+      contentGroups: [],
+      looseFunctions: [],
+      contentsSummary: '',
 
       // dependencies
       fileDeps: {},
       dict: {},
+      hasDeps: false,
+      neighborhoodSub: '',
 
       // ui
       openGlossary: false,
@@ -544,8 +369,6 @@ AST Metrics - Explorer
         this.risksByPath = _d.risks || {};
         this.fileDeps = _d.fileDeps || {};
         this.dict = _d.dictionary || {};
-        this.$watch('filters', () => this.rebuild(), { deep: true });
-        this.rebuild();
         const requestedFile = this.getFileQueryParam();
         if (requestedFile) {
           const fileToSelect = this.findFileByQueryParam(requestedFile);
@@ -559,10 +382,7 @@ AST Metrics - Explorer
         if (f) this.select(f);
       },
 
-      // helpers
-      fmtFixed(v, n) { return (typeof v === 'number') ? v.toFixed(n) : '-'; },
-      fmtNumber(v) { return (typeof v === 'number') ? (Number.isInteger(v) ? v : v.toFixed(2)) : '-'; },
-      fileRiskScore(f) { return f?.stmts?.analyze?.risk?.score || 0; },
+      // ---------- deep link ----------
       getFileQueryParam() {
         try {
           return new URLSearchParams(window.location.search).get('file');
@@ -589,170 +409,363 @@ AST Metrics - Explorer
           // no-op: URL sharing is best effort
         }
       },
-      collectTopLevelFunctions(f) {
-        const out = [];
-        const push = (fn) => { if (fn) out.push(fn); };
-        const st = f?.stmts;
-        (st?.stmtFunction || []).forEach(push);
-        (st?.stmtNamespace || []).forEach(ns => (ns?.stmts?.stmtFunction || []).forEach(push));
+
+      // ---------- formatting ----------
+      fmtNumber(v) { return (typeof v === 'number') ? (Number.isInteger(v) ? v : v.toFixed(2)) : '-'; },
+      formatMI(v) { return Number.isFinite(v) ? Number(v).toFixed(0) : '-'; },
+      miPct(v) { const x = Math.max(0, Math.min(128, Number(v) || 0)); return (x / 128 * 100).toFixed(0); },
+      miRaw(c) { return c?.stmts?.analyze?.maintainability?.maintainabilityIndex; },
+      miBadgeClass(v) {
+        const lvl = this.levelOfMI(v);
+        if (lvl === 'good') return 'bg-green-100 text-green-700';
+        if (lvl === 'warn') return 'bg-amber-100 text-amber-700';
+        if (lvl === 'bad') return 'bg-rose-100 text-rose-700';
+        return 'bg-slate-100 text-slate-500';
+      },
+      pluralize(n, word) { return n + ' ' + word + (n === 1 ? '' : (word.endsWith('s') ? 'es' : 's')); },
+
+      // ---------- severity, one rule per metric ----------
+      levelOfMI(v) {
+        if (typeof v !== 'number') return 'none';
+        if (v >= 85) return 'good';
+        if (v >= 65) return 'warn';
+        return 'bad';
+      },
+      levelOfCyclo(avg) {
+        if (typeof avg !== 'number' || avg <= 0) return 'none';
+        if (avg <= 5) return 'good';
+        if (avg <= 10) return 'warn';
+        return 'bad';
+      },
+      levelOfLcom(v) {
+        if (typeof v !== 'number' || v <= 0) return 'none';
+        if (v <= 1) return 'good';
+        if (v <= 3) return 'warn';
+        return 'bad';
+      },
+      levelOfLloc(v) {
+        if (typeof v !== 'number') return 'none';
+        if (v <= 200) return 'good';
+        if (v <= 400) return 'warn';
+        return 'bad';
+      },
+      // ---------- selection ----------
+      select(f) {
+        this.selected = f;
+        this.updateUrlWithSelectedFile(f);
+        window.dispatchEvent(new CustomEvent('explorer-file-selected', { detail: { path: f.path } }));
+        this.risks = (this.risksByPath[f.pathHash] || []).slice()
+          .sort((a, b) => (b.severity || 0) - (a.severity || 0));
+
+        const classes = f?.stmts?.stmtClass || [];
+        this.classes = classes;
+        const methodsFromClasses = classes.flatMap(c => (c?.stmts?.stmtFunction) || []);
+        const topLevelFunctions = this.collectTopLevelFunctions(f);
+        this.methods = this.dedupe([...methodsFromClasses, ...topLevelFunctions]);
+
+        this.buildHeader(f);
+        this.buildMetrics(f, classes, topLevelFunctions);
+        this.buildContents(classes, topLevelFunctions);
+        this.buildNeighborhood(f);
+        this.insight = this.buildInsight(f);
+
+        // Deferred so Alpine makes the diagram container visible first
+        this.$nextTick(() => this.renderDependencyDiagram(f));
+      },
+
+      dedupe(list) {
         const seen = new Set();
-        return out.filter(fn => {
-          const key = fn?.name?.qualified || fn?.name?.short || JSON.stringify(fn?.name || {});
+        return list.filter(m => {
+          const key = m?.name?.qualified || m?.name?.short || JSON.stringify(m?.name || {});
           if (seen.has(key)) return false;
           seen.add(key);
           return true;
         });
       },
-      fileMImax(f) {
-        let minMI = 128;
-        const classes = f?.stmts?.stmtClass || [];
-        if (!classes.length) return "-";
+      collectTopLevelFunctions(f) {
+        const out = [];
+        const st = f?.stmts;
+        (st?.stmtFunction || []).forEach(fn => { if (fn) out.push(fn); });
+        (st?.stmtNamespace || []).forEach(ns => (ns?.stmts?.stmtFunction || []).forEach(fn => { if (fn) out.push(fn); }));
+        return this.dedupe(out);
+      },
+
+      buildHeader(f) {
+        const parts = (f.shortPath || f.path || '').split('/');
+        this.fileName = parts[parts.length - 1] || (f.path || '');
+        this.breadcrumb = parts.slice(0, -1).join(' / ');
+        const bits = [];
+        if (f.programmingLanguage) bits.push(f.programmingLanguage);
+        if (f.isTest) bits.push('test file');
+        const commits = f.commits?.count || 0;
+        if (commits > 0) bits.push(this.pluralize(commits, 'commit'));
+        this.fileMeta = bits.join(' · ');
+      },
+
+      buildMetrics(f, classes, topLevelFunctions) {
+        // Maintainability: worst class, or the file itself when it holds no class
+        let mi = null;
         for (const c of classes) {
-          const mi = c?.stmts?.analyze?.maintainability?.maintainabilityIndex;
-          if (typeof mi === 'number' && mi < minMI) minMI = mi;
+          const v = this.miRaw(c);
+          if (typeof v === 'number' && (mi === null || v < mi)) mi = v;
         }
-        return minMI;
-      },
-      displayWorstMI(f) { const v = this.fileMImax(f); return Number.isFinite(v) ? `worst MI: ${v.toFixed(0)}` : ''; },
-      nbRisksFor(f) { return (this.risksByPath[f.pathHash] || []).length; },
-      matchesFilters(f) {
-        const q = (this.filters.q || '').toLowerCase();
-        if (q && !f.path.toLowerCase().includes(q) && !(f.shortPath || '').toLowerCase().includes(q)) return false;
-        const miVal = this.fileMImax(f);
-        if (!isNaN(this.filters.miMax) && miVal > this.filters.miMax) return false;
-        if (this.nbRisksFor(f) < (this.filters.minRisks || 0)) return false;
-        const currentLang = '{{ currentLanguage }}';
-        if (currentLang && currentLang !== 'All' && f.programmingLanguage !== currentLang) return false;
-        return true;
-      },
-      rebuild() {
-        const filtered = this.files.filter(f => this.matchesFilters(f));
-        const byDir = {};
-        for (const f of filtered) {
-          const parts = (f.shortPath || f.path).split('/');
-          let acc = '';
-          for (let i = 0; i < parts.length - 1; i++) {
-            acc += (i ? '/' : '') + parts[i];
-            if (!byDir[acc]) byDir[acc] = { files: [] };
-          }
-          const dir = parts.slice(0, -1).join('/');
-          if (!byDir[dir]) byDir[dir] = { files: [] };
-          byDir[dir].files.push(f);
+        if (mi === null) {
+          const v = f?.stmts?.analyze?.maintainability?.maintainabilityIndex;
+          if (typeof v === 'number') mi = v;
         }
-        const rootsMap = {};
-        Object.keys(byDir).forEach(d => {
-          const root = (d.split('/')[0]) || '/';
-          if (!rootsMap[root]) rootsMap[root] = [];
-          rootsMap[root].push(d);
-        });
-        this.tree = Object.keys(rootsMap).sort().map(root => ({
-          name: root,
-          expanded: true,
-          dirs: rootsMap[root].sort().map(d => ({
-            name: d,
-            path: d,
-            expanded: true,
-            files: (byDir[d].files || []).sort((a, b) => a.path.localeCompare(b.path))
-          }))
-        }));
-      },
-      select(f) {
-        this.selected = f;
-        this.updateUrlWithSelectedFile(f);
-        window.dispatchEvent(new CustomEvent('explorer-file-selected', { detail: { path: f.path } }));
-        this.risks = (this.risksByPath[f.pathHash] || []).slice();
-        const classes = f?.stmts?.stmtClass || [];
-        this.classes = classes;
-        const methodsFromClasses = classes.flatMap(c => (c?.stmts?.stmtFunction) || []);
-        const topLevelFunctions = this.collectTopLevelFunctions(f);
-        const allFunctionsAndMethods = [...methodsFromClasses, ...topLevelFunctions];
-        const seenFunctionsAndMethods = new Set();
-        this.methods = allFunctionsAndMethods.filter(m => {
-          const key = m?.name?.qualified || m?.name?.short || JSON.stringify(m?.name || {});
-          if (seenFunctionsAndMethods.has(key)) return false;
-          seenFunctionsAndMethods.add(key);
-          return true;
-        });
+        this.miValue = mi;
+        this.miDisplay = this.formatMI(mi);
+        this.miLevel = this.levelOfMI(mi);
 
-        // KPIs
-        this.worstMI = this.fileMImax(f) || 0;
-        const classCyclo = classes
-          .map(c => c?.stmts?.analyze?.complexity?.cyclomatic)
-          .filter(x => typeof x === 'number');
-        const classCycloSum = classCyclo.length ? classCyclo.reduce((a, b) => a + b, 0) : 0;
-        const functionCyclo = topLevelFunctions
-          .map(fn => fn?.stmts?.analyze?.complexity?.cyclomatic)
-          .filter(x => typeof x === 'number');
-        const functionCycloSum = functionCyclo.length ? functionCyclo.reduce((a, b) => a + b, 0) : 0;
-        const computedFileCyclo = classes.length ? classCycloSum : functionCycloSum;
+        // Decision paths: file total, judged on the average per method
+        const sum = (arr) => arr.reduce((a, b) => a + b, 0);
+        const classCyclo = classes.map(c => c?.stmts?.analyze?.complexity?.cyclomatic).filter(x => typeof x === 'number');
+        const functionCyclo = topLevelFunctions.map(fn => fn?.stmts?.analyze?.complexity?.cyclomatic).filter(x => typeof x === 'number');
+        const computed = classes.length ? sum(classCyclo) : sum(functionCyclo);
         const rawFileCyclo = f?.stmts?.analyze?.complexity?.cyclomatic;
-        this.fileCyclomatic = computedFileCyclo > 0 ? computedFileCyclo : (typeof rawFileCyclo === 'number' ? rawFileCyclo : 0);
+        this.fileCyclomatic = computed > 0 ? computed : (typeof rawFileCyclo === 'number' ? rawFileCyclo : 0);
 
-        const methodCyclo = this.methods
-          .map(m => m?.stmts?.analyze?.complexity?.cyclomatic)
-          .filter(x => typeof x === 'number');
-        this.avgMethodCyclomatic = methodCyclo.length ? (methodCyclo.reduce((a, b) => a + b, 0) / methodCyclo.length) : 0;
-        // lcom4 = 0 means the class has no method to measure cohesion on: it is not averaged
+        const methodCyclo = this.methods.map(m => m?.stmts?.analyze?.complexity?.cyclomatic).filter(x => typeof x === 'number');
+        this.avgMethodCyclomatic = methodCyclo.length ? (sum(methodCyclo) / methodCyclo.length) : 0;
+        this.cycloLevel = this.levelOfCyclo(this.avgMethodCyclomatic);
+        this.cycloQualifier = this.avgMethodCyclomatic <= 0 ? 'nothing to branch on'
+          : this.avgMethodCyclomatic <= 5 ? 'low'
+            : this.avgMethodCyclomatic <= 10 ? 'moderate'
+              : this.avgMethodCyclomatic <= 20 ? 'high' : 'very high';
+        this.cycloPct = Math.min(100, Math.round(this.avgMethodCyclomatic / 10 * 100));
+
+        // Responsibilities: lcom4 = 0 means there was no method to measure
         const lcom = classes.map(c => c?.stmts?.analyze?.classCohesion?.lcom4).filter(x => typeof x === 'number' && x > 0);
-        this.avgLCOM4Display = lcom.length ? (lcom.reduce((a, b) => a + b, 0) / lcom.length).toFixed(2) : '-';
-        const vol = f?.stmts?.analyze?.volume;
-        const fileLLOC = (vol && typeof vol.lloc === 'number') ? vol.lloc : null;
-        if (fileLLOC !== null) this.fileLLocDisplay = String(fileLLOC); else {
-          const classLL = classes.map(c => c?.stmts?.analyze?.volume?.lloc).filter(x => typeof x === 'number');
-          this.fileLLocDisplay = classLL.length ? String(classLL.reduce((a, b) => a + b, 0)) : '-';
+        this.lcomValue = lcom.length ? sum(lcom) / lcom.length : null;
+        this.maxLcom = lcom.length ? Math.max(...lcom) : null;
+        this.lcomDisplay = this.lcomValue === null ? '-'
+          : (Number.isInteger(this.lcomValue) ? String(this.lcomValue) : this.lcomValue.toFixed(1));
+        this.lcomLevel = this.levelOfLcom(this.maxLcom);
+        this.lcomPct = this.lcomValue ? Math.round(100 / Math.max(1, this.lcomValue)) : 0;
+
+        // Lines of code
+        const fileLloc = f?.stmts?.analyze?.volume?.lloc;
+        let lloc = (typeof fileLloc === 'number' && fileLloc > 0) ? fileLloc : null;
+        if (lloc === null) {
+          const parts = [...classes, ...topLevelFunctions]
+            .map(x => x?.stmts?.analyze?.volume?.lloc).filter(x => typeof x === 'number');
+          lloc = parts.length ? sum(parts) : null;
+        }
+        this.llocValue = lloc;
+        this.llocDisplay = lloc === null ? '-' : String(lloc);
+        this.llocLevel = this.levelOfLloc(lloc);
+        this.llocQualifier = lloc === null ? 'not measured'
+          : lloc === 0 ? 'declarations only'
+              : lloc <= 200 ? 'comfortable size'
+                : lloc <= 400 ? 'getting long' : 'oversized';
+        this.llocPct = lloc === null ? 0 : Math.min(100, Math.round(lloc / 400 * 100));
+      },
+
+      buildContents(classes, topLevelFunctions) {
+        const methodEntry = (m) => {
+          const cyclo = m?.stmts?.analyze?.complexity?.cyclomatic;
+          return {
+            key: m?.name?.qualified || m?.name?.short || Math.random().toString(36),
+            name: m?.name?.short || m?.name?.describer || m?.name?.qualified || '-',
+            qualified: m?.name?.qualified || '',
+            cyclo: typeof cyclo === 'number' ? cyclo : '-',
+            level: typeof cyclo === 'number' ? (cyclo <= 5 ? 'none' : cyclo <= 10 ? 'warn' : 'bad') : 'none',
+          };
+        };
+        this.contentGroups = classes.map(c => {
+          const methods = (c?.stmts?.stmtFunction || []).map(methodEntry);
+          const lloc = c?.stmts?.analyze?.volume?.lloc;
+          const lcom = c?.stmts?.analyze?.classCohesion?.lcom4;
+          const meta = [
+            this.pluralize(methods.length, 'method'),
+            (typeof lloc === 'number' ? lloc + ' lines' : null),
+            (typeof lcom === 'number' && lcom > 1 ? lcom + ' method groups' : null),
+          ].filter(Boolean).join(' · ');
+          return {
+            key: c?.name?.qualified || c?.name?.short || Math.random().toString(36),
+            name: c?.name?.short || c?.name?.qualified || '-',
+            qualified: c?.name?.qualified || '',
+            mi: this.miRaw(c),
+            meta: meta,
+            methods: methods,
+          };
+        });
+        this.looseFunctions = topLevelFunctions.map(methodEntry);
+        const nMethods = this.contentGroups.reduce((a, c) => a + c.methods.length, 0);
+        const summary = [];
+        if (this.contentGroups.length) summary.push(this.pluralize(this.contentGroups.length, 'class'));
+        if (nMethods) summary.push(this.pluralize(nMethods, 'method'));
+        if (this.looseFunctions.length) summary.push(this.pluralize(this.looseFunctions.length, 'function'));
+        this.contentsSummary = summary.join(' · ');
+      },
+
+      buildNeighborhood(f) {
+        const deps = this.fileDeps[f.pathHash] || {};
+        const eff = (deps.efferent || []).length;
+        const aff = (deps.afferent || []).length;
+        this.hasDeps = eff > 0 || aff > 0;
+        if (!eff && !aff) {
+          this.neighborhoodSub = 'This file stands alone in the analyzed code.';
+        } else if (eff && !aff) {
+          this.neighborhoodSub = `This file uses ${this.pluralize(eff, 'file')}. Nobody uses it.`;
+        } else if (!eff && aff) {
+          this.neighborhoodSub = `This file uses nothing, but ${this.pluralize(aff, 'file')} depend on it.`;
+        } else {
+          this.neighborhoodSub = `This file uses ${this.pluralize(eff, 'file')} and is used by ${aff}.`;
+        }
+      },
+
+      // ---------- the sentence ----------
+      buildInsight(f) {
+        const nClasses = this.classes.length;
+        const nMethods = this.methods.length;
+        const mi = this.miDisplay;
+        const avg = this.avgMethodCyclomatic ? this.avgMethodCyclomatic.toFixed(1).replace(/\.0$/, '') : '0';
+        const groups = this.maxLcom;
+        const lloc = this.llocValue;
+        const num = (n) => `<strong>${n}</strong>`;
+
+        // Nothing measurable
+        if (!nClasses && !nMethods) {
+          return { level: 'none', text: 'Nothing to measure here: no class and no function was found in this file.' };
         }
 
-        // Risks grouping
-        this.computeGroupedRisks();
-
-        // Dependency diagram (deferred so Alpine x-show makes the container visible first)
-        this.$nextTick(() => this.renderDependencyDiagram(f));
-      },
-
-      // MI formatting
-      mi(c) { const v = this.miRaw(c); return typeof v === 'number' ? v.toFixed(2) : '-'; },
-      miRaw(c) { return c?.stmts?.analyze?.maintainability?.maintainabilityIndex; },
-      miPct(v) { const x = Math.max(0, Math.min(128, Number(v) || 0)); return (x / 128 * 100).toFixed(0); },
-      formatMI(v) { return Number.isFinite(v) ? v.toFixed(0) : '-'; },
-      miBadgeClass(v) {
-        const val = Number(v) || 0;
-        if (val >= 85) return 'bg-green-100 text-green-700 px-1.5 py-0.5 rounded text-xs';
-        if (val >= 65) return 'bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded text-xs';
-        return 'bg-rose-100 text-rose-700 px-1.5 py-0.5 rounded text-xs';
-      },
-      miBarClass(v) {
-        const val = Number(v) || 0;
-        if (val >= 85) return 'bg-green-500';
-        if (val >= 65) return 'bg-amber-500';
-        return 'bg-rose-500';
-      },
-
-      // Complexity formatting
-      complexityBand(v) { if (v <= 5) return 'Low'; if (v <= 10) return 'Moderate'; if (v <= 20) return 'High'; return 'Very high'; },
-      complexityTextClass(v) { if (v <= 5) return 'text-green-700'; if (v <= 10) return 'text-amber-700'; if (v <= 20) return 'text-orange-700'; return 'text-rose-700'; },
-      complexityBadgeClass(v) { if (v <= 5) return 'bg-green-100 text-green-700'; if (v <= 10) return 'bg-amber-100 text-amber-700'; if (v <= 20) return 'bg-orange-100 text-orange-700'; return 'bg-rose-100 text-rose-700'; },
-
-      // Risks
-      risksSorted() {
-        const list = this.risks.slice().sort((a, b) => (b.severity || 0) - (a.severity || 0));
-        return this.filters.onlyHigh ? list.filter(r => (r.severity || 0) >= 0.75) : list;
-      },
-      computeGroupedRisks() {
-        const byCat = {};
-        const list = this.risksSorted();
-        for (const r of list) {
-          const cat = r.category || r.rule || '';
-          if (!byCat[cat]) byCat[cat] = [];
-          byCat[cat].push(r);
+        // Types and structs only: nothing that runs
+        if (nClasses && !nMethods) {
+          return {
+            level: 'none',
+            text: `Declarations only: ${num(this.pluralize(nClasses, 'class'))} and no method, so there is nothing here to complicate.`
+          };
         }
-        this.groupedRisks = byCat;
-        this.groupedRisksKeys = Object.keys(byCat).sort((a, b) => a.localeCompare(b));
+
+        // Test files are read differently: branching and length matter, cohesion does not
+        if (f.isTest) {
+          if (this.cycloLevel === 'bad') {
+            return {
+              level: 'warn',
+              text: `Test file, but its checks branch a lot: ${num(avg + ' decision paths')} per function on average. Logic inside tests is logic nobody tests.`
+            };
+          }
+          if (this.llocLevel !== 'good' && lloc !== null) {
+            return {
+              level: this.llocLevel,
+              text: `Long test file: ${num(lloc + ' logical lines')} over ${num(this.pluralize(nMethods, 'function'))}. Fine as long as each case stays readable on its own.`
+            };
+          }
+          if (this.miLevel !== 'good' && this.miValue !== null) {
+            return {
+              level: this.miLevel,
+              text: `Dense test file: ease of maintenance at ${num(mi)} where 85 is comfortable. Test code gets reread more often than it gets written.`
+            };
+          }
+          return {
+            level: 'good',
+            text: `Calm test file: ${num(this.pluralize(nMethods, 'function'))}, each staying under 5 decision paths.`
+          };
+        }
+
+        // No class: a bag of functions
+        if (!nClasses) {
+          if (this.miLevel === 'bad') {
+            return {
+              level: 'bad',
+              text: `No class here, just ${num(this.pluralize(nMethods, 'function'))}, and ease of maintenance is down to ${num(mi)} where 85 is comfortable.`
+            };
+          }
+          if (this.cycloLevel === 'bad') {
+            return {
+              level: 'bad',
+              text: `Its ${num(this.pluralize(nMethods, 'function'))} average ${num(avg + ' decision paths')} each. Branch-heavy functions are the ones that break silently.`
+            };
+          }
+          if (this.llocLevel === 'bad') {
+            return {
+              level: 'bad',
+              text: `Readable functions, but ${num(lloc + ' logical lines')} in a single file is a lot to hold in your head at once.`
+            };
+          }
+          if (this.miLevel === 'warn') {
+            return {
+              level: 'warn',
+              text: `Its ${num(this.pluralize(nMethods, 'function'))} still read fine, but at ${num(mi)} the file is drifting below the comfortable 85 mark.`
+            };
+          }
+          if (this.cycloLevel === 'warn' || this.llocLevel === 'warn') {
+            return {
+              level: 'warn',
+              text: `No class here, just ${num(this.pluralize(nMethods, 'function'))} averaging ${num(avg + ' decision paths')} over ${num(lloc + ' logical lines')}. Watch the longest ones.`
+            };
+          }
+          return {
+            level: 'good',
+            text: `Straightforward file: ${num(this.pluralize(nMethods, 'function'))}, no class, and nothing branching hard.`
+          };
+        }
+
+        // Maintainability is the loudest signal
+        if (this.miLevel === 'bad') {
+          const because = (this.llocLevel !== 'good' && lloc !== null) ? `mostly because of its ${num(lloc + ' logical lines')}.`
+            : (this.cycloLevel !== 'good') ? `mostly because its methods carry ${num(avg + ' decision paths')} on average.`
+              : (groups > 1) ? `mostly because ${num(groups + ' unrelated method groups')} share the same class.`
+                : 'even though no single metric stands out.';
+          return { level: 'bad', text: `Hard to maintain: ease of maintenance sits at ${num(mi)} where 85 is comfortable, ${because}` };
+        }
+
+        // Then branching
+        if (this.cycloLevel === 'bad') {
+          return {
+            level: 'bad',
+            text: `Readable overall, but its methods average ${num(avg + ' decision paths')} each, well past the 5 that keep a method testable.`
+          };
+        }
+
+        // Then cohesion: the sentence the maquette is built around
+        if (this.lcomLevel !== 'good' && this.lcomLevel !== 'none' && groups > 1) {
+          return {
+            level: this.lcomLevel,
+            text: `Readable, but ${num(groups + ' independent method groups')} live in the same class. Worth splitting if the file keeps growing.`
+          };
+        }
+
+        // Then the softer warnings
+        if (this.miLevel === 'warn') {
+          return {
+            level: 'warn',
+            text: `Still readable at ${num(mi)}, but drifting below the 85 mark that keeps a file comfortable to change.`
+          };
+        }
+        if (this.llocLevel !== 'good' && lloc !== null) {
+          return {
+            level: this.llocLevel,
+            text: `Metrics look sound, but ${num(lloc + ' logical lines')} in one file is a lot to read before touching anything.`
+          };
+        }
+        if (this.cycloLevel === 'warn') {
+          return {
+            level: 'warn',
+            text: `Nothing alarming, yet its methods already average ${num(avg + ' decision paths')}; the longest ones are close to needing a split.`
+          };
+        }
+
+        if (this.miValue === null) {
+          return {
+            level: 'good',
+            text: `Nothing stands out: ${num(this.pluralize(nMethods, 'method'))} across ${num(this.pluralize(nClasses, 'class'))}, all of them short and focused.`
+          };
+        }
+
+        return {
+          level: 'good',
+          text: `Healthy file: ease of maintenance at ${num(mi)}, one clear responsibility per class, and methods that stay short.`
+        };
+      },
+
+      // ---------- risks ----------
+      visibleRisks() {
+        return this.filters.onlyHigh ? this.risks.filter(r => (r.severity || 0) >= 0.75) : this.risks;
       },
       severityLevel(s) { const v = Number(s) || 0; if (v >= 0.9) return 'Critical'; if (v >= 0.75) return 'High'; if (v >= 0.5) return 'Medium'; if (v > 0) return 'Low'; return 'Info'; },
-      severityBadgeClass(s) { const v = Number(s) || 0; if (v >= 0.75) return 'bg-rose-100 text-rose-700'; if (v >= 0.5) return 'bg-orange-100 text-orange-700'; if (v > 0) return 'bg-amber-100 text-amber-700'; return 'bg-slate-100 text-slate-700'; },
-      severityBarClass(s) { const v = Number(s) || 0; if (v >= 0.75) return 'bg-rose-500'; if (v >= 0.5) return 'bg-orange-500'; if (v > 0) return 'bg-amber-500'; return 'bg-slate-400'; },
-      severityPct(s) { const v = Math.max(0, Math.min(1, Number(s) || 0)); return (v * 100).toFixed(0); },
-      riskCardClass(r) { return (r.severity || 0) >= 0.75 ? 'border-rose-200' : (r.severity || 0) >= 0.5 ? 'border-orange-200' : 'border-amber-200'; },
+      riskLevel(s) { const v = Number(s) || 0; if (v >= 0.75) return 'bad'; if (v >= 0.5) return 'warn'; if (v > 0) return 'warn'; return 'none'; },
 
       renderDependencyDiagram(f) {
         const container = document.getElementById('file-deps-diagram');
@@ -762,7 +775,7 @@ AST Metrics - Explorer
         if (!deps || (!deps.efferent?.length && !deps.afferent?.length)) return;
 
         const width = container.clientWidth || 600;
-        const height = 360;
+        const height = 320;
         const centerX = width / 2;
         const centerY = height / 2;
 
@@ -807,10 +820,10 @@ AST Metrics - Explorer
         });
 
         const simulation = d3.forceSimulation(nodes)
-          .force('link', d3.forceLink(links).id(d => d.id).distance(120))
+          .force('link', d3.forceLink(links).id(d => d.id).distance(110))
           .force('charge', d3.forceManyBody().strength(-300))
           .force('center', d3.forceCenter(centerX, centerY))
-          .force('collision', d3.forceCollide().radius(40));
+          .force('collision', d3.forceCollide().radius(36));
 
         const link = svg.append('g').selectAll('line')
           .data(links).join('line')
@@ -828,17 +841,17 @@ AST Metrics - Explorer
 
         const colorMap = { self: '#3b82f6', efferent: '#0d9488', afferent: '#7c3aed' };
         nodeG.append('circle')
-          .attr('r', d => d.type === 'self' ? 14 : 10)
+          .attr('r', d => d.type === 'self' ? 13 : 9)
           .attr('fill', d => colorMap[d.type])
           .attr('stroke', '#fff').attr('stroke-width', 2)
           .attr('opacity', 0.9);
 
         nodeG.append('text')
           .text(d => d.short.length > 18 ? d.short.slice(0, 16) + '..' : d.short)
-          .attr('dy', d => d.type === 'self' ? -20 : -16)
+          .attr('dy', d => d.type === 'self' ? -19 : -15)
           .attr('text-anchor', 'middle')
           .attr('font-size', '11px')
-          .attr('fill', '#374151')
+          .attr('fill', '#64748b')
           .attr('font-weight', d => d.type === 'self' ? '600' : '400');
 
         // Tooltip on hover — resolve hash to readable path

--- a/internal/report/templates/html/index.html
+++ b/internal/report/templates/html/index.html
@@ -10,404 +10,251 @@ AST Metrics - Overview
 
 {% block content %}
 
-<script>
-document.addEventListener('alpine:init', () => {
-    Alpine.store('helpModal', { open: false, title: '', video: '', link: '' });
-});
-</script>
-
-<!-- start: language tabs-->
-<div class="flex overflow-x-auto overflow-y-hidden border-b border-gray-200 whitespace-nowrap ">
-
-    <a tabindex="-1" href="index.html"
-        class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center {% if currentLanguage == " All"%}text-blue-600 border-blue-500{% endif %} bg-transparent border-b-2 sm:px-4 -px-1 focus:outline-none">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-        </svg>
-
-        <span class="mx-1 text-sm sm:text-base">
-            All languages <span class="text-xs sm:text-sm">({{ projectAggregated.Combined.ConcernedFiles|length }}
-                files)</span>
-        </span>
-    </a>
-
-    <!-- start: language tab -->
-    {% for languageName, lang in projectAggregated.ByProgrammingLanguage %}
-    <a tabindex="0" href="index_{{ languageName|langSlug }}.html"
-        class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center bg-transparent border-b-2 {% if currentLanguage == languageName %}text-blue-600 border-blue-500{% else %}text-gray-700   border-transparent{% endif %} sm:px-4 -px-1 hover:border-gray-400">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-        </svg>
-
-        <span class="mx-1 text-sm sm:text-base">
-            {{ languageName }} <span class="text-xs sm:text-sm">({{ lang.ConcernedFiles|length }} files)
-            </span>
-    </a>
-    {% endfor %}
-    <!-- end: language tab -->
-
-</div>
-<!-- end: language tabs-->
+{% include "partials/language_tabs.html" with pageBase="index" %}
 
 <!-- start alert -->
 {% if currentView.Comparaison %}
 {% if currentView.Comparaison.ChangedFiles|length > 0 %}
-<div class="flex bg-white rounded-2xl mt-6" style="box-shadow: 0 1px 3px rgba(0,0,0,0.05);">
-    <div class="rounded-l-2xl flex items-center justify-center w-12 bg-blue-100">
-        <svg class="w-6 h-6 text-blue-600 fill-current" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
-            <path
-                d="M20 3.33331C10.8 3.33331 3.33337 10.8 3.33337 20C3.33337 29.2 10.8 36.6666 20 36.6666C29.2 36.6666 36.6667 29.2 36.6667 20C36.6667 10.8 29.2 3.33331 20 3.33331ZM21.6667 28.3333H18.3334V25H21.6667V28.3333ZM21.6667 21.6666H18.3334V11.6666H21.6667V21.6666Z" />
-        </svg>
-    </div>
-
-    <div class="px-4 py-2 -mx-3">
-        <div class="mx-3">
-            <span class="font-normal text-gray-900">Code has changed</span>
-            <div class="text-sm text-gray-500 font-light mt-1">
-                Compared to {{ currentView.Comparaison.ComparedBranch }}.
-                <a href="compare.html" class="text-gray-600 hover:text-gray-900 underline">Explore changes</a>.
-            </div>
-        </div>
-    </div>
+<div class="insight mb-6">
+    <span class="dot sev-none" style="background-color:#3b82f6;"></span>
+    <span>Code has changed compared to <strong>{{ currentView.Comparaison.ComparedBranch }}</strong>.
+        <a href="compare{{ scopeSuffix }}.html"
+           class="text-blue-600 hover:underline font-medium">Explore the changes</a>.</span>
 </div>
 {% endif %}
 {% endif %}
 <!-- end alert -->
 
-{% set cm = currentView.Community %}
+<!-- start: verdict / summary -->
+<script>
+  // Raw aggregates injected by the template; the summary component below turns
+  // them into a plain-language verdict and two "going well / needs attention" lists.
+  window.__AST_SUMMARY_INPUT__ = {
+    ccn: {{ currentView.CyclomaticComplexityPerMethod.Avg|floatformat:2 }},
+    locPerMethod: {{ currentView.LocPerMethod.Avg|floatformat:1 }},
+    lcom: {{ currentView.Lcom4PerClass.Avg|floatformat:2 }},
+    mi: {{ currentView.MaintainabilityIndex.Avg|floatformat:1 }},
+    busFactor: {{ currentView.BusFactor }},
+    topCommitterPct: {% if currentView.TopCommitters|length > 0 %}{{ currentView.TopCommitters.0.Percentage|floatformat:1 }}{% else %}null{% endif %},
+    isolation: {% if currentView.TestQuality %}{{ currentView.TestQuality.GlobalIsolationScore|floatformat:1 }}{% else %}null{% endif %},
+    isolationLabel: {% if currentView.TestQuality %}"{{ currentView.TestQuality.IsolationLabel|escapejs }}"{% else %}null{% endif %},
+    godTests: {% if currentView.TestQuality %}{{ currentView.TestQuality.GodTests|length }}{% else %}0{% endif %},
+    nbTestFiles: {% if currentView.TestQuality %}{{ currentView.TestQuality.NbTestFiles }}{% else %}0{% endif %}
+  };
 
-<style>
-    /* Clean Google Labs / Antigravity style for dashboard */
-    #layered-map-dashboard {
-        background: transparent;
+  function codeSummary() {
+    const clamp = (v) => Math.max(0, Math.min(100, v));
+    return {
+      headline: '',
+      subline: '',
+      items: [],
+
+      init() {
+        const d = window.__AST_SUMMARY_INPUT__ || {};
+        const items = [];
+
+        // Each metric: plain-language label, technical name, judgment level,
+        // and a 0-100 sub-score used both for the bar and the overall score.
+        if (d.ccn > 0) {
+          items.push({
+            key: 'ccn', weight: 15,
+            label: 'Complexity per method',
+            href: 'classes{{ scopeSuffix }}.html?view=complex',
+            detail: 'Cyclomatic complexity · target < 5',
+            help: 'Average number of independent execution paths per method. Below 5 methods stay easy to read and test.',
+            display: d.ccn.toFixed(2),
+            level: d.ccn < 5 ? 'good' : (d.ccn < 10 ? 'warn' : 'bad'),
+            score: clamp((15 - d.ccn) / 13 * 100),
+            concern: d.ccn >= 10 ? 'methods are too complex' : null,
+          });
+        }
+        if (d.locPerMethod > 0) {
+          items.push({
+            key: 'size', weight: 10,
+            label: 'Method size',
+            href: 'metrics{{ scopeSuffix }}.html',
+            detail: 'Average lines per method · target < 20',
+            help: 'Average number of lines per method. Short methods are easier to name, test and reuse.',
+            display: d.locPerMethod.toFixed(0),
+            level: d.locPerMethod < 20 ? 'good' : (d.locPerMethod < 40 ? 'warn' : 'bad'),
+            score: clamp((60 - d.locPerMethod) / 50 * 100),
+            concern: d.locPerMethod >= 40 ? 'methods are too long' : null,
+          });
+        }
+        if (d.lcom > 0) {
+          items.push({
+            key: 'lcom', weight: 10,
+            label: 'Focused classes',
+            href: 'classes{{ scopeSuffix }}.html?view=cohesion',
+            detail: 'LCOM4 cohesion · target close to 1',
+            help: 'Average number of unrelated responsibility groups per class. 1 means each class does one thing.',
+            display: d.lcom.toFixed(1),
+            level: d.lcom <= 1.7 ? 'good' : (d.lcom <= 2.5 ? 'warn' : 'bad'),
+            score: clamp((4 - d.lcom) / 3 * 100),
+            concern: d.lcom > 2.5 ? 'classes mix several responsibilities' : null,
+          });
+        }
+        if (d.mi > 0) {
+          items.push({
+            key: 'mi', weight: 25,
+            label: 'Ease of maintenance',
+            href: 'classes{{ scopeSuffix }}.html?view=maintainability',
+            detail: 'Maintainability Index · target > 85',
+            help: 'Composite of size, complexity and Halstead volume (0-128). Above 85 the code is comfortable to work with.',
+            display: d.mi.toFixed(0),
+            level: d.mi >= 85 ? 'good' : (d.mi >= 65 ? 'warn' : 'bad'),
+            score: clamp((d.mi - 40) / 60 * 100),
+            concern: d.mi < 65 ? 'maintainability is low' : (d.mi < 85 ? 'maintainability is slipping' : null),
+          });
+        }
+        if (d.isolation !== null && d.nbTestFiles > 0) {
+          const detail = [
+            d.isolationLabel,
+            `${d.nbTestFiles} test file${d.nbTestFiles === 1 ? '' : 's'}`,
+            (d.godTests > 0 ? `${d.godTests} touching five structures or more` : null),
+          ].filter(Boolean).join(' · ');
+          items.push({
+            key: 'tests', weight: 25,
+            label: 'Test isolation',
+            href: 'testquality{{ scopeSuffix }}.html',
+            detail: detail + ' · target ≥ 80',
+            help: 'How few structures a single test touches. A focused test tells you precisely what broke; a test that touches everything breaks for unrelated reasons.',
+            display: d.isolation.toFixed(0),
+            level: d.isolation >= 80 ? 'good' : (d.isolation >= 50 ? 'warn' : 'bad'),
+            score: clamp(d.isolation),
+            concern: d.isolation < 50 ? 'the tests touch too much at once' : (d.isolation < 80 ? 'some tests touch too much at once' : null),
+          });
+        }
+        if (d.busFactor > 0) {
+          const bf = d.busFactor;
+          items.push({
+            key: 'bus', weight: 15,
+            label: 'People who carry the project',
+            href: 'busfactor{{ scopeSuffix }}.html',
+            detail: 'Bus factor · target ≥ 3' + (d.topCommitterPct ? ` · top contributor: ${d.topCommitterPct.toFixed(0)}% of commits` : ''),
+            help: 'Minimum number of people whose departure would endanger the project. The higher, the safer.',
+            display: String(bf),
+            level: bf >= 3 ? 'good' : (bf === 2 ? 'warn' : 'bad'),
+            score: bf >= 4 ? 100 : ({ 1: 15, 2: 50, 3: 80 }[bf] || 0),
+            concern: bf === 1 ? 'a single person carries it' : (bf === 2 ? 'only two people really know it' : null),
+          });
+        }
+
+        // Single list, healthy metrics first, critical ones last (reads top-down
+        // like a report: what holds, then what to fix).
+        const order = { good: 0, warn: 1, bad: 2 };
+        this.items = items.slice().sort((a, b) => order[a.level] - order[b.level]);
+
+        // Headline: judge the code itself on the four structural metrics.
+        const structural = items.filter(i => ['ccn', 'size', 'lcom', 'mi'].includes(i.key));
+        const badCount = structural.filter(i => i.level === 'bad').length;
+        const warnCount = structural.filter(i => i.level === 'warn').length;
+        if (structural.length === 0) {
+          this.headline = 'Not enough data to judge this codebase.';
+        } else if (badCount === 0 && warnCount <= 1) {
+          this.headline = 'Your code is in good shape.';
+        } else if (badCount === 0) {
+          this.headline = 'Your code is in decent shape.';
+        } else {
+          this.headline = 'Your code needs attention.';
+        }
+
+        // Subline: the concerns, phrased as one sentence. Tests and bus factor
+        // first: they are the concerns a reader can act on most directly.
+        const concernOrder = ['tests', 'bus', 'mi', 'ccn', 'size', 'lcom'];
+        const concerns = concernOrder
+          .map(k => items.find(i => i.key === k)?.concern)
+          .filter(Boolean);
+        if (concerns.length === 0) {
+          this.subline = items.length ? 'No weak point stands out.' : '';
+        } else {
+          let sentence;
+          if (concerns.length === 1) sentence = concerns[0];
+          else sentence = concerns.slice(0, -1).join(', ') + ', and ' + concerns[concerns.length - 1];
+          this.subline = sentence.charAt(0).toUpperCase() + sentence.slice(1) + '.';
+        }
+      },
+
+      dotClass(level) { return 'sev-' + (level || 'none'); },
+      barClass(level) { return 'sev-' + (level || 'none'); },
     }
+  }
+</script>
 
-    .dashboard-card {
-        background: white;
-        border: 1px solid #e2e8f0;
-        border-radius: 16px;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        position: relative;
-        overflow: hidden;
-    }
+<div x-data="codeSummary()" x-init="init()" class="page-hero animate-fade-in-up">
+  <p class="page-kicker mb-3">
+    {{ currentView.ConcernedFiles|length }} {% if scopeKind != "all" %}{{ scopeLabel }} {% endif %}files
+    &middot; analyzed on {{ datetime }}
+  </p>
+  <h1 class="verdict-title max-w-4xl">
+    <span x-text="headline"></span>
+    <span class="verdict-muted block" x-show="subline" x-text="subline"></span>
+  </h1>
 
-    .dashboard-card:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-        border-color: #cbd5e1;
-    }
-
-    .dashboard-card::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, #3b82f6, #8b5cf6);
-        opacity: 0;
-        transition: opacity 0.3s ease;
-    }
-
-    .dashboard-card:hover::before {
-        opacity: 1;
-    }
-
-    .metric-value {
-        font-family: var(--font-mono);
-        letter-spacing: -0.05em;
-    }
-
-    .contributor-avatar {
-        width: 36px;
-        height: 36px;
-        border-radius: 50%;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: 600;
-        font-size: 14px;
-        color: white;
-        flex-shrink: 0;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    }
-
-    .contributor-avatar-small {
-        width: 28px;
-        height: 28px;
-        font-size: 11px;
-    }
-</style>
-
-<!-- start: bento grid -->
-<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-6">
-    <!-- Code Health Bubble Chart - Hero Card (2x2) -->
-    <div class="col-span-1 md:col-span-2 lg:col-span-2 row-span-2 dashboard-card p-6 animate-fade-in-up stagger-1" style="border: 2px solid #e2e8f0;">
-        <div class="flex items-center justify-between mb-3">
-            <div>
-                <h5 class="text-xl font-bold text-gray-900 mb-1">Code Health</h5>
-                <p class="text-xs text-gray-500 leading-relaxed">Each bubble is a class (or file). Color = complexity, size = lines of code, glow = git activity.</p>
-            </div>
-        </div>
-        <script id="bubble-explorer-url" type="application/json">"explorer{% if currentLanguage != "All" %}_{{ currentLanguage|langSlug }}{% endif %}.html"</script>
-        {% include "componentBubbleChart.html" %}
-    </div>
-
-    <!-- Complexity Card -->
-    <div class="dashboard-card p-5 animate-fade-in-up stagger-3">
-        <div class="flex items-start justify-between">
-            <div>
-                <h5 class="text-2xl font-semibold text-gray-900 mb-0.5 metric-value tracking-tight">
-                    {{ currentView.CyclomaticComplexityPerMethod.Avg | floatformat:2 }}
-                </h5>
-                <p class="text-xs font-medium text-gray-500 flex items-center gap-2 mb-3">
-                    {% if currentView.Comparaison %}
-                    {% include 'componentComparaisonBadge.html' with comparaisonMode='lowIsBetter' diff=currentView.Comparaison.AverageCyclomaticComplexityPerMethod round=2 %}
-                    {% endif %}
-                    Complexity / Method
-                </p>
-            </div>
-            <button x-data @click="Object.assign($store.helpModal, { open: true, title: 'Cyclomatic Complexity', video: 'https://ast-metrics.dev/animations/Cyclomatic-complexity.webm', link: 'https://ast-metrics.dev/metrics/cyclomatic-complexity/' })" class="text-gray-300 hover:text-blue-500 transition-colors flex items-center gap-1" title="Watch video explanation">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.91 11.672a.375.375 0 010 .656l-5.603 3.113a.375.375 0 01-.557-.328V8.887c0-.286.307-.466.557-.327l5.603 3.112z" /></svg>
-            </button>
-        </div>
-        <div class="card-graph mt-3">
-            {{ currentView|barchartCyclomaticByMethodRepartition}}
-        </div>
-        <p class="mt-3 text-xs text-gray-500 border-t border-gray-100 pt-2">
-            Avg. decision paths per method. Lower is simpler.
-        </p>
-    </div>
-
-    <!-- Class Cohesion Card -->
-    <div class="dashboard-card p-5 animate-fade-in-up stagger-3">
-        <div class="flex items-start justify-between">
-            <div>
-                <h5 class="text-2xl font-semibold text-gray-900 mb-0.5 metric-value tracking-tight flex items-center gap-2">
-                    {% set color="red" %}
-                    {% if currentView.Lcom4PerClass.Avg < 1.7 %} {% set color="emerald" %} {% elif currentView.Lcom4PerClass.Avg> 1.7 %} {% set color="amber" %} {% endif %}
-                        <span class="text-{{ color }}-600">{{ currentView.Lcom4PerClass.Avg | floatformat:1 }}</span>
-                </h5>
-                <p class="text-xs font-medium text-gray-500 flex items-center gap-2 mb-3">
-                    {% if currentView.Comparaison %}
-                    {% include 'componentComparaisonBadge.html' with comparaisonMode='lowIsBetter' diff=currentView.Comparaison.AverageLcom4 round=2 %}
-                    {% endif %}
-                    Class Cohesion
-                </p>
-            </div>
-            <button x-data @click="Object.assign($store.helpModal, { open: true, title: 'Class Cohesion (LCOM4)', video: 'https://ast-metrics.dev/animations/lcom.webm', link: 'https://ast-metrics.dev/metrics/lcom4/' })" class="text-gray-300 hover:text-blue-500 transition-colors flex items-center gap-1" title="Watch video explanation">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.91 11.672a.375.375 0 010 .656l-5.603 3.113a.375.375 0 01-.557-.328V8.887c0-.286.307-.466.557-.327l5.603 3.112z" /></svg>
-            </button>
-        </div>
-        <div class="card-graph mt-3">
-            {{ currentView|barchartLcomRepartition}}
-        </div>
-        <p class="mt-3 text-xs text-gray-500 border-t border-gray-100 pt-2">
-            How focused classes are. Closer to 1 is better.
-        </p>
-    </div>
-
-    <!-- Maintainability Card -->
-    <div class="dashboard-card p-5 animate-fade-in-up stagger-4">
-        <div>
-            <h5 class="text-2xl font-semibold text-gray-900 mb-0.5 metric-value tracking-tight flex items-center gap-2">
-                {% set color="red" %}
-                {% if currentView.MaintainabilityIndex.Avg > 84 %} {% set color="emerald" %} {% elif currentView.MaintainabilityIndex.Avg > 64 %} {% set color="amber" %} {% endif %}
-                <span class="text-{{ color }}-600">{{ currentView.MaintainabilityIndex.Avg | floatformat:0 }}</span>
-            </h5>
-            <p class="text-xs font-medium text-gray-500 flex items-center gap-2 mb-3">
-                {% if currentView.Comparaison %}
-                {% include 'componentComparaisonBadge.html' with comparaisonMode='highIsBetter' diff=currentView.Comparaison.AverageMI round=2 %}
-                {% endif %}
-                Maintainability Index
-            </p>
-        </div>
-        <div class="card-graph mt-3">
-            {{ currentView|barchartMaintainabilityIndexRepartition}}
-        </div>
-        <p class="mt-3 text-xs text-gray-500 border-t border-gray-100 pt-2">
-            Ease of maintenance. Higher is better (> 85).
-        </p>
-    </div>
-
-    <!-- LOC/Method Card -->
-    <div class="dashboard-card p-5 animate-fade-in-up stagger-4">
-        <div>
-            <h5 class="text-2xl font-semibold text-gray-900 mb-0.5 metric-value tracking-tight">
-                {{ currentView.LocPerMethod.Avg | floatformat:0 }}
-            </h5>
-            <p class="text-xs font-medium text-gray-500 flex items-center gap-2 mb-3">
-                {% if currentView.Comparaison %}
-                {% include 'componentComparaisonBadge.html' with comparaisonMode='lowIsBetter' diff=currentView.Comparaison.AverageLocPerMethod round=2 %}
-                {% endif %}
-                Method Size
-            </p>
-        </div>
-        <div class="card-graph mt-3">
-            {{ currentView|barchartLocPerMethodRepartition}}
-        </div>
-        <p class="mt-3 text-xs text-gray-500 border-t border-gray-100 pt-2">
-            Avg. lines per method. Ideally under 20.
-        </p>
-    </div>
-
-</div>
-
-<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-6">
-    <!-- Git Activity Card (1 col) -->
-    <div class="dashboard-card md:col-span-1 p-4 animate-fade-in-up stagger-5 mt-8">
-        {% if currentView.ResultOfGitAnalysis %}
-        <div class="mb-3">
-            <h5 class="text-xl font-bold text-gray-900 metric-value tracking-tight">
-                {{ currentView.CommitCountForPeriod | stringifyNumber }}
-            </h5>
-            <p class="text-xs text-gray-500">Commits (12m)</p>
-        </div>
-        <div class="card-graph w-full h-24 mb-3">
-            {{ currentView|lineChartGitActivity}}
-        </div>
-        <div class="overflow-x-auto">
-            <table class="w-full text-left border-collapse text-xs">
-                <thead>
-                    <tr class="text-xs text-gray-500 border-b border-gray-100">
-                        <th class="py-1 font-medium">Repo</th>
-                        <th class="py-1 font-medium">Total</th>
-                        <th class="py-1 font-medium">Imp.</th>
-                    </tr>
-                </thead>
-                <tbody class="text-xs text-gray-600">
-                    {% for commitAnalysis in currentView.ResultOfGitAnalysis %}
-                    <tr class="border-b border-gray-50 last:border-0 hover:bg-gray-50 transition-colors">
-                        <td class="py-1 font-medium text-gray-900 truncate max-w-[100px]" title="{{ commitAnalysis.ReportRootDir }}">
-                            {{ commitAnalysis.ReportRootDir|truncatechars:15 }}
-                        </td>
-                        <td class="py-1">{{ commitAnalysis.CountCommits }}</td>
-                        <td class="py-1">{{ commitAnalysis.CountCommitsForLanguage }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-        {% else %}
-        <div class="mb-3">
-            <h5 class="text-xl font-bold text-gray-900 metric-value tracking-tight">
-                {{ currentView.CommitCountForPeriod | stringifyNumber }}
-            </h5>
-            <p class="text-xs text-gray-500">Commits</p>
-        </div>
-        <div class="card-graph h-24">
-            {{ currentView|lineChartGitActivity}}
-        </div>
-        {% endif %}
-    </div>
-
-    <!-- Bus Factor Card -->
-    <div class="dashboard-card md:col-span-2 p-6 animate-fade-in-up stagger-5 mt-8">
-        <div class="flex items-start justify-between mb-4">
-            <div>
-                <h5 class="text-4xl font-bold text-gray-900 metric-value tracking-tight mb-1">
-                    {{ currentView.BusFactor }}
-                </h5>
-                <p class="text-sm font-medium text-gray-500 mb-1">Bus Factor</p>
-                <p class="text-xs text-gray-500">Min. key people who understand the code. Ideally > 3.</p>
-            </div>
-            <button x-data @click="Object.assign($store.helpModal, { open: true, title: 'Bus Factor', video: 'https://ast-metrics.dev/animations/bus-factor.webm', link: 'https://ast-metrics.dev/metrics/bus-factor/' })" class="text-gray-300 hover:text-blue-500 transition-colors flex items-center gap-1" title="Watch video explanation">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.91 11.672a.375.375 0 010 .656l-5.603 3.113a.375.375 0 01-.557-.328V8.887c0-.286.307-.466.557-.327l5.603 3.112z" /></svg>
-            </button>
-        </div>
-
-        <!-- Sparkline Timeline -->
-        {% if currentView.TopCommitters|length > 0 %}
-        <div class="mb-4">
-            <div class="flex items-end justify-between h-8 gap-0.5" id="sparkline-committers">
-                {% for committer in currentView.TopCommitters %}
-                {% if forloop.Counter <= 10 %}
-                <div class="flex-1 rounded-t opacity-80 hover:opacity-100 transition-opacity sparkline-bar" 
-                    data-count="{{ committer.Count }}"
-                    style="background-color: {{ committer.Name|contributorColor }};"
-                    title="{{ committer.Name }}: {{ committer.Count }} commits">
-                </div>
-                {% endif %}
-                {% endfor %}
-            </div>
-            <p class="text-xs text-gray-500 mt-1">Commit distribution</p>
-        </div>
-        <script>
-            // Normalize sparkline heights
-            (function() {
-                const bars = document.querySelectorAll('#sparkline-committers .sparkline-bar');
-                if (bars.length === 0) return;
-                
-                const counts = Array.from(bars).map(bar => parseInt(bar.getAttribute('data-count')) || 0);
-                const maxCount = Math.max(...counts, 1);
-                
-                bars.forEach((bar, index) => {
-                    const count = counts[index];
-                    const height = maxCount > 0 ? (count / maxCount) * 32 : 0;
-                    bar.style.height = Math.max(2, height) + 'px';
-                });
-            })();
-        </script>
-        {% endif %}
-
-        <!-- Top Contributors -->
-        <div class="border-t border-gray-100 pt-3">
-            <p class="text-xs font-medium text-gray-500 mb-2">Top Contributors</p>
-            <div class="space-y-1">
-                {% for committer in currentView.TopCommitters %}
-                <div class="flex justify-between items-center text-xs">
-                    <div class="flex items-center gap-2 flex-1 min-w-0">
-                        <div class="contributor-avatar contributor-avatar-small" style="background-color: {{ committer.Name|contributorColor }};">
-                            {{ committer.Name|contributorInitials }}
-                        </div>
-                        <span class="text-gray-900 truncate" title="{{ committer.Name }}">{{ committer.Name }}</span>
-                    </div>
-                    <span class="text-gray-500 bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-medium ml-2 flex-shrink-0">
-                        {{ committer.Percentage|floatformat:1 }}%
-                    </span>
-                </div>
-                {% endfor %}
-            </div>
-        </div>
-    </div>
-
-    <!-- Refactoring Candidates (2 cols) -->
-    <div class="col-span-1 md:col-span-1 dashboard-card p-6 animate-fade-in-up stagger-5 mt-8">
-        <div class="flex items-center justify-between mb-4">
-            <h5 class="text-lg font-semibold text-gray-900">Refactoring Candidates</h5>
-            <a href="risks.html" class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline">View all</a>
-        </div>
-        <p class="text-sm text-gray-500 mb-4">Components with low maintainability & high churn.</p>
-        <div class="overflow-x-auto">
-            {% include "componentTableRisks.html" with detailled=false linesToDisplay=5 %}
-        </div>
-    </div>
-</div>
-
-
-<!-- Help Modal -->
-<div x-data x-show="$store.helpModal.open" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4"
-    style="backdrop-filter: blur(4px);">
-    <div class="absolute inset-0 bg-black/40" @click="$store.helpModal.open = false"></div>
-    <div class="relative dashboard-card w-full max-w-2xl p-6 max-h-[90vh] overflow-y-auto">
-        <div class="flex items-center justify-between mb-4 pb-3 border-b border-gray-200">
-            <h3 class="text-lg font-semibold text-gray-900" x-text="$store.helpModal.title"></h3>
-            <button @click="$store.helpModal.open = false" class="text-gray-400 hover:text-gray-600 transition-colors">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
-            </button>
-        </div>
-        <video x-ref="helpVideo" :src="$store.helpModal.video" autoplay loop controls playsinline class="w-full rounded-lg mb-4"
-            x-effect="if (!$store.helpModal.open) { $refs.helpVideo?.pause(); $refs.helpVideo?.removeAttribute('src'); }"></video>
-        <a :href="$store.helpModal.link" target="_blank" rel="noopener noreferrer"
-            class="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline">
-            Read full documentation
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+  <!-- One row per metric, healthy ones first -->
+  <div class="mt-8">
+    <template x-if="items.length === 0">
+      <p class="text-sm text-gray-500 py-2">Not enough data to summarize this codebase.</p>
+    </template>
+    <template x-for="it in items" :key="it.key">
+      <div class="summary-row">
+        <span class="dot" :class="dotClass(it.level)"></span>
+        <a :href="it.href" class="summary-row-label group">
+          <span class="truncate group-hover:underline" x-text="it.label"></span>
+          <svg class="summary-row-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12l-7.5 7.5M21 12H3" />
+          </svg>
         </a>
+        <span class="text-slate-300 text-xs shrink-0" tabindex="0" :data-tip="it.help + ' ' + it.detail + '.'">&#9432;</span>
+        <div class="w-28 md:w-44 shrink-0 ml-auto">
+          <div class="meter" style="margin-top:0">
+            <div class="meter-fill" :class="barClass(it.level)" :style="`width:${it.score}%`"></div>
+          </div>
+        </div>
+        <span class="w-16 text-right font-mono text-lg font-bold text-gray-900" x-text="it.display"></span>
+      </div>
+    </template>
+  </div>
+
+  <!-- Who keeps this code alive -->
+  {% if currentView.TopCommitters|length > 0 %}
+  <div class="mt-8 pt-6 border-t border-slate-200/60 flex flex-wrap items-center gap-x-4 gap-y-3">
+    <p class="section-title">Team</p>
+    <div class="flex items-center">
+      {% for committer in currentView.TopCommitters %}
+      <span class="contributor-chip" style="background-color: {{ committer.Name|contributorColor }};"
+            title="{{ committer.Name }} &mdash; {{ committer.Count }} commits ({{ committer.Percentage|floatformat:1 }}%)">
+        {% set avatar = committer.Email|gravatarUrl:64 %}
+        {% if avatar %}<img src="{{ avatar }}" alt="" loading="lazy" decoding="async"
+             onerror="this.remove()" class="contributor-chip-img">{% endif %}
+        {{ committer.Name|contributorInitials }}
+      </span>
+      {% endfor %}
     </div>
+    <p class="text-sm text-gray-600 min-w-0">
+      <span class="font-semibold text-gray-900">{{ currentView.TopCommitters.0.Name }}</span>
+      signs <strong class="font-semibold text-gray-900">{{ currentView.TopCommitters.0.Percentage|floatformat:1 }}%</strong>
+      of the commits.
+      <a href="busfactor{{ scopeSuffix }}.html" class="text-blue-600 hover:underline font-medium whitespace-nowrap">See the team</a>
+    </p>
+  </div>
+  {% endif %}
 </div>
+<!-- end: verdict / summary -->
+
+<!-- start: code map -->
+<div class="soft-card mt-6 animate-fade-in-up stagger-2">
+    <div class="flex items-start justify-between gap-4 mb-4">
+        <div>
+            <h2 class="card-title">Code map</h2>
+            <p class="card-sub">One bubble per class. Size = lines of code, color = complexity, ring = recent git activity.</p>
+        </div>
+        <a href="classes{{ scopeSuffix }}.html"
+           class="shrink-0 text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline">Browse classes</a>
+    </div>
+    <script id="bubble-explorer-url" type="application/json">"explorer{{ scopeSuffix }}.html"</script>
+    {% include "componentBubbleChart.html" %}
+</div>
+<!-- end: code map -->
 
 {% endblock %}

--- a/internal/report/templates/html/layout.html
+++ b/internal/report/templates/html/layout.html
@@ -20,6 +20,11 @@
             --font-mono: 'JetBrains Mono', monospace;
         }
 
+        /* Quiet text is slate 500 (#64748b) on the white cards and on the
+           slate 50 page wash, and slate 600 (#475569) on tinted pills and
+           segmented tracks. Those are the lightest greys that still clear
+           the 4.5:1 contrast ratio the report is asserted against. */
+
         body {
             font-family: var(--font-sans);
             background-color: #f8fafc;
@@ -238,7 +243,7 @@
             font-weight: 600;
             letter-spacing: 0.14em;
             text-transform: uppercase;
-            color: #94a3b8;
+            color: #64748b;
         }
 
         .verdict-title {
@@ -254,7 +259,7 @@
         }
 
         /* Second half of the verdict, deliberately quieter than the first */
-        .verdict-muted { color: #94a3b8; }
+        .verdict-muted { color: #64748b; }
 
         .verdict-lead {
             font-size: 0.9375rem;
@@ -286,7 +291,7 @@
 
         .kpi-label {
             font-size: 11px;
-            color: #94a3b8;
+            color: #64748b;
             margin-top: 0.25rem;
             line-height: 1.4;
         }
@@ -314,7 +319,7 @@
         /* Every card says what it shows, in plain words */
         .card-sub {
             font-size: 0.8125rem;
-            color: #94a3b8;
+            color: #64748b;
             margin-top: 0.125rem;
         }
 
@@ -347,7 +352,7 @@
 
         .stat-tile-target {
             font-size: 11px;
-            color: #94a3b8;
+            color: #64748b;
             margin-top: 0.5rem;
         }
 
@@ -375,7 +380,7 @@
         .text-good { color: #15803d; }
         .text-warn { color: #b45309; }
         .text-bad { color: #b91c1c; }
-        .text-none { color: #94a3b8; }
+        .text-none { color: #64748b; }
 
         /* Level pill: "High risk", "Isolated", ... */
         .level-pill {
@@ -435,7 +440,7 @@
 
         .row-meta {
             font-size: 0.75rem;
-            color: #94a3b8;
+            color: #64748b;
             margin-top: 0.125rem;
         }
 
@@ -487,7 +492,7 @@
             width: 0.875rem;
             height: 0.875rem;
             flex-shrink: 0;
-            color: #94a3b8;
+            color: #64748b;
             opacity: 0;
             transform: translateX(-3px);
             transition: opacity 0.15s ease, transform 0.15s ease;
@@ -528,7 +533,7 @@
         }
 
         .nav-link--active:hover { background: #eff6ff; color: #1d4ed8; }
-        .nav-link--quiet { color: #94a3b8; }
+        .nav-link--quiet { color: #64748b; }
 
         .nav-icon { width: 1.125rem; height: 1.125rem; flex-shrink: 0; }
 
@@ -638,7 +643,7 @@
             font-weight: 600;
             letter-spacing: 0.12em;
             text-transform: uppercase;
-            color: #94a3b8;
+            color: #64748b;
         }
 
         /* Shared accessible CSS tooltips: any element with data-tip="..." shows a

--- a/internal/report/templates/html/layout.html
+++ b/internal/report/templates/html/layout.html
@@ -844,7 +844,7 @@
                 </nav>
             </div>
 
-            <!-- Share buttons -->
+            <!-- Project links -->
             <div class="flex items-center gap-2 px-4 pt-4 border-t border-gray-100">
                 <a aria-label="Visit Github repository of AST Metrics"
                     href="https://github.com/Halleck45/ast-metrics/"
@@ -855,10 +855,13 @@
                         </path>
                     </svg>
                 </a>
-                <a id="share-twitter" class="cursor-pointer p-1.5 rounded hover:bg-gray-100 text-gray-500 hover:text-gray-700 transition-colors">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M14.095479,10.316482L22.286354,1h-1.940718l-7.115352,8.087682L7.551414,1H1l8.589488,12.231093L1,23h1.940717l7.509372-8.542861L16.448587,23H23L14.095479,10.316482z M11.436522,13.338465l-0.871624-1.218704l-6.924311-9.68815h2.981339l5.58978,7.82155l0.867949,1.218704l7.26506,10.166271h-2.981339L11.436522,13.338465z" />
+                <a aria-label="Sponsor AST Metrics on GitHub"
+                    href="https://github.com/sponsors/Halleck45"
+                    class="flex items-center gap-1.5 p-1.5 rounded hover:bg-gray-100 text-gray-500 hover:text-pink-600 transition-colors">
+                    <svg viewBox="0 0 16 16" aria-hidden="true" class="h-5 w-5 fill-current">
+                        <path d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 0 0 8 13.393a20.561 20.561 0 0 0 3.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.749.749 0 0 1-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5ZM8 14.25l-.345.666a.752.752 0 0 0 .69 0L8 14.25Zm-.008-12.306C6.936 1.257 5.775.75 4.25.75 2.104.75 0 2.535 0 5.5c0 2.909 2.067 5.283 3.885 6.85a21.994 21.994 0 0 0 3.65 2.52l.028.014.008.004.001.001c.276.135.579.135.856 0l.001-.001.008-.004.028-.014a15.005 15.005 0 0 0 .459-.246 21.99 21.99 0 0 0 3.192-2.274C13.933 10.783 16 8.409 16 5.5c0-2.965-2.104-4.75-4.25-4.75-1.525 0-2.686.507-3.742 1.194Z" />
                     </svg>
+                    <span class="text-sm">Sponsor</span>
                 </a>
             </div>
         </aside>
@@ -872,47 +875,6 @@
                 {% block content %}{% endblock %}
             </div>
 
-            <footer class="bg-white ">
-                <div
-                    class="container flex flex-col items-center justify-end p-6 mx-auto space-y-4 sm:space-y-0 sm:flex-row">
-                    <div class="flex -mx-2">
-
-                        <a aria-label="Visit Twitter account of Halleck45" href="https://twitter.com/Halleck45"
-                            class="mx-2 text-gray-600 transition-colors duration-300" aria-label="Twitter">
-                            <svg class="w-5 h-5 fill-current" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                fill="currentColor" viewBox="0 0 16 16">
-                                <path
-                                    d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z" />
-                            </svg>
-                        </a>
-
-                        <a aria-label="Visit LinkedIn account of Jean-François Lépine"
-                            href="https://www.linkedin.com/in/jean-fran%C3%A7ois-l%C3%A9pine-6a122726"
-                            class="mx-2 text-gray-600 transition-colors duration-300" aria-label="Facebook">
-                            <svg class="w-5 h-5 fill-current" role="img" viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg">
-                                <title>LinkedIn</title>
-                                <path
-                                    d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-                            </svg>
-                        </a>
-
-                        <a aria-label="Visit Github repository of AST Metrics"
-                            href="https://github.com/Halleck45/ast-metrics/"
-                            class="mx-2 text-gray-600 transition-colors duration-300" aria-label="Github">
-                            <svg class="w-5 h-5 fill-current" viewBox="0 0 24 24" fill="none"
-                                xmlns="http://www.w3.org/2000/svg">
-                                <path
-                                    d="M12.026 2C7.13295 1.99937 2.96183 5.54799 2.17842 10.3779C1.395 15.2079 4.23061 19.893 8.87302 21.439C9.37302 21.529 9.55202 21.222 9.55202 20.958C9.55202 20.721 9.54402 20.093 9.54102 19.258C6.76602 19.858 6.18002 17.92 6.18002 17.92C5.99733 17.317 5.60459 16.7993 5.07302 16.461C4.17302 15.842 5.14202 15.856 5.14202 15.856C5.78269 15.9438 6.34657 16.3235 6.66902 16.884C6.94195 17.3803 7.40177 17.747 7.94632 17.9026C8.49087 18.0583 9.07503 17.99 9.56902 17.713C9.61544 17.207 9.84055 16.7341 10.204 16.379C7.99002 16.128 5.66202 15.272 5.66202 11.449C5.64973 10.4602 6.01691 9.5043 6.68802 8.778C6.38437 7.91731 6.42013 6.97325 6.78802 6.138C6.78802 6.138 7.62502 5.869 9.53002 7.159C11.1639 6.71101 12.8882 6.71101 14.522 7.159C16.428 5.868 17.264 6.138 17.264 6.138C17.6336 6.97286 17.6694 7.91757 17.364 8.778C18.0376 9.50423 18.4045 10.4626 18.388 11.453C18.388 15.286 16.058 16.128 13.836 16.375C14.3153 16.8651 14.5612 17.5373 14.511 18.221C14.511 19.555 14.499 20.631 14.499 20.958C14.499 21.225 14.677 21.535 15.186 21.437C19.8265 19.8884 22.6591 15.203 21.874 10.3743C21.089 5.54565 16.9181 1.99888 12.026 2Z">
-                                </path>
-                            </svg>
-                        </a>
-                    </div>
-                </div>
-                <div class="text-sm text-right text-gray-600 p-6">
-                    at {{ datetime }} by <a href="https://github.com/Halleck45/ast-metrics">AST Metrics</a>
-                </div>
-            </footer>
         </main>
 
         {% include "partials/file_explorer_sidebar.html" %}
@@ -921,46 +883,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/d3@7" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/pixi.js@7.3.3/dist/pixi.min.js" defer></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"
-        integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoeqMV/TJlSKda6FXzoEyYGjTe+vXA=="
-        crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-    <script type="text/javascript">
-        document.addEventListener('DOMContentLoaded', function () {
-
-
-
-            // Share buttons
-            const shareButton = document.getElementById('share-twitter');
-            shareButton.addEventListener('click', function (event) {
-
-                event.preventDefault();
-
-                html2canvas(document.body).then(function (canvas) {
-                    // Get image as base64
-                    let img = canvas.toDataURL('image/png');
-                    img = img.replace('data:image/png;base64,', '');
-
-                    // Upload image to imgbb
-                    const imgbbKey = '1dc935a4acbf4c4afb9e42a9cc315691';
-                    const formData = new FormData();
-                    formData.append('image', img);
-                    formData.append('name', 'ast-metrics-report.png');
-
-                    fetch('https://api.imgbb.com/1/upload?key=' + imgbbKey, {
-                        method: 'POST',
-                        body: formData
-                    })
-                        .then(response => response.json())
-                        .then(data => {
-                            const imageUrl = data.data.url_viewer;
-                            const text = `Check out my code analysis report, generated by AST Metrics ! #code #analysis #dev`;
-                            const url = 'https://twitter.com/intent/tweet?text=' + encodeURIComponent(text) + '&url=' + encodeURIComponent(imageUrl);
-                            window.open(url, '_blank');
-                        });
-                });
-            });
-        });
-    </script>
     <!-- Generic table sorting: makes every <table class="sortable"> header clickable. No dependency. -->
     <script type="text/javascript">
         (function () {

--- a/internal/report/templates/html/layout.html
+++ b/internal/report/templates/html/layout.html
@@ -32,12 +32,67 @@
             font-family: var(--font-mono);
         }
 
+        /* Page canvas: a very light wash so white cards still read as raised */
+        .report-canvas {
+            background:
+                radial-gradient(1200px 500px at 12% -8%, #eef4ff 0%, rgba(238, 244, 255, 0) 60%),
+                radial-gradient(900px 420px at 92% 4%, #f4f1ff 0%, rgba(244, 241, 255, 0) 55%),
+                #f6f8fb;
+            min-height: 100vh;
+        }
+
         .card-graph {
             height: 135px;
         }
 
+        /* Sortable tables. Only the headers enhanced by the sorting script
+           (see the end of the body) become interactive. */
         .sortable th {
+            cursor: default;
+        }
+
+        .sortable th.sort-header {
             cursor: pointer;
+        }
+
+        .sortable th .sort-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+            font: inherit;
+            color: inherit;
+            letter-spacing: inherit;
+            text-transform: inherit;
+            text-align: inherit;
+            background: none;
+            border: 0;
+            padding: 0;
+            cursor: pointer;
+        }
+
+        .sortable th .sort-btn:focus-visible {
+            outline: 2px solid #93c5fd;
+            /* Blue 300 */
+            outline-offset: 2px;
+            border-radius: 2px;
+        }
+
+        /* Direction indicator: idle (both ways), then ascending / descending */
+        .sortable th .sort-arrow::after {
+            content: '\2195';
+            font-size: 0.85em;
+            line-height: 1;
+            opacity: 0.3;
+        }
+
+        .sortable th[aria-sort="ascending"] .sort-arrow::after {
+            content: '\2191';
+            opacity: 0.8;
+        }
+
+        .sortable th[aria-sort="descending"] .sort-arrow::after {
+            content: '\2193';
+            opacity: 0.8;
         }
 
         .progress {
@@ -151,7 +206,506 @@
         .file-sidebar.translate-x-full { transform: translateX(100%); }
         @media (min-width: 1024px) { .file-sidebar { width: 320px; } }
         @media (max-width: 1023px) { .file-sidebar { width: 85vw; max-width: 360px; } }
+
+        /* ------------------------------------------------------------------
+           Shared report components.
+
+           Every page is built from the same few pieces, in this order:
+             1. .page-hero      the verdict: what this page found, in words
+             2. .kpi-strip      the two to four numbers that back the verdict
+             3. .soft-card      one card per idea, with .card-title/.card-sub
+             4. .stat-tile      a single metric, with its meter and its target
+             5. .insight        a one-sentence diagnosis, colored by severity
+
+           Severity is always expressed with the same three words in class
+           names and data attributes: good, warn, bad.
+           ------------------------------------------------------------------ */
+
+        /* 1. Page hero: verdict sentence + supporting numbers */
+        .page-hero {
+            background: linear-gradient(135deg, #eff6ff 0%, #f5f3ff 45%, #ecfdf5 100%);
+            border: 1px solid #e2e8f0;
+            border-radius: 24px;
+            padding: 2rem;
+        }
+
+        @media (min-width: 768px) {
+            .page-hero { padding: 2.5rem; }
+        }
+
+        .page-kicker {
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+            color: #94a3b8;
+        }
+
+        .verdict-title {
+            font-size: 1.875rem;
+            line-height: 1.15;
+            font-weight: 700;
+            letter-spacing: -0.02em;
+            color: #0f172a;
+        }
+
+        @media (min-width: 768px) {
+            .verdict-title { font-size: 2.25rem; }
+        }
+
+        /* Second half of the verdict, deliberately quieter than the first */
+        .verdict-muted { color: #94a3b8; }
+
+        .verdict-lead {
+            font-size: 0.9375rem;
+            line-height: 1.65;
+            color: #475569;
+            max-width: 60ch;
+        }
+
+        .verdict-lead strong {
+            font-weight: 600;
+            color: #0f172a;
+        }
+
+        /* 2. KPI strip: big numbers, quiet labels, thin separators */
+        .kpi-strip {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 2rem;
+        }
+
+        .kpi-value {
+            font-size: 1.875rem;
+            font-weight: 700;
+            letter-spacing: -0.03em;
+            line-height: 1.1;
+            color: #0f172a;
+            font-family: var(--font-mono);
+        }
+
+        .kpi-label {
+            font-size: 11px;
+            color: #94a3b8;
+            margin-top: 0.25rem;
+            line-height: 1.4;
+        }
+
+        .kpi-strip--divided > * + * {
+            padding-left: 2rem;
+            border-left: 1px solid #e2e8f0;
+        }
+
+        /* 3. Soft card: calmer than .dashboard-card, no hover lift */
+        .soft-card {
+            background: white;
+            border: 1px solid #e2e8f0;
+            border-radius: 20px;
+            padding: 1.5rem;
+        }
+
+        .card-title {
+            font-size: 1.0625rem;
+            font-weight: 600;
+            letter-spacing: -0.01em;
+            color: #0f172a;
+        }
+
+        /* Every card says what it shows, in plain words */
+        .card-sub {
+            font-size: 0.8125rem;
+            color: #94a3b8;
+            margin-top: 0.125rem;
+        }
+
+        /* 4. Stat tile: one metric, its meter, its target */
+        .stat-tile {
+            background: white;
+            border: 1px solid #e2e8f0;
+            border-radius: 16px;
+            padding: 1.125rem 1.25rem;
+        }
+
+        .stat-tile-label {
+            font-size: 0.8125rem;
+            color: #64748b;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.5rem;
+        }
+
+        .stat-tile-value {
+            font-size: 1.75rem;
+            font-weight: 700;
+            letter-spacing: -0.03em;
+            line-height: 1.15;
+            color: #0f172a;
+            margin-top: 0.375rem;
+            font-family: var(--font-mono);
+        }
+
+        .stat-tile-target {
+            font-size: 11px;
+            color: #94a3b8;
+            margin-top: 0.5rem;
+        }
+
+        /* Meter: shared by stat tiles, verdict rows and list rows */
+        .meter {
+            height: 6px;
+            border-radius: 999px;
+            background: #e8ecf1;
+            overflow: hidden;
+            margin-top: 0.625rem;
+        }
+
+        .meter-fill {
+            height: 100%;
+            border-radius: 999px;
+            transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        /* Severity colors, one source of truth */
+        .dot { width: 8px; height: 8px; border-radius: 999px; flex-shrink: 0; display: inline-block; }
+        .sev-good { background-color: #22c55e; }
+        .sev-warn { background-color: #f59e0b; }
+        .sev-bad { background-color: #ef4444; }
+        .sev-none { background-color: #cbd5e1; }
+        .text-good { color: #15803d; }
+        .text-warn { color: #b45309; }
+        .text-bad { color: #b91c1c; }
+        .text-none { color: #94a3b8; }
+
+        /* Level pill: "High risk", "Isolated", ... */
+        .level-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            padding: 0.375rem 0.875rem;
+            border-radius: 999px;
+            background: white;
+            border: 1px solid #e2e8f0;
+            color: #334155;
+        }
+
+        .level-pill--good { background: #f0fdf4; border-color: #bbf7d0; color: #15803d; }
+        .level-pill--warn { background: #fffbeb; border-color: #fde68a; color: #b45309; }
+        .level-pill--bad { background: #fef2f2; border-color: #fecaca; color: #b91c1c; }
+
+        /* 5. Insight: a single sentence of diagnosis */
+        .insight {
+            display: flex;
+            gap: 0.75rem;
+            align-items: flex-start;
+            font-size: 0.875rem;
+            line-height: 1.6;
+            padding: 0.875rem 1.125rem;
+            border-radius: 14px;
+            border: 1px solid #e2e8f0;
+            background: #f8fafc;
+            color: #334155;
+        }
+
+        .insight strong { font-weight: 600; color: #0f172a; }
+        .insight--good { background: #f0fdf4; border-color: #bbf7d0; }
+        .insight--warn { background: #fffbeb; border-color: #fde68a; }
+        .insight--bad { background: #fef2f2; border-color: #fecaca; }
+        .insight .dot { margin-top: 0.45rem; }
+
+        /* List rows: name on the left, value on the right */
+        .data-row {
+            display: flex;
+            align-items: center;
+            gap: 0.875rem;
+            padding: 0.75rem 0;
+            border-bottom: 1px solid #f1f5f9;
+        }
+
+        .data-row:last-child { border-bottom: 0; }
+
+        .row-name {
+            font-size: 0.875rem;
+            font-weight: 500;
+            color: #0f172a;
+            min-width: 0;
+        }
+
+        .row-meta {
+            font-size: 0.75rem;
+            color: #94a3b8;
+            margin-top: 0.125rem;
+        }
+
+        .row-value {
+            font-family: var(--font-mono);
+            font-size: 0.875rem;
+            font-weight: 600;
+            color: #0f172a;
+            text-align: right;
+            flex-shrink: 0;
+        }
+
+        /* Code identifiers, wherever they appear in prose */
+        .ident {
+            font-family: var(--font-mono);
+            font-size: 0.875em;
+            background: rgba(148, 163, 184, 0.16);
+            padding: 0.1em 0.4em;
+            border-radius: 5px;
+        }
+
+        /* Summary rows on the dashboard: each one links to the screen where
+           that metric can be acted on. */
+        .summary-row {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.875rem 0.75rem;
+            margin: 0 -0.75rem;
+            border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+            border-radius: 10px;
+            transition: background 0.15s ease;
+        }
+
+        .summary-row:last-child { border-bottom: 0; }
+        .summary-row:hover { background: rgba(255, 255, 255, 0.55); }
+
+        .summary-row-label {
+            display: flex;
+            align-items: center;
+            gap: 0.375rem;
+            min-width: 0;
+            font-size: 1rem;
+            font-weight: 500;
+            color: #0f172a;
+        }
+
+        .summary-row-arrow {
+            width: 0.875rem;
+            height: 0.875rem;
+            flex-shrink: 0;
+            color: #94a3b8;
+            opacity: 0;
+            transform: translateX(-3px);
+            transition: opacity 0.15s ease, transform 0.15s ease;
+        }
+
+        .summary-row:hover .summary-row-arrow,
+        .summary-row-label:focus-visible .summary-row-arrow {
+            opacity: 1;
+            transform: translateX(0);
+        }
+
+        /* ---- Navigation ------------------------------------------------- */
+        .nav-link, .nav-group-btn {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            width: 100%;
+            padding: 0.5rem 0.75rem;
+            border-radius: 10px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            color: #475569;
+            text-align: left;
+            background: none;
+            border: 0;
+            cursor: pointer;
+            transition: background 0.15s ease, color 0.15s ease;
+        }
+
+        .nav-link + .nav-link, .nav-group, .nav-link + .nav-group { margin-top: 0.125rem; }
+
+        .nav-link:hover, .nav-group-btn:hover { background: #f1f5f9; color: #0f172a; }
+
+        .nav-link--active {
+            background: #eff6ff;
+            color: #1d4ed8;
+            font-weight: 600;
+        }
+
+        .nav-link--active:hover { background: #eff6ff; color: #1d4ed8; }
+        .nav-link--quiet { color: #94a3b8; }
+
+        .nav-icon { width: 1.125rem; height: 1.125rem; flex-shrink: 0; }
+
+        .nav-chevron {
+            width: 0.875rem;
+            height: 0.875rem;
+            margin-left: auto;
+            flex-shrink: 0;
+            color: #cbd5e1;
+            transition: transform 0.2s ease;
+        }
+
+        .nav-sublist {
+            margin: 0.125rem 0 0.25rem 0;
+            padding-left: 2.1rem;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .nav-sublink {
+            padding: 0.375rem 0.75rem;
+            border-radius: 8px;
+            font-size: 0.8125rem;
+            color: #64748b;
+            transition: background 0.15s ease, color 0.15s ease;
+        }
+
+        .nav-sublink:hover { background: #f1f5f9; color: #0f172a; }
+
+        .nav-sublink--active {
+            color: #1d4ed8;
+            font-weight: 600;
+            background: #eff6ff;
+        }
+
+        .nav-sublink--active:hover { background: #eff6ff; color: #1d4ed8; }
+
+        /* Contributor chip: initials, overlaid by a Gravatar when one exists.
+           Chips overlap slightly, like a stack of faces. */
+        .contributor-chip {
+            position: relative;
+            width: 34px;
+            height: 34px;
+            border-radius: 999px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 11px;
+            font-weight: 600;
+            color: white;
+            flex-shrink: 0;
+            overflow: hidden;
+            border: 2px solid white;
+            box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+        }
+
+        .contributor-chip + .contributor-chip { margin-left: -10px; }
+
+        .contributor-chip-img {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        /* Segmented control, used for language tabs and small view switches */
+        .seg {
+            display: inline-flex;
+            align-items: center;
+            gap: 2px;
+            padding: 3px;
+            background: rgba(226, 232, 240, 0.7);
+            border-radius: 999px;
+        }
+
+        .seg-item {
+            font-size: 0.8125rem;
+            font-weight: 500;
+            color: #475569;
+            padding: 0.375rem 0.875rem;
+            border-radius: 999px;
+            white-space: nowrap;
+            transition: background 0.15s ease, color 0.15s ease;
+        }
+
+        .seg-item:hover { color: #0f172a; background: rgba(255, 255, 255, 0.6); }
+
+        .seg-item--active {
+            background: white;
+            color: #0f172a;
+            font-weight: 600;
+            box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+        }
+
+        .seg-item--active:hover { background: white; }
+
+        /* Section heading between two groups of cards */
+        .section-title {
+            font-size: 0.75rem;
+            font-weight: 600;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            color: #94a3b8;
+        }
+
+        /* Shared accessible CSS tooltips: any element with data-tip="..." shows a
+           small dark bubble on hover and on keyboard focus. */
+        [data-tip] { position: relative; cursor: help; }
+        [data-tip]::after {
+            content: attr(data-tip);
+            position: absolute;
+            bottom: calc(100% + 8px);
+            left: 50%;
+            transform: translateX(-50%) translateY(4px);
+            background: #1e293b;
+            color: #f8fafc;
+            font-size: 11px;
+            font-weight: 400;
+            line-height: 1.5;
+            text-transform: none;
+            letter-spacing: 0;
+            text-align: left;
+            padding: 8px 10px;
+            border-radius: 8px;
+            width: max-content;
+            max-width: 260px;
+            white-space: normal;
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.15s ease, transform 0.15s ease;
+            z-index: 60;
+            pointer-events: none;
+            box-shadow: 0 4px 6px -1px rgba(0,0,0,0.2);
+        }
+        [data-tip]::before {
+            content: '';
+            position: absolute;
+            bottom: calc(100% + 3px);
+            left: 50%;
+            transform: translateX(-50%);
+            border: 5px solid transparent;
+            border-top-color: #1e293b;
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.15s ease;
+            z-index: 60;
+            pointer-events: none;
+        }
+        [data-tip]:hover::after, [data-tip]:focus-visible::after,
+        [data-tip]:hover::before, [data-tip]:focus-visible::before {
+            opacity: 1;
+            visibility: visible;
+            transform: translateX(-50%) translateY(0);
+        }
+        [data-tip]:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; border-radius: 4px; }
     </style>
+    <script>
+        function reportNav() {
+            let state = {};
+            try { state = JSON.parse(localStorage.getItem('ast-nav-open') || '{}'); } catch (e) { state = {}; }
+            return {
+                open: state,
+                // Called once per group: the group holding the current page wins
+                // over a remembered "closed".
+                init(key, holdsCurrentPage) {
+                    if (holdsCurrentPage) this.open[key] = true;
+                    else if (!(key in this.open)) this.open[key] = false;
+                },
+                isOpen(key) { return !!this.open[key]; },
+                toggle(key) {
+                    this.open = { ...this.open, [key]: !this.open[key] };
+                    try { localStorage.setItem('ast-nav-open', JSON.stringify(this.open)); } catch (e) { /* private mode */ }
+                },
+            };
+        }
+    </script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 
@@ -177,127 +731,116 @@
             </a>
 
             <div class="flex flex-col justify-between flex-1 mt-12">
-                <nav role="menu">
-                    <a role="menuitem" aria-label="Dashboard" tabindex="0" href="index.html"
-                        class="flex items-center px-4 py-2 {% if page == 'index.html'%}text-gray-700 bg-gray-100{% else %}text-gray-600{% endif %} rounded-md hover:opacity-70">
-                        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path
-                                d="M19 11H5M19 11C20.1046 11 21 11.8954 21 13V19C21 20.1046 20.1046 21 19 21H5C3.89543 21 3 20.1046 3 19V13C3 11.8954 3.89543 11 5 11M19 11V9C19 7.89543 18.1046 7 17 7M5 11V9C5 7.89543 5.89543 7 7 7M7 7V5C7 3.89543 7.89543 3 9 3H15C16.1046 3 17 3.89543 17 5V7M7 7H17"
-                                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                        </svg>
+                <!-- Navigation. Grouped by the question the reader is asking,
+                     rather than by the metric family. The group holding the
+                     current page opens itself. -->
+                <nav aria-label="Report sections" x-data="reportNav()">
 
-                        <span class="mx-4 font-medium">Dashboard</span>
+                    <a href="index{{ scopeSuffix }}.html"
+                       class="nav-link {% if page == 'index.html' %}nav-link--active{% endif %}"
+                       {% if page == 'index.html' %}aria-current="page"{% endif %}>
+                        <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h12A2.25 2.25 0 0 1 20.25 6v3H3.75V6ZM3.75 12h7.5v8.25H6A2.25 2.25 0 0 1 3.75 18v-6ZM14.25 12h6v6A2.25 2.25 0 0 1 18 20.25h-3.75V12Z" />
+                        </svg>
+                        <span>Overview</span>
                     </a>
 
-                    <a role="menuitem" aria-label="Browse" tabindex="0" href="explorer.html"
-                        class="flex items-center px-4 py-2 mt-5 {% if page == 'explorer.html'%}text-gray-700 bg-gray-100{% else %}text-gray-600{% endif %} transition-colors duration-300 transform rounded-md hover:opacity-70">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                            stroke="currentColor" class="size-6">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+                    {% set inCode = page == 'explorer.html' or page == 'classes.html' or page == 'metrics.html' or page == 'testquality.html' %}
+                    {% set inArchi = page == 'dependencies.html' or page == 'communities.html' or page == 'classification.html' %}
+                    {% set inHealth = page == 'linters.html' or page == 'risks.html' %}
+
+                    <!-- What the code is made of -->
+                    <div class="nav-group">
+                        <button type="button" @click="toggle('code')" :aria-expanded="isOpen('code') ? 'true' : 'false'"
+                                class="nav-group-btn" x-init="init('code', {% if inCode %}true{% else %}false{% endif %})">
+                            <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25M6.75 17.25 1.5 12l5.25-5.25M14.25 3.75l-4.5 16.5" />
+                            </svg>
+                            <span>The code</span>
+                            <svg class="nav-chevron" :class="isOpen('code') ? 'rotate-90' : ''" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                            </svg>
+                        </button>
+                        <div x-show="isOpen('code')" x-cloak class="nav-sublist">
+                            <a href="explorer{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'explorer.html' %}nav-sublink--active{% endif %}"
+                               {% if page == 'explorer.html' %}aria-current="page"{% endif %}>Files</a>
+                            <a href="classes{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'classes.html' %}nav-sublink--active{% endif %}"
+                               {% if page == 'classes.html' %}aria-current="page"{% endif %}>Classes</a>
+                            <a href="testquality{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'testquality.html' %}nav-sublink--active{% endif %}"
+                               {% if page == 'testquality.html' %}aria-current="page"{% endif %}>Tests</a>
+                            <a href="metrics{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'metrics.html' %}nav-sublink--active{% endif %}"
+                               {% if page == 'metrics.html' %}aria-current="page"{% endif %}>All metrics</a>
+                        </div>
+                    </div>
+
+                    <!-- How the pieces fit together -->
+                    <div class="nav-group">
+                        <button type="button" @click="toggle('archi')" :aria-expanded="isOpen('archi') ? 'true' : 'false'"
+                                class="nav-group-btn" x-init="init('archi', {% if inArchi %}true{% else %}false{% endif %})">
+                            <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z" />
+                            </svg>
+                            <span>Architecture</span>
+                            <svg class="nav-chevron" :class="isOpen('archi') ? 'rotate-90' : ''" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                            </svg>
+                        </button>
+                        <div x-show="isOpen('archi')" x-cloak class="nav-sublist">
+                            <a href="dependencies{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'dependencies.html' %}nav-sublink--active{% endif %}"
+                               {% if page == 'dependencies.html' %}aria-current="page"{% endif %}>Dependencies</a>
+                            <a href="communities{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'communities.html' %}nav-sublink--active{% endif %}"
+                               {% if page == 'communities.html' %}aria-current="page"{% endif %}>Natural groups</a>
+                            <a href="classification{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'classification.html' %}nav-sublink--active{% endif %}"
+                               {% if page == 'classification.html' %}aria-current="page"{% endif %}>Roles</a>
+                        </div>
+                    </div>
+
+                    <!-- What may bite -->
+                    <div class="nav-group">
+                        <button type="button" @click="toggle('health')" :aria-expanded="isOpen('health') ? 'true' : 'false'"
+                                class="nav-group-btn" x-init="init('health', {% if inHealth %}true{% else %}false{% endif %})">
+                            <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+                            </svg>
+                            <span>Health</span>
+                            <svg class="nav-chevron" :class="isOpen('health') ? 'rotate-90' : ''" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                            </svg>
+                        </button>
+                        <div x-show="isOpen('health')" x-cloak class="nav-sublist">
+                            <a href="linters{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'linters.html' %}nav-sublink--active{% endif %}"
+                               {% if page == 'linters.html' %}aria-current="page"{% endif %}>Rule violations</a>
+                            <a href="risks{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'risks.html' %}nav-sublink--active{% endif %}"
+                               {% if page == 'risks.html' %}aria-current="page"{% endif %}>Observations</a>
+                        </div>
+                    </div>
+
+                    <a href="busfactor{{ scopeSuffix }}.html"
+                       class="nav-link {% if page == 'busfactor.html' %}nav-link--active{% endif %}"
+                       {% if page == 'busfactor.html' %}aria-current="page"{% endif %}>
+                        <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
                         </svg>
-                        <span class="mx-4 font-medium">Browse</span>
-                    </a>
-
-                    <a role="menuitem" aria-label="Dependencies" tabindex="0" href="dependencies.html"
-                        class="flex items-center px-4 py-2 mt-5 {% if page == 'dependencies.html'%}text-gray-700 bg-gray-100{% else %}text-gray-600{% endif %} transition-colors duration-300 transform rounded-md hover:opacity-70">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                            stroke="currentColor" class="size-6">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z" />
-                        </svg>
-                        <span class="mx-4 font-medium">Dependencies</span>
-                    </a>
-
-                    <a role="menuitem" aria-label="Architecture (AI)" tabindex="0" href="classification.html"
-                        class="flex items-center px-4 py-2 mt-5 {% if page == 'classification.html'%}text-gray-700 bg-gray-100{% else %}text-gray-600{% endif %} transition-colors duration-300 transform rounded-md hover:opacity-70">
-
-                        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px"
-                            fill="#333333">
-                            <path
-                                d="M480-80q-50 0-85-35t-35-85q0-5 .5-11t1.5-11l-83-47q-16 14-36 21.5t-43 7.5q-50 0-85-35t-35-85q0-50 35-85t85-35q24 0 45 9t38 25l119-60q-3-23 2.5-45t19.5-41l-34-52q-7 2-14.5 3t-15.5 1q-50 0-85-35t-35-85q0-50 35-85t85-35q50 0 85 35t35 85q0 20-6.5 38.5T456-688l35 52q8-2 15-3t15-1q17 0 32 4t29 12l66-54q-4-10-6-20.5t-2-21.5q0-50 35-85t85-35q50 0 85 35t35 85q0 50-35 85t-85 35q-17 0-32-4.5T699-617l-66 55q4 10 6 20.5t2 21.5q0 50-35 85t-85 35q-24 0-45.5-9T437-434l-118 59q2 9 1.5 18t-2.5 18l84 48q16-14 35.5-21.5T480-320q50 0 85 35t35 85q0 50-35 85t-85 35ZM200-320q17 0 28.5-11.5T240-360q0-17-11.5-28.5T200-400q-17 0-28.5 11.5T160-360q0 17 11.5 28.5T200-320Zm160-400q17 0 28.5-11.5T400-760q0-17-11.5-28.5T360-800q-17 0-28.5 11.5T320-760q0 17 11.5 28.5T360-720Zm120 560q17 0 28.5-11.5T520-200q0-17-11.5-28.5T480-240q-17 0-28.5 11.5T440-200q0 17 11.5 28.5T480-160Zm40-320q17 0 28.5-11.5T560-520q0-17-11.5-28.5T520-560q-17 0-28.5 11.5T480-520q0 17 11.5 28.5T520-480Zm240-200q17 0 28.5-11.5T800-720q0-17-11.5-28.5T760-760q-17 0-28.5 11.5T720-720q0 17 11.5 28.5T760-680Z" />
-                        </svg>
-                        <span class="mx-4 font-medium">Architecture</span>
-                    </a>
-
-                    <a role="menuitem" aria-label="Bus Factor" tabindex="0" href="busfactor.html"
-                        class="flex items-center px-4 py-2 mt-5 {% if page == 'busfactor.html'%}text-gray-700 bg-gray-100{% else %}text-gray-600{% endif %} transition-colors duration-300 transform rounded-md hover:opacity-70">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                            stroke="currentColor" class="size-6">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-                        </svg>
-                        <span class="mx-4 font-medium">Bus Factor</span>
-                    </a>
-
-                    <a role="menuitem" aria-label="Communities" tabindex="0" href="communities.html"
-                        class="flex items-center px-4 py-2 mt-5 {% if page == 'communities.html'%}text-gray-700 bg-gray-100{% else %}text-gray-600{% endif %} transition-colors duration-300 transform rounded-md hover:opacity-70">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                            stroke="currentColor" class="size-6">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z" />
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z" />
-                        </svg>
-                        <span class="mx-4 font-medium">Communities</span>
-                    </a>
-
-
-                    <a role="menuitem" aria-label="Test Quality" tabindex="0" href="testquality.html"
-                        class="flex items-center px-4 py-2 mt-5 {% if page == 'testquality.html'%}text-gray-700 bg-gray-100{% else %}text-gray-600{% endif %} transition-colors duration-300 transform rounded-md hover:opacity-70">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                            stroke="currentColor" class="size-6">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
-                        </svg>
-                        <span class="mx-4 font-medium">Test Quality</span>
-                    </a>
-
-                    <a role="menuitem" aria-label="Linters" tabindex="0" href="linters.html"
-                        class="flex items-center px-4 py-2 mt-5 {% if page == 'linters.html'%}text-gray-700 bg-gray-100{% else %}text-gray-600{% endif %} transition-colors duration-300 transform rounded-md hover:opacity-70">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                            stroke="currentColor" class="size-6">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0 1 18 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3 1.5 1.5 3-3.75" />
-                        </svg>
-
-                        <span class="mx-4 font-medium">Linters</span>
+                        <span>Team</span>
                     </a>
 
                     {% if currentView.Comparaison %}
-                    <a role="menuitem" aria-label="Compare with {{ currentView.Comparaison.ComparedBranch }}"
-                        tabindex="0" href="compare.html"
-                        class="flex items-center px-4 py-2 mt-5 {% if page == 'compare.html'%}text-gray-700 bg-gray-100{% else %}text-gray-600{% endif %} transition-colors duration-300 transform rounded-md hover:opacity-70">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                            stroke="currentColor" class="size-6">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 0 1-2.25 2.25M16.5 7.5V18a2.25 2.25 0 0 0 2.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 0 0 2.25 2.25h13.5M6 7.5h3v3H6v-3Z" />
+                    <a href="compare{{ scopeSuffix }}.html"
+                       class="nav-link {% if page == 'compare.html' %}nav-link--active{% endif %}"
+                       {% if page == 'compare.html' %}aria-current="page"{% endif %}>
+                        <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
                         </svg>
-                        <span class="mx-4 font-medium">Compare with {{ currentView.Comparaison.ComparedBranch }}</span>
+                        <span>Changes</span>
                     </a>
                     {% endif %}
 
-                    <a role="menuitem" aria-label="Metrics" tabindex="0" href="risks.html"
-                        class="flex items-center px-4 py-2 mt-5 {% if page == 'risks.html'%}text-gray-700 bg-gray-100{% else %}text-gray-600{% endif %} transition-colors duration-300 transform rounded-md hover:opacity-70">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                            stroke="currentColor" class="size-6">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+                    <a href="https://halleck45.github.io/ast-metrics/getting-started/" class="nav-link nav-link--quiet">
+                        <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
                         </svg>
-
-                        <span class="mx-4 font-medium">Suggestions</span>
+                        <span>Help</span>
                     </a>
-
-                    <a tabindex="0" role="menuitem" aria-label="Help"
-                        href="https://halleck45.github.io/ast-metrics/getting-started/"
-                        class="flex items-center px-4 py-2 mt-5 text-gray-600 transition-colors duration-300 transform rounded-md hover:text-gray-700  hover:opacity-70">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                            stroke="currentColor" class="w-6 h-6">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                d="M16.712 4.33a9.027 9.027 0 0 1 1.652 1.306c.51.51.944 1.064 1.306 1.652M16.712 4.33l-3.448 4.138m3.448-4.138a9.014 9.014 0 0 0-9.424 0M19.67 7.288l-4.138 3.448m4.138-3.448a9.014 9.014 0 0 1 0 9.424m-4.138-5.976a3.736 3.736 0 0 0-.88-1.388 3.737 3.737 0 0 0-1.388-.88m2.268 2.268a3.765 3.765 0 0 1 0 2.528m-2.268-4.796a3.765 3.765 0 0 0-2.528 0m4.796 4.796c-.181.506-.475.982-.88 1.388a3.736 3.736 0 0 1-1.388.88m2.268-2.268 4.138 3.448m0 0a9.027 9.027 0 0 1-1.306 1.652c-.51.51-1.064.944-1.652 1.306m0 0-3.448-4.138m3.448 4.138a9.014 9.014 0 0 1-9.424 0m5.976-4.138a3.765 3.765 0 0 1-2.528 0m0 0a3.736 3.736 0 0 1-1.388-.88 3.737 3.737 0 0 1-.88-1.388m2.268 2.268L7.288 19.67m0 0a9.024 9.024 0 0 1-1.652-1.306 9.027 9.027 0 0 1-1.306-1.652m0 0 4.138-3.448M4.33 16.712a9.014 9.014 0 0 1 0-9.424m4.138 5.976a3.765 3.765 0 0 1 0-2.528m0 0c.181-.506.475-.982.88-1.388a3.736 3.736 0 0 1 1.388-.88m-2.268 2.268L4.33 7.288m6.406 1.18L7.288 4.33m0 0a9.024 9.024 0 0 0-1.652 1.306A9.025 9.025 0 0 0 4.33 7.288" />
-                        </svg>
-                        <span class="mx-4 font-medium">Help</span>
-                    </a>
-
                 </nav>
             </div>
 
@@ -321,7 +864,7 @@
         </aside>
 
         <main class="col-span-full lg:col-span-6">
-            <div class="bg-gray-100 py-8 px-8">
+            <div class="report-canvas py-8 px-6 md:px-8">
 
                 <script src="{{ dataScriptPath }}"></script>
                 {% if linterScriptPath and page == "linters.html" %}<script src="{{ linterScriptPath }}"></script>{% endif %}
@@ -417,6 +960,246 @@
                 });
             });
         });
+    </script>
+    <!-- Generic table sorting: makes every <table class="sortable"> header clickable. No dependency. -->
+    <script type="text/javascript">
+        (function () {
+            'use strict';
+
+            // Number at the beginning of a cell: "12", "-3.5", "1 234", "1.2 K", "45%"
+            var LEADING_NUMBER = /^([+-]?\d[\d\s,.]*)\s*([kmgt])?\s*%?/i;
+            var SCALES = { k: 1e3, m: 1e6, g: 1e9, t: 1e12 };
+            var EMPTY_VALUES = ['', '-', '--', 'n/a', 'na'];
+
+            function cellText(row, index) {
+                var cell = row.cells[index];
+                if (!cell) {
+                    return '';
+                }
+                // Non breaking spaces are common in formatted numbers
+                return (cell.textContent || '').replace(/ /g, ' ').trim();
+            }
+
+            // Returns a number, or null when the cell holds no numeric value.
+            function parseNumber(text) {
+                if (EMPTY_VALUES.indexOf(text.toLowerCase()) !== -1) {
+                    return null;
+                }
+                var match = text.match(LEADING_NUMBER);
+                if (!match) {
+                    return null;
+                }
+                var digits = match[1].replace(/\s/g, '');
+                if (/^\d{1,3}(,\d{3})+(\.\d+)?$/.test(digits)) {
+                    digits = digits.replace(/,/g, ''); // "1,234" : thousand separator
+                } else {
+                    digits = digits.replace(',', '.'); // "1,2" : decimal comma
+                }
+                var value = parseFloat(digits);
+                if (isNaN(value)) {
+                    return null;
+                }
+                return value * (SCALES[(match[2] || '').toLowerCase()] || 1);
+            }
+
+            // Rows spanning several columns (empty states, notices) are never sorted.
+            function isSortableRow(row) {
+                for (var i = 0; i < row.cells.length; i++) {
+                    if (row.cells[i].colSpan > 1) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            function sortableRows(table) {
+                var body = table.tBodies[0];
+                if (!body) {
+                    return [];
+                }
+                // body.rows only contains real <tr>, so Alpine <template> blocks are ignored
+                return Array.prototype.filter.call(body.rows, isSortableRow);
+            }
+
+            // Headers of the last row of the <thead>.
+            function headerCells(table) {
+                var head = table.tHead;
+                if (!head || !head.rows.length) {
+                    return [];
+                }
+                var row = head.rows[head.rows.length - 1];
+                return Array.prototype.filter.call(row.cells, function (cell) {
+                    return cell.tagName === 'TH';
+                });
+            }
+
+            // Auto detection: numeric when most of the filled cells parse as numbers.
+            function isNumericColumn(rows, index) {
+                var numeric = 0;
+                var filled = 0;
+                for (var i = 0; i < rows.length; i++) {
+                    var text = cellText(rows[i], index);
+                    if (!text) {
+                        continue;
+                    }
+                    filled++;
+                    if (parseNumber(text) !== null) {
+                        numeric++;
+                    }
+                }
+                return filled > 0 && (numeric / filled) >= 0.6;
+            }
+
+            function reorder(table, state) {
+                var body = table.tBodies[0];
+                if (!body) {
+                    return;
+                }
+                var factor = state.direction === 'descending' ? -1 : 1;
+                var allRows = Array.prototype.slice.call(body.rows);
+                var items = allRows.filter(isSortableRow).map(function (row, position) {
+                    var text = cellText(row, state.index);
+                    return {
+                        row: row,
+                        position: position,
+                        text: text,
+                        value: state.numeric ? parseNumber(text) : null
+                    };
+                });
+
+                items.sort(function (a, b) {
+                    if (state.numeric) {
+                        // Cells without value always land at the bottom
+                        if (a.value === null || b.value === null) {
+                            if (a.value === b.value) {
+                                return a.position - b.position;
+                            }
+                            return a.value === null ? 1 : -1;
+                        }
+                        if (a.value !== b.value) {
+                            return (a.value - b.value) * factor;
+                        }
+                    } else {
+                        if (!a.text || !b.text) {
+                            if (a.text === b.text) {
+                                return a.position - b.position;
+                            }
+                            return a.text ? -1 : 1;
+                        }
+                        var comparison = a.text.localeCompare(b.text, undefined, { numeric: true, sensitivity: 'base' });
+                        if (comparison !== 0) {
+                            return comparison * factor;
+                        }
+                    }
+                    return a.position - b.position; // stable for ties
+                });
+
+                // Re-inject the sorted rows, keeping the non sortable rows at their own index
+                var fragment = document.createDocumentFragment();
+                var cursor = 0;
+                allRows.forEach(function (row) {
+                    fragment.appendChild(isSortableRow(row) ? items[cursor++].row : row);
+                });
+                body.appendChild(fragment);
+            }
+
+            // Applies the sort without letting our own DOM moves wake up the observer.
+            function applySort(table, state) {
+                var observer = table.astSortObserver;
+                if (observer) {
+                    observer.disconnect();
+                }
+                reorder(table, state);
+                if (observer) {
+                    observer.observe(table.tBodies[0], { childList: true, subtree: true, characterData: true });
+                }
+            }
+
+            // Some tables are rendered client side (Alpine x-for in linters.html): rows appear or are
+            // rewritten after a filter change, which would silently reset the order. We watch the tbody
+            // and replay the current sort. Alpine keeps its own references to the rows, so moving them
+            // around does not break its bookkeeping: it may reorder them on the next update, and we
+            // simply sort again.
+            function watchRerenders(table) {
+                var body = table.tBodies[0];
+                if (!body || typeof MutationObserver === 'undefined') {
+                    return;
+                }
+                var scheduled = false;
+                var observer = new MutationObserver(function () {
+                    if (scheduled || !table.astSortState) {
+                        return;
+                    }
+                    scheduled = true;
+                    // setTimeout, not requestAnimationFrame: also runs in a hidden tab,
+                    // and after the current batch of framework updates
+                    window.setTimeout(function () {
+                        scheduled = false;
+                        if (table.astSortState) {
+                            applySort(table, table.astSortState);
+                        }
+                    }, 0);
+                });
+                table.astSortObserver = observer;
+                observer.observe(body, { childList: true, subtree: true, characterData: true });
+            }
+
+            function setupTable(table) {
+                var headers = headerCells(table);
+                if (!headers.length || !table.tBodies[0]) {
+                    return;
+                }
+                watchRerenders(table);
+
+                headers.forEach(function (header, index) {
+                    if (!(header.textContent || '').trim()) {
+                        return; // decorative column (icon only): nothing to sort on
+                    }
+                    header.classList.add('sort-header');
+                    header.setAttribute('aria-sort', 'none');
+
+                    // The existing content is moved into a button: native click, Enter and Space support,
+                    // while the <th> keeps its columnheader role and its aria-sort attribute.
+                    var button = document.createElement('button');
+                    button.type = 'button';
+                    button.className = 'sort-btn';
+                    button.setAttribute('tabindex', '0');
+                    while (header.firstChild) {
+                        button.appendChild(header.firstChild);
+                    }
+                    var arrow = document.createElement('span');
+                    arrow.className = 'sort-arrow';
+                    arrow.setAttribute('aria-hidden', 'true');
+                    button.appendChild(arrow);
+                    header.appendChild(button);
+
+                    button.addEventListener('click', function () {
+                        var previous = table.astSortState;
+                        var ascending = !(previous && previous.index === index && previous.direction === 'ascending');
+                        var method = header.getAttribute('data-sort-method');
+                        var numeric = method === 'number';
+                        if (!numeric && method !== 'text') {
+                            numeric = isNumericColumn(sortableRows(table), index);
+                        }
+
+                        headers.forEach(function (other) {
+                            if (other.hasAttribute('aria-sort')) {
+                                other.setAttribute('aria-sort', 'none');
+                            }
+                        });
+                        var direction = ascending ? 'ascending' : 'descending';
+                        header.setAttribute('aria-sort', direction);
+
+                        table.astSortState = { index: index, direction: direction, numeric: numeric };
+                        applySort(table, table.astSortState);
+                    });
+                });
+            }
+
+            document.addEventListener('DOMContentLoaded', function () {
+                Array.prototype.forEach.call(document.querySelectorAll('table.sortable'), setupTable);
+            });
+        })();
     </script>
     {% block javascripts %}{% endblock %}
 </body>

--- a/internal/report/templates/html/layout.html
+++ b/internal/report/templates/html/layout.html
@@ -541,6 +541,12 @@
             transition: transform 0.2s ease;
         }
 
+        /* The groups are native <details>, so the menu paints in its final
+           state without waiting for any script (no jump on load). */
+        .nav-group > summary { list-style: none; }
+        .nav-group > summary::-webkit-details-marker { display: none; }
+        .nav-group[open] > summary .nav-chevron { transform: rotate(90deg); }
+
         .nav-sublist {
             margin: 0.125rem 0 0.25rem 0;
             padding-left: 2.1rem;
@@ -686,26 +692,6 @@
         }
         [data-tip]:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; border-radius: 4px; }
     </style>
-    <script>
-        function reportNav() {
-            let state = {};
-            try { state = JSON.parse(localStorage.getItem('ast-nav-open') || '{}'); } catch (e) { state = {}; }
-            return {
-                open: state,
-                // Called once per group: the group holding the current page wins
-                // over a remembered "closed".
-                init(key, holdsCurrentPage) {
-                    if (holdsCurrentPage) this.open[key] = true;
-                    else if (!(key in this.open)) this.open[key] = false;
-                },
-                isOpen(key) { return !!this.open[key]; },
-                toggle(key) {
-                    this.open = { ...this.open, [key]: !this.open[key] };
-                    try { localStorage.setItem('ast-nav-open', JSON.stringify(this.open)); } catch (e) { /* private mode */ }
-                },
-            };
-        }
-    </script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 
@@ -734,7 +720,7 @@
                 <!-- Navigation. Grouped by the question the reader is asking,
                      rather than by the metric family. The group holding the
                      current page opens itself. -->
-                <nav aria-label="Report sections" x-data="reportNav()">
+                <nav aria-label="Report sections">
 
                     <a href="index{{ scopeSuffix }}.html"
                        class="nav-link {% if page == 'index.html' %}nav-link--active{% endif %}"
@@ -750,18 +736,17 @@
                     {% set inHealth = page == 'linters.html' or page == 'risks.html' %}
 
                     <!-- What the code is made of -->
-                    <div class="nav-group">
-                        <button type="button" @click="toggle('code')" :aria-expanded="isOpen('code') ? 'true' : 'false'"
-                                class="nav-group-btn" x-init="init('code', {% if inCode %}true{% else %}false{% endif %})">
+                    <details class="nav-group" data-nav-group="code"{% if inCode %} open{% endif %}>
+                        <summary class="nav-group-btn">
                             <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25M6.75 17.25 1.5 12l5.25-5.25M14.25 3.75l-4.5 16.5" />
                             </svg>
                             <span>The code</span>
-                            <svg class="nav-chevron" :class="isOpen('code') ? 'rotate-90' : ''" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                            <svg class="nav-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
                             </svg>
-                        </button>
-                        <div x-show="isOpen('code')" x-cloak class="nav-sublist">
+                        </summary>
+                        <div class="nav-sublist">
                             <a href="explorer{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'explorer.html' %}nav-sublink--active{% endif %}"
                                {% if page == 'explorer.html' %}aria-current="page"{% endif %}>Files</a>
                             <a href="classes{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'classes.html' %}nav-sublink--active{% endif %}"
@@ -771,21 +756,20 @@
                             <a href="metrics{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'metrics.html' %}nav-sublink--active{% endif %}"
                                {% if page == 'metrics.html' %}aria-current="page"{% endif %}>All metrics</a>
                         </div>
-                    </div>
+                    </details>
 
                     <!-- How the pieces fit together -->
-                    <div class="nav-group">
-                        <button type="button" @click="toggle('archi')" :aria-expanded="isOpen('archi') ? 'true' : 'false'"
-                                class="nav-group-btn" x-init="init('archi', {% if inArchi %}true{% else %}false{% endif %})">
+                    <details class="nav-group" data-nav-group="archi"{% if inArchi %} open{% endif %}>
+                        <summary class="nav-group-btn">
                             <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z" />
                             </svg>
                             <span>Architecture</span>
-                            <svg class="nav-chevron" :class="isOpen('archi') ? 'rotate-90' : ''" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                            <svg class="nav-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
                             </svg>
-                        </button>
-                        <div x-show="isOpen('archi')" x-cloak class="nav-sublist">
+                        </summary>
+                        <div class="nav-sublist">
                             <a href="dependencies{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'dependencies.html' %}nav-sublink--active{% endif %}"
                                {% if page == 'dependencies.html' %}aria-current="page"{% endif %}>Dependencies</a>
                             <a href="communities{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'communities.html' %}nav-sublink--active{% endif %}"
@@ -793,27 +777,26 @@
                             <a href="classification{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'classification.html' %}nav-sublink--active{% endif %}"
                                {% if page == 'classification.html' %}aria-current="page"{% endif %}>Roles</a>
                         </div>
-                    </div>
+                    </details>
 
                     <!-- What may bite -->
-                    <div class="nav-group">
-                        <button type="button" @click="toggle('health')" :aria-expanded="isOpen('health') ? 'true' : 'false'"
-                                class="nav-group-btn" x-init="init('health', {% if inHealth %}true{% else %}false{% endif %})">
+                    <details class="nav-group" data-nav-group="health"{% if inHealth %} open{% endif %}>
+                        <summary class="nav-group-btn">
                             <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
                             </svg>
                             <span>Health</span>
-                            <svg class="nav-chevron" :class="isOpen('health') ? 'rotate-90' : ''" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                            <svg class="nav-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
                             </svg>
-                        </button>
-                        <div x-show="isOpen('health')" x-cloak class="nav-sublist">
+                        </summary>
+                        <div class="nav-sublist">
                             <a href="linters{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'linters.html' %}nav-sublink--active{% endif %}"
                                {% if page == 'linters.html' %}aria-current="page"{% endif %}>Rule violations</a>
                             <a href="risks{{ scopeSuffix }}.html" class="nav-sublink {% if page == 'risks.html' %}nav-sublink--active{% endif %}"
                                {% if page == 'risks.html' %}aria-current="page"{% endif %}>Observations</a>
                         </div>
-                    </div>
+                    </details>
 
                     <a href="busfactor{{ scopeSuffix }}.html"
                        class="nav-link {% if page == 'busfactor.html' %}nav-link--active{% endif %}"
@@ -835,13 +818,30 @@
                     </a>
                     {% endif %}
 
-                    <a href="https://halleck45.github.io/ast-metrics/getting-started/" class="nav-link nav-link--quiet">
+                    <a href="https://ast-metrics.dev/" class="nav-link nav-link--quiet">
                         <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
                         </svg>
                         <span>Help</span>
                     </a>
                 </nav>
+                <script>
+                    // Reopen the groups the reader left open, and remember any
+                    // change. Runs synchronously, right after the menu markup,
+                    // so the state is settled before the first paint.
+                    (function () {
+                        var state = {};
+                        try { state = JSON.parse(localStorage.getItem('ast-nav-open') || '{}'); } catch (e) { }
+                        document.querySelectorAll('details[data-nav-group]').forEach(function (group) {
+                            var key = group.getAttribute('data-nav-group');
+                            if (state[key]) group.open = true;
+                            group.addEventListener('toggle', function () {
+                                state[key] = group.open;
+                                try { localStorage.setItem('ast-nav-open', JSON.stringify(state)); } catch (e) { /* private mode */ }
+                            });
+                        });
+                    })();
+                </script>
             </div>
 
             <!-- Project links -->

--- a/internal/report/templates/html/linters.html
+++ b/internal/report/templates/html/linters.html
@@ -10,297 +10,365 @@
 
 {% block content %}
 
-<style>
-    .dashboard-card {
-        background: white;
-        border: 1px solid #e2e8f0;
-        border-radius: 16px;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        position: relative;
-        overflow: hidden;
-    }
+{% if not projectAggregated.Evaluation %}
+    <div class="page-hero animate-fade-in-up">
+        <h1 class="verdict-title">
+            No rule was evaluated.<br>
+            <span class="verdict-muted">Nothing was checked on this code base.</span>
+        </h1>
+        <p class="verdict-lead mt-4">
+            Declare requirements in your <code class="ident">.ast-metrics.yaml</code> file, then run the
+            analysis again: every rule you enable will be checked here, file by file.
+        </p>
+    </div>
+{% else %}
 
-    .dashboard-card:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-        border-color: #cbd5e1;
-    }
+<div x-data="linters()" x-init="init()">
 
-    .dashboard-card::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, #3b82f6, #8b5cf6);
-        opacity: 0;
-        transition: opacity 0.3s ease;
-    }
+    <!-- Verdict: what the rules found -->
+    <div class="page-hero animate-fade-in-up">
+        <div class="flex flex-wrap items-start justify-between gap-8">
+            <div class="min-w-0">
+                <template x-if="!loading">
+                    <div>
+                        <span class="level-pill mb-5"
+                              :class="total === 0 ? 'level-pill--good' : (count('high') > 0 ? 'level-pill--bad' : 'level-pill--warn')">
+                            <span class="dot" :class="total === 0 ? 'sev-good' : (count('high') > 0 ? 'sev-bad' : 'sev-warn')"></span>
+                            <span x-text="total === 0 ? 'Every check passes' : (count('high') > 0 ? 'High severity findings' : 'Medium and low severity only')"></span>
+                        </span>
+                    </div>
+                </template>
+                <p class="page-kicker mb-3" x-text="kicker">&nbsp;</p>
+                <h1 class="verdict-title">
+                    <span x-text="headline">&nbsp;</span><br>
+                    <span class="verdict-muted" x-text="headlineMuted"></span>
+                </h1>
+                <p class="verdict-lead mt-4" x-html="lead"></p>
+            </div>
+            <div class="kpi-strip kpi-strip--divided shrink-0">
+                <div>
+                    <div class="kpi-value" x-text="fmt(count('high'))">0</div>
+                    <div class="kpi-label">high severity</div>
+                </div>
+                <div>
+                    <div class="kpi-value" x-text="fmt(count('medium') + count('low'))">0</div>
+                    <div class="kpi-label">medium or low</div>
+                </div>
+                <div>
+                    <div class="kpi-value" x-text="fmt(rulesBroken)">0</div>
+                    <div class="kpi-label">rules broken</div>
+                </div>
+            </div>
+        </div>
+    </div>
 
-    .dashboard-card:hover::before {
-        opacity: 1;
-    }
+    <div class="mt-6">
+        {% include "partials/language_tabs.html" with pageBase="linters" %}
+    </div>
 
-    @keyframes fadeIn {
-        from { opacity: 0; transform: translateY(10px); }
-        to { opacity: 1; transform: translateY(0); }
-    }
-
-    .animate-fade-in-up {
-        animation: fadeIn 0.5s ease-out backwards;
-    }
-
-    .stagger-1 { animation-delay: 0.1s; }
-    .stagger-2 { animation-delay: 0.2s; }
-    .stagger-3 { animation-delay: 0.3s; }
-    .stagger-4 { animation-delay: 0.4s; }
-</style>
-
-    <!-- start: language tabs-->
-    <div class="flex overflow-x-auto overflow-y-hidden border-b border-gray-200 whitespace-nowrap ">
-
-        <a 
-            tabindex="-1"
-            href="linters.html"
-            class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center {% if currentLanguage == 'All' %}text-blue-600 border-blue-500{% endif %} bg-transparent border-b-2 sm:px-4 -px-1 focus:outline-none">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
+    <div class="text-center mt-8 mb-8" x-show="loading">
+        <div role="status">
+            <svg aria-hidden="true" class="inline w-8 h-8 text-gray-200 animate-spin fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
+                <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
             </svg>
-
-            <span class="mx-1 text-sm sm:text-base">
-                All languages <span class="text-xs sm:text-sm">({{ projectAggregated.Combined.ConcernedFiles|length }} files)</span>
-            </span>
-        </a>
-
-        <!-- start: language tab -->
-            {% for languageName, lang in projectAggregated.ByProgrammingLanguage %}
-            <a 
-                tabindex="0"
-                href="linters_{{ languageName|langSlug }}.html"
-                class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center bg-transparent border-b-2 {% if currentLanguage == languageName %}text-blue-600 border-blue-500{% else %}text-gray-700   border-transparent{% endif %} sm:px-4 -px-1 hover:border-gray-400">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-                </svg>
-    
-                <span class="mx-1 text-sm sm:text-base">
-                    {{ languageName }} <span class="text-xs sm:text-sm">({{ lang.ConcernedFiles|length }} files)</span>
-                </span>
-            </a>
-            {% endfor %}
-        <!-- end: language tab -->
-
+            <span class="sr-only">Loading...</span>
+        </div>
     </div>
-    <!-- end: language tabs-->
 
-    {% if not projectAggregated.Evaluation %}
-        <div class="mt-6 p-4 bg-yellow-50 border border-yellow-200 text-yellow-800 rounded-lg">No requirements were evaluated. Configure requirements to see linters results.</div>
-    {% else %}
+    <div class="mt-6 space-y-6" x-cloak x-show="!loading" x-transition.opacity.duration.200ms>
 
-    <div x-data="linters()" x-init="init()">
-        <!-- start: line of cards -->
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-6">
-
-            <!-- High -->
-            <div class="dashboard-card p-5 animate-fade-in-up stagger-1">
+        <!-- Which rules are broken -->
+        <div class="soft-card animate-fade-in-up">
+            <div class="flex items-start justify-between gap-4 mb-4">
                 <div>
-                    <h5 class="text-2xl font-bold text-gray-900 mb-1" style="letter-spacing: -0.3px;">
-                        <span class="text-red-600 bg-red-50 rounded-full px-3 py-1 text-sm font-medium">
-                            {{ projectAggregated.Evaluation.CountErrorsBySeverityString('high') }}
-                        </span>
-                    </h5>
-                    <p class="text-xs font-medium text-gray-500 mt-2 mb-3">High severity</p>
-                    <p class="border-t border-gray-100 pt-3 text-xs text-gray-500">
-                        Should probably be fixed.
-                    </p>
+                    <h2 class="card-title">Which rules are broken</h2>
+                    <p class="card-sub">How the violations spread over the rules you enabled. Click a rule to see only its violations.</p>
                 </div>
+                <button type="button" x-show="rule !== ''" @click="rule = ''"
+                        class="text-sm text-blue-600 hover:underline shrink-0">Clear rule filter</button>
             </div>
 
-            <!-- Medium -->
-            <div class="dashboard-card p-5 animate-fade-in-up stagger-2">
-                <div>
-                    <h5 class="text-2xl font-bold text-gray-900 mb-1" style="letter-spacing: -0.3px;">
-                        <span class="text-orange-600 bg-orange-50 rounded-full px-3 py-1 text-sm font-medium">
-                            {{ projectAggregated.Evaluation.CountErrorsBySeverityString('medium') }}
-                        </span>
-                    </h5>
-                    <p class="text-xs font-medium text-gray-500 mt-2 mb-3">Medium severity</p>
-                    <p class="border-t border-gray-100 pt-3 text-xs text-gray-500">
-                        May cause some issues.
-                    </p>
-                </div>
-            </div>
+            <template x-if="ruleGroups.length === 0">
+                <p class="text-sm text-gray-500 py-4">No violation matches the current filters.</p>
+            </template>
 
-            <!-- Low -->
-            <div class="dashboard-card p-5 animate-fade-in-up stagger-3">
-                <div>
-                    <h5 class="text-2xl font-bold text-gray-900 mb-1" style="letter-spacing: -0.3px;">
-                        <span class="text-yellow-600 bg-yellow-50 rounded-full px-3 py-1 text-sm font-medium">
-                            {{ projectAggregated.Evaluation.CountErrorsBySeverityString('low') }}
+            <template x-for="g in ruleGroups" :key="g.rule">
+                <button type="button" class="data-row w-full text-left px-2 -mx-2 rounded-lg hover:bg-slate-50"
+                        :class="rule === g.rule ? 'bg-slate-50' : ''"
+                        @click="rule = (rule === g.rule ? '' : g.rule)">
+                    <span class="dot" :class="dotClass(g.worst)"></span>
+                    <span class="min-w-0 flex-1">
+                        <span class="row-name truncate block" x-text="label(g.rule)"></span>
+                        <span class="row-meta block font-mono" x-text="g.rule"></span>
+                    </span>
+                    <span class="w-28 shrink-0 hidden sm:block">
+                        <span class="meter block" style="margin-top:0">
+                            <span class="meter-fill block" :class="dotClass(g.worst)" :style="'width:' + g.share + '%'"></span>
                         </span>
-                    </h5>
-                    <p class="text-xs font-medium text-gray-500 mt-2 mb-3">Low severity</p>
-                    <p class="border-t border-gray-100 pt-3 text-xs text-gray-500">
-                        Minor issues, mostly stylistic.
-                    </p>
-                </div>
-            </div>
-
-            <!-- Successes -->
-            <div class="dashboard-card p-5 animate-fade-in-up stagger-4">
-                <div>
-                    <h5 class="text-2xl font-bold text-gray-900 mb-1" style="letter-spacing: -0.3px;">
-                        <span class="text-green-600 bg-green-50 rounded-full px-3 py-1 text-sm font-medium">
-                            {{projectAggregated.Evaluation.Successes|length| floatformat:0}}
-                        </span>
-                    </h5>
-                    <p class="text-xs font-medium text-gray-500 mt-2 mb-3">Successes</p>
-                    <p class="border-t border-gray-100 pt-3 text-xs text-gray-500">
-                        Successful linter checks.
-                    </p>
-                </div>
-            </div>
-        </div>
-        <!-- end: line of cards -->
-
-        <div class="text-center mt-8 mb-8" x-show="loading">
-            <div role="status">
-                <svg aria-hidden="true" class="inline w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
-                    <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
-                </svg>
-                <span class="sr-only">Loading...</span>
-            </div>
+                    </span>
+                    <span class="row-value w-16" x-text="fmt(g.count)"></span>
+                </button>
+            </template>
         </div>
 
-
-        <!-- Filters -->
-        <div class="mt-6 flex flex-col md:flex-row md:items-end gap-4" x-cloak x-show="!loading" x-transition.opacity.duration.200ms>
-            <div>
-                <label class="block text-sm font-medium text-gray-700">Filter by severity</label>
-                <select x-model="severity" class="mt-1 block w-52 pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md">
-                    <option value="">All</option>
-                    <option value="high">High</option>
-                    <option value="medium">Medium</option>
-                    <option value="low">Low</option>
-                    <option value="unknown">Unknown</option>
-                </select>
+        <!-- The violations themselves -->
+        <div class="soft-card animate-fade-in-up">
+            <div class="flex items-start justify-between gap-4 mb-4">
+                <div>
+                    <h2 class="card-title">Every violation, one per line</h2>
+                    <p class="card-sub" x-text="tableSub"></p>
+                </div>
             </div>
-            <div class="flex-1">
-                <label class="block text-sm font-medium text-gray-700">Search</label>
-                <input x-model.debounce.200ms="query" type="text" placeholder="Search by message, rule, or file..." class="mt-1 block w-full pl-3 pr-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" />
-            </div>
-        </div>
 
-        <!-- Table -->
-        <div class="mt-6 overflow-x-auto dashboard-card p-6"  x-cloak x-show="!loading" x-transition.opacity.duration.200ms>
-            <table class="min-w-full divide-y divide-gray-200 sortable">
-                <thead class="bg-gray-50">
-                    <tr>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">File</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Severity</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rule</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Message</th>
-                    </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                    <template x-for="e in filtered" >
-                        <tr>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900" x-text="e.file"></td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full"
-                                      :class="badgeClass(e.severity)">
-                                    <span x-text="(e.severity||'unknown').toLowerCase()"></span>
-                                </span>
-                            </td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900" x-text="e.rule"></td>
-                            <td class="px-6 py-4 whitespace-normal text-sm text-gray-900" x-text="e.message"></td>
+            <!-- Filters -->
+            <div class="flex flex-col md:flex-row md:items-end gap-4 mb-5">
+                <div>
+                    <label class="block text-xs font-medium text-gray-500 mb-1" for="linter-severity">Severity</label>
+                    <select id="linter-severity" x-model="severity"
+                            class="block w-48 pl-3 pr-10 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-blue-500 focus:border-blue-500">
+                        <option value="">All severities</option>
+                        <option value="high">High</option>
+                        <option value="medium">Medium</option>
+                        <option value="low">Low</option>
+                        <option value="unknown">Unknown</option>
+                    </select>
+                </div>
+                <div class="flex-1">
+                    <label class="block text-xs font-medium text-gray-500 mb-1" for="linter-search">Search</label>
+                    <input id="linter-search" x-model.debounce.200ms="query" type="text"
+                           placeholder="Search by message, rule, or file..."
+                           class="block w-full pl-3 pr-3 py-2 text-sm border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+                </div>
+            </div>
+
+            <div class="overflow-x-auto">
+                <table class="sortable w-full min-w-full">
+                    <thead>
+                        <tr class="border-b border-gray-200">
+                            <th scope="col" title="How serious the rule declares its own violations to be. It comes from your ruleset, not from a judgement on the code."
+                                class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-left">Severity</th>
+                            <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-left">Rule</th>
+                            <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-left">File</th>
+                            <th scope="col" class="py-3 px-4 text-xs font-semibold text-gray-600 uppercase tracking-wide text-left">What was measured</th>
                         </tr>
-                    </template>
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody class="divide-y divide-gray-100">
+                        <tr x-show="filtered.length === 0">
+                            <td colspan="4" class="px-4 py-12 text-center text-sm text-gray-500">
+                                No violation matches these filters.
+                            </td>
+                        </tr>
+                        <template x-for="e in filtered">
+                            <tr class="hover:bg-slate-50 transition-colors">
+                                <td class="px-4 py-3 whitespace-nowrap">
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full"
+                                          :class="badgeClass(e.severity)">
+                                        <span x-text="(e.severity||'unknown').toLowerCase()"></span>
+                                    </span>
+                                </td>
+                                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-900" x-text="label(e.rule)" :title="e.rule"></td>
+                                <td class="px-4 py-3 text-sm font-mono text-xs text-gray-600" x-text="shortPath(e.file)" :title="e.file"></td>
+                                <td class="px-4 py-3 whitespace-normal text-sm text-gray-900" x-text="e.message"></td>
+                            </tr>
+                        </template>
+                    </tbody>
+                </table>
+            </div>
         </div>
-    </div>
 
-    <script>
-        function linters() {
-            return {
-                errors: [],
-                successes: [],
-                allowed: new Set(),
-                severity: '',
-                loading: true,
-                query: '',
-                init() {
-                    // Decode dictionary-encoded linter data from data/linters.js
-                    const L = window.__AST_LINTERS__ || {};
-                    const dict = L.d || {};
-                    const decode = (arr) => (arr || []).map(t => ({
-                        rule: dict[t[0]] || t[0],
-                        severity: dict[t[1]] || t[1],
-                        file: dict[t[2]] || t[2],
-                        message: t[3]
-                    }));
-                    this.errors = decode(L.e);
-                    this.successes = decode(L.s);
-                    // Derive allowed files from the per-language files list (Level 2)
-                    const d = window.__AST_DATA__ || {};
-                    this.allowed = new Set((d.files || []).map(f => f.path));
-                    this.loading = false;
-                },
-                inScope(item) {
-                    if (this.allowed.size === 0) return true;
-                    if (!item.file) return false;
-                    return this.allowed.has(item.file);
-                },
-                count(sev) {
-                    const s = (sev || 'unknown').toLowerCase();
-                    return this.errors.filter(e => this.inScope(e) && (e.severity || 'unknown').toLowerCase() === s).length;
-                },
-                get countSuccess() {
-                    const explicit = this.successes.filter(e => this.inScope(e)).length;
-                    if (explicit > 0) return explicit;
-                    const filesWithErrors = new Set(this.errors.filter(e => this.inScope(e)).map(e => e.file));
-                    let total = 0;
-                    for (const f of this.allowed) {
-                        if (!filesWithErrors.has(f)) total++;
-                    }
-                    return total;
-                },
-                badgeClass(sev) {
-                    const s = (sev || 'unknown').toLowerCase();
-                    if (s === 'high') return 'bg-red-100 text-red-800';
-                    if (s === 'medium') return 'bg-orange-100 text-orange-800';
-                    if (s === 'low') return 'bg-green-100 text-green-800';
-                    return 'bg-gray-200 text-gray-800';
-                },
-                get filtered() {
-                    let rows = this.errors.filter(e => this.inScope(e));
-                    if (this.severity) {
-                        const sev = this.severity.toLowerCase();
-                        rows = rows.filter(e => (e.severity || 'unknown').toLowerCase() === sev);
-                    }
-                    if (this.query) {
-                        const q = this.query.toLowerCase();
-                        rows = rows.filter(e => (e.message || '').toLowerCase().includes(q)
-                            || (e.rule || '').toLowerCase().includes(q)
-                            || (e.file || '').toLowerCase().includes(q));
-                    }
-                    const order = {high:0, medium:1, low:2, unknown:3};
-                    rows.sort((a, b) => {
-                        if (a.file !== b.file) return a.file < b.file ? -1 : 1;
-                        const as = (a.severity || 'unknown').toLowerCase();
-                        const bs = (b.severity || 'unknown').toLowerCase();
-                        if (order[as] !== order[bs]) return order[as] - order[bs];
-                        const ar = (a.rule || ''), br = (b.rule || '');
-                        return ar < br ? -1 : (ar > br ? 1 : 0);
-                    });
-                    return rows;
+    </div>
+</div>
+
+<script>
+    function linters() {
+        return {
+            errors: [],
+            successes: [],
+            allowed: new Set(),
+            prefix: '',
+            severity: '',
+            rule: '',
+            loading: true,
+            query: '',
+            init() {
+                // Decode dictionary-encoded linter data from data/linters.js
+                const L = window.__AST_LINTERS__ || {};
+                const dict = L.d || {};
+                const decode = (arr) => (arr || []).map(t => ({
+                    rule: dict[t[0]] || t[0],
+                    severity: dict[t[1]] || t[1],
+                    file: dict[t[2]] || t[2],
+                    message: t[3]
+                }));
+                this.errors = decode(L.e);
+                this.successes = decode(L.s);
+                // Derive allowed files from the per-language files list (Level 2)
+                const d = window.__AST_DATA__ || {};
+                this.allowed = new Set((d.files || []).map(f => f.path));
+                this.prefix = this.commonPrefix(this.errors.filter(e => this.inScope(e)).map(e => e.file));
+                this.loading = false;
+            },
+            // Longest directory prefix shared by every reported file: shown paths stay readable,
+            // the full path remains available in the title attribute.
+            commonPrefix(paths) {
+                if (paths.length < 2) return '';
+                let prefix = paths[0] || '';
+                for (const p of paths) {
+                    let i = 0;
+                    while (i < prefix.length && i < p.length && prefix[i] === p[i]) i++;
+                    prefix = prefix.slice(0, i);
+                    if (!prefix) break;
                 }
+                const cut = prefix.lastIndexOf('/');
+                return cut > 0 ? prefix.slice(0, cut + 1) : '';
+            },
+            shortPath(path) {
+                const p = path || '';
+                return this.prefix && p.startsWith(this.prefix) ? p.slice(this.prefix.length) : p;
+            },
+            inScope(item) {
+                if (this.allowed.size === 0) return true;
+                if (!item.file) return false;
+                return this.allowed.has(item.file);
+            },
+            fmt(n) {
+                return (n || 0).toLocaleString('en-US');
+            },
+            // "max_loc_by_method" reads as "Max LOC by method"
+            label(rule) {
+                const acronyms = { loc: 'LOC', lloc: 'LLOC', lcom: 'LCOM', lcom4: 'LCOM4', api: 'API', ci: 'CI' };
+                const words = (rule || '').replace(/[_-]+/g, ' ').trim().split(' ').filter(Boolean);
+                if (!words.length) return 'Unknown rule';
+                const out = words.map(w => acronyms[w.toLowerCase()] || w);
+                if (!acronyms[words[0].toLowerCase()]) {
+                    out[0] = out[0].charAt(0).toUpperCase() + out[0].slice(1);
+                }
+                return out.join(' ');
+            },
+            count(sev) {
+                const s = (sev || 'unknown').toLowerCase();
+                return this.errors.filter(e => this.inScope(e) && (e.severity || 'unknown').toLowerCase() === s).length;
+            },
+            get total() {
+                return this.errors.filter(e => this.inScope(e)).length;
+            },
+            get rulesBroken() {
+                return new Set(this.errors.filter(e => this.inScope(e)).map(e => e.rule)).size;
+            },
+            get countSuccess() {
+                const explicit = this.successes.filter(e => this.inScope(e)).length;
+                if (explicit > 0) return explicit;
+                const filesWithErrors = new Set(this.errors.filter(e => this.inScope(e)).map(e => e.file));
+                let total = 0;
+                for (const f of this.allowed) {
+                    if (!filesWithErrors.has(f)) total++;
+                }
+                return total;
+            },
+            get kicker() {
+                const files = this.allowed.size || new Set(this.errors.map(e => e.file)).size;
+                const rules = new Set(this.errors.concat(this.successes).map(e => e.rule)).size;
+                return this.fmt(files) + ' files checked · ' + this.fmt(rules) + ' rules evaluated';
+            },
+            get headline() {
+                if (this.total === 0) return 'No rule is broken.';
+                const rules = this.rulesBroken;
+                return this.fmt(this.total) + (this.total > 1 ? ' violations' : ' violation')
+                    + ', spread over ' + this.fmt(rules) + (rules > 1 ? ' rules.' : ' rule.');
+            },
+            get headlineMuted() {
+                return this.fmt(this.countSuccess) + (this.countSuccess === 1 ? ' check passes.' : ' checks pass.');
+            },
+            get lead() {
+                const high = this.count('high');
+                if (this.total === 0) {
+                    return 'Every rule you enabled was checked against every file, and none of them was broken.';
+                }
+                const rest = this.total - high;
+                if (high === 0) {
+                    return 'All <strong>' + this.fmt(rest) + '</strong> of them are medium or low severity. '
+                        + 'Severity is the one declared by each rule in your configuration, not a judgement on the code.';
+                }
+                return '<strong>' + this.fmt(high) + '</strong> of them are high severity, '
+                    + '<strong>' + this.fmt(rest) + '</strong> medium or low. '
+                    + 'Severity is the one declared by each rule in your configuration, not a judgement on the code.';
+            },
+            get tableSub() {
+                const shown = this.filtered.length;
+                if (shown === this.total) {
+                    return 'All ' + this.fmt(this.total) + ' violations, with the measurement that triggered them.';
+                }
+                return this.fmt(shown) + ' of ' + this.fmt(this.total) + ' violations shown.';
+            },
+            badgeClass(sev) {
+                const s = (sev || 'unknown').toLowerCase();
+                if (s === 'high') return 'bg-red-100 text-red-800';
+                if (s === 'medium') return 'bg-amber-100 text-amber-700';
+                if (s === 'low') return 'bg-slate-100 text-slate-700';
+                return 'bg-gray-200 text-gray-800';
+            },
+            dotClass(sev) {
+                const s = (sev || 'unknown').toLowerCase();
+                if (s === 'high') return 'sev-bad';
+                if (s === 'medium') return 'sev-warn';
+                return 'sev-none';
+            },
+            // Rows matching the severity filter and the search, before the rule filter:
+            // the rule list stays browsable while a rule is selected.
+            get matching() {
+                let rows = this.errors.filter(e => this.inScope(e));
+                if (this.severity) {
+                    const sev = this.severity.toLowerCase();
+                    rows = rows.filter(e => (e.severity || 'unknown').toLowerCase() === sev);
+                }
+                if (this.query) {
+                    const q = this.query.toLowerCase();
+                    rows = rows.filter(e => (e.message || '').toLowerCase().includes(q)
+                        || (e.rule || '').toLowerCase().includes(q)
+                        || (e.file || '').toLowerCase().includes(q));
+                }
+                return rows;
+            },
+            get ruleGroups() {
+                const order = { high: 0, medium: 1, low: 2, unknown: 3 };
+                const groups = new Map();
+                for (const e of this.matching) {
+                    const key = e.rule || 'unknown';
+                    let g = groups.get(key);
+                    if (!g) {
+                        g = { rule: key, count: 0, worst: 'unknown', share: 0 };
+                        groups.set(key, g);
+                    }
+                    g.count++;
+                    const sev = (e.severity || 'unknown').toLowerCase();
+                    if (order[sev] < order[g.worst]) g.worst = sev;
+                }
+                const list = Array.from(groups.values()).sort((a, b) => b.count - a.count || (a.rule < b.rule ? -1 : 1));
+                const max = list.length ? list[0].count : 1;
+                list.forEach(g => { g.share = Math.round((g.count / max) * 100); });
+                return list;
+            },
+            get filtered() {
+                let rows = this.matching;
+                if (this.rule) {
+                    rows = rows.filter(e => e.rule === this.rule);
+                }
+                const order = { high: 0, medium: 1, low: 2, unknown: 3 };
+                rows = rows.slice().sort((a, b) => {
+                    const as = (a.severity || 'unknown').toLowerCase();
+                    const bs = (b.severity || 'unknown').toLowerCase();
+                    if (order[as] !== order[bs]) return order[as] - order[bs];
+                    if (a.file !== b.file) return a.file < b.file ? -1 : 1;
+                    const ar = (a.rule || ''), br = (b.rule || '');
+                    return ar < br ? -1 : (ar > br ? 1 : 0);
+                });
+                return rows;
             }
         }
-    </script>
+    }
+</script>
 
-    {% endif %}
+{% endif %}
 
 {% endblock %}

--- a/internal/report/templates/html/metrics.html
+++ b/internal/report/templates/html/metrics.html
@@ -233,7 +233,7 @@ document.addEventListener('alpine:init', () => {
                 <span class="row-name flex-1 flex items-center gap-1.5">Cyclomatic complexity per method
                     <span tabindex="0" data-tip="Average number of independent execution paths per method. Below 5 methods stay easy to test." class="text-gray-300 text-xs">ⓘ</span></span>
                 <span class="row-value">{{ currentView.CyclomaticComplexityPerMethod.Avg|floatformat:2 }}
-                    {% if currentView.CyclomaticComplexityPerMethod.Max > 0 %}<span class="text-xs text-gray-400 font-sans font-normal">min {{ currentView.CyclomaticComplexityPerMethod.Min|floatformat:0 }} · max {{ currentView.CyclomaticComplexityPerMethod.Max|floatformat:0 }}</span>{% endif %}</span>
+                    {% if currentView.CyclomaticComplexityPerMethod.Max > 0 %}<span class="text-xs text-gray-500 font-sans font-normal">min {{ currentView.CyclomaticComplexityPerMethod.Min|floatformat:0 }} · max {{ currentView.CyclomaticComplexityPerMethod.Max|floatformat:0 }}</span>{% endif %}</span>
             </div>
             <div class="data-row">
                 <span class="row-name flex-1 flex items-center gap-1.5">Cyclomatic complexity per class
@@ -249,7 +249,7 @@ document.addEventListener('alpine:init', () => {
                 <span class="row-name flex-1 flex items-center gap-1.5">LCOM4 per class
                     <span tabindex="0" data-tip="Number of unrelated responsibility groups per class. 1 means each class does one thing." class="text-gray-300 text-xs">ⓘ</span></span>
                 <span class="row-value">{{ currentView.Lcom4PerClass.Avg|floatformat:2 }}
-                    {% if currentView.Lcom4PerClass.Max > 0 %}<span class="text-xs text-gray-400 font-sans font-normal">min {{ currentView.Lcom4PerClass.Min|floatformat:0 }} · max {{ currentView.Lcom4PerClass.Max|floatformat:0 }}</span>{% endif %}</span>
+                    {% if currentView.Lcom4PerClass.Max > 0 %}<span class="text-xs text-gray-500 font-sans font-normal">min {{ currentView.Lcom4PerClass.Min|floatformat:0 }} · max {{ currentView.Lcom4PerClass.Max|floatformat:0 }}</span>{% endif %}</span>
             </div>
             <div class="data-row">
                 <span class="row-name flex-1 flex items-center gap-1.5">Afferent coupling (Ca)
@@ -278,7 +278,7 @@ document.addEventListener('alpine:init', () => {
                 <span class="row-name flex-1 flex items-center gap-1.5">Maintainability Index
                     <span tabindex="0" data-tip="Composite of size, complexity and Halstead volume (0-128). Above 85 the code is comfortable to work with." class="text-gray-300 text-xs">ⓘ</span></span>
                 <span class="row-value">{{ currentView.MaintainabilityIndex.Avg|floatformat:1 }}
-                    {% if currentView.MaintainabilityIndex.Max > 0 %}<span class="text-xs text-gray-400 font-sans font-normal">min {{ currentView.MaintainabilityIndex.Min|floatformat:0 }} · max {{ currentView.MaintainabilityIndex.Max|floatformat:0 }}</span>{% endif %}</span>
+                    {% if currentView.MaintainabilityIndex.Max > 0 %}<span class="text-xs text-gray-500 font-sans font-normal">min {{ currentView.MaintainabilityIndex.Min|floatformat:0 }} · max {{ currentView.MaintainabilityIndex.Max|floatformat:0 }}</span>{% endif %}</span>
             </div>
             <div class="data-row">
                 <span class="row-name flex-1 flex items-center gap-1.5">Without comments
@@ -320,7 +320,7 @@ document.addEventListener('alpine:init', () => {
             </div>
         </div>
         <p class="card-sub mt-4 pt-3 border-t border-gray-100">
-            Per-class Halstead details (vocabulary, length, bugs) are available on the <a href="classes{{ scopeSuffix }}.html" class="text-blue-600 hover:underline">Classes</a> page.
+            Per-class Halstead details (vocabulary, length, bugs) are available on the <a href="classes{{ scopeSuffix }}.html" class="text-blue-600 underline">Classes</a> page.
         </p>
     </div>
 </div>
@@ -332,7 +332,7 @@ document.addEventListener('alpine:init', () => {
     <div class="relative soft-card w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         <div class="flex items-center justify-between mb-4 pb-3 border-b border-gray-200">
             <h3 class="card-title" x-text="$store.helpModal.title"></h3>
-            <button @click="$store.helpModal.open = false" class="text-gray-400 hover:text-gray-600 transition-colors">
+            <button @click="$store.helpModal.open = false" class="text-gray-500 hover:text-gray-600 transition-colors">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
             </button>
         </div>

--- a/internal/report/templates/html/metrics.html
+++ b/internal/report/templates/html/metrics.html
@@ -1,0 +1,349 @@
+{% extends "layout.html" %}
+
+{% block title %}
+Metrics
+{% endblock %}
+
+{% block pageTitle %}
+AST Metrics - Metrics
+{% endblock %}
+
+{% block content %}
+
+<script>
+document.addEventListener('alpine:init', () => {
+    Alpine.store('helpModal', { open: false, title: '', video: '', link: '' });
+});
+</script>
+
+<style>
+    .metric-value {
+        font-family: var(--font-mono);
+        letter-spacing: -0.05em;
+    }
+</style>
+
+{% set avgCcPerMethod = currentView.CyclomaticComplexityPerMethod.Avg %}
+{% set avgLocPerMethod = currentView.LocPerMethod.Avg %}
+{% set avgLocPerFile = currentView.Loc.Avg %}
+
+<!-- Verdict -->
+<div class="page-hero animate-fade-in-up mb-6">
+    <div class="flex flex-wrap items-start justify-between gap-8">
+        <div class="min-w-0">
+            <p class="page-kicker mb-3">
+                {{ scopeLabel|upper }} ·
+                PRODUCTION FILES ONLY
+            </p>
+            <h1 class="verdict-title">
+                {% if avgCcPerMethod <= 5 %}
+                    {% if avgLocPerMethod <= 20 %}
+                        {% if avgLocPerFile > 250 %}
+                        Methods stay simple, files get long.<br>
+                        <span class="verdict-muted">The weight sits in how much each file holds.</span>
+                        {% else %}
+                        The code stays small and simple.<br>
+                        <span class="verdict-muted">Nothing in the aggregates stands out.</span>
+                        {% endif %}
+                    {% else %}
+                    Methods stay simple, but they run long.<br>
+                    <span class="verdict-muted">Few branches, many lines: mostly straight-line code.</span>
+                    {% endif %}
+                {% else %}
+                    {% if avgLocPerMethod <= 20 %}
+                    Short methods, dense logic.<br>
+                    <span class="verdict-muted">Each one packs more branches than its size suggests.</span>
+                    {% else %}
+                    Methods are long and branch-heavy.<br>
+                    <span class="verdict-muted">Both size and control flow run past the usual limits.</span>
+                    {% endif %}
+                {% endif %}
+            </h1>
+            <p class="verdict-lead mt-4">
+                On average a method holds <strong>{{ currentView.LocPerMethod.Avg|floatformat:0 }} lines</strong>
+                and <strong>{{ currentView.CyclomaticComplexityPerMethod.Avg|floatformat:1 }} decision paths</strong>,
+                while a file holds <strong>{{ currentView.Loc.Avg|floatformat:0 }} lines</strong>.
+                Maintainability averages <strong>{{ currentView.MaintainabilityIndex.Avg|floatformat:0 }}</strong>
+                against a target of 85, and a class covers
+                <strong>{{ currentView.Lcom4PerClass.Avg|floatformat:1 }}</strong> groups of unrelated methods
+                where 1 means one job per class.
+            </p>
+        </div>
+        <div class="kpi-strip kpi-strip--divided shrink-0">
+            <div>
+                <div class="kpi-value">{{ currentView.ConcernedFiles|length }}</div>
+                <div class="kpi-label">files</div>
+            </div>
+            <div>
+                <div class="kpi-value">{{ currentView.NbClasses }}</div>
+                <div class="kpi-label">classes<br>&amp; structs</div>
+            </div>
+            <div>
+                <div class="kpi-value">{{ currentView.NbMethods }}</div>
+                <div class="kpi-label">methods<br>&amp; functions</div>
+            </div>
+            <div>
+                <div class="kpi-value">{{ currentView.Loc.Sum|stringifyNumber }}</div>
+                <div class="kpi-label" tabindex="0" data-tip="Physical lines of the production files, comments and blank lines included. Logical lines: {{ currentView.Lloc.Sum|stringifyNumber }}.">lines of code ⓘ</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% include "partials/language_tabs.html" with pageBase="metrics" %}
+
+<p class="section-title mb-3">How the codebase spreads out</p>
+
+<!-- Distribution charts -->
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+
+    <!-- Complexity per method -->
+    <div class="soft-card animate-fade-in-up stagger-1">
+        <div class="flex items-start justify-between gap-2">
+            <div class="min-w-0">
+                <h2 class="card-title">Branching per method</h2>
+                <p class="card-sub">How many decision paths a method holds.</p>
+            </div>
+            <button x-data @click="Object.assign($store.helpModal, { open: true, title: 'Cyclomatic Complexity', video: 'https://ast-metrics.dev/animations/Cyclomatic-complexity.webm', link: 'https://ast-metrics.dev/metrics/cyclomatic-complexity/' })" class="shrink-0 text-gray-300 hover:text-blue-500 transition-colors" title="Watch video explanation">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.91 11.672a.375.375 0 010 .656l-5.603 3.113a.375.375 0 01-.557-.328V8.887c0-.286.307-.466.557-.327l5.603 3.112z" /></svg>
+            </button>
+        </div>
+        <div class="flex items-baseline gap-2 mt-3">
+            <span class="stat-tile-value metric-value">{{ currentView.CyclomaticComplexityPerMethod.Avg | floatformat:2 }}</span>
+            {% if currentView.Comparaison %}
+            {% include 'componentComparaisonBadge.html' with comparaisonMode='lowIsBetter' diff=currentView.Comparaison.AverageCyclomaticComplexityPerMethod round=2 %}
+            {% endif %}
+        </div>
+        <div class="stat-tile-target">average per method &middot; target under 5</div>
+        <div class="card-graph mt-3">
+            {{ currentView|barchartCyclomaticByMethodRepartition}}
+        </div>
+    </div>
+
+    <!-- Class cohesion -->
+    <div class="soft-card animate-fade-in-up stagger-1">
+        <div class="flex items-start justify-between gap-2">
+            <div class="min-w-0">
+                <h2 class="card-title">Focused classes</h2>
+                <p class="card-sub">Unrelated groups of methods per class (LCOM4).</p>
+            </div>
+            <button x-data @click="Object.assign($store.helpModal, { open: true, title: 'Class Cohesion (LCOM4)', video: 'https://ast-metrics.dev/animations/lcom.webm', link: 'https://ast-metrics.dev/metrics/lcom4/' })" class="shrink-0 text-gray-300 hover:text-blue-500 transition-colors" title="Watch video explanation">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.91 11.672a.375.375 0 010 .656l-5.603 3.113a.375.375 0 01-.557-.328V8.887c0-.286.307-.466.557-.327l5.603 3.112z" /></svg>
+            </button>
+        </div>
+        <div class="flex items-baseline gap-2 mt-3">
+            {% set lcomClass="text-bad" %}
+            {% if currentView.Lcom4PerClass.Avg < 1.7 %}{% set lcomClass="text-good" %}{% elif currentView.Lcom4PerClass.Avg < 3 %}{% set lcomClass="text-warn" %}{% endif %}
+            <span class="stat-tile-value metric-value {{ lcomClass }}">{{ currentView.Lcom4PerClass.Avg | floatformat:1 }}</span>
+            {% if currentView.Comparaison %}
+            {% include 'componentComparaisonBadge.html' with comparaisonMode='lowIsBetter' diff=currentView.Comparaison.AverageLcom4 round=2 %}
+            {% endif %}
+        </div>
+        <div class="stat-tile-target">average per class &middot; 1 is ideal</div>
+        <div class="card-graph mt-3">
+            {{ currentView|barchartLcomRepartition}}
+        </div>
+    </div>
+
+    <!-- Maintainability -->
+    <div class="soft-card animate-fade-in-up stagger-2">
+        <div class="min-w-0">
+            <h2 class="card-title">Ease of maintenance</h2>
+            <p class="card-sub">Maintainability Index, from 0 to 128.</p>
+        </div>
+        <div class="flex items-baseline gap-2 mt-3">
+            {% set miClass="text-bad" %}
+            {% if currentView.MaintainabilityIndex.Avg > 84 %}{% set miClass="text-good" %}{% elif currentView.MaintainabilityIndex.Avg > 64 %}{% set miClass="text-warn" %}{% endif %}
+            <span class="stat-tile-value metric-value {{ miClass }}">{{ currentView.MaintainabilityIndex.Avg | floatformat:0 }}</span>
+            {% if currentView.Comparaison %}
+            {% include 'componentComparaisonBadge.html' with comparaisonMode='highIsBetter' diff=currentView.Comparaison.AverageMI round=2 %}
+            {% endif %}
+        </div>
+        <div class="stat-tile-target">average per class &middot; target &ge; 85</div>
+        <div class="card-graph mt-3">
+            {{ currentView|barchartMaintainabilityIndexRepartition}}
+        </div>
+    </div>
+
+    <!-- Method size -->
+    <div class="soft-card animate-fade-in-up stagger-2">
+        <div class="min-w-0">
+            <h2 class="card-title">Method size</h2>
+            <p class="card-sub">Lines of code inside a single method.</p>
+        </div>
+        <div class="flex items-baseline gap-2 mt-3">
+            <span class="stat-tile-value metric-value">{{ currentView.LocPerMethod.Avg | floatformat:0 }}</span>
+            {% if currentView.Comparaison %}
+            {% include 'componentComparaisonBadge.html' with comparaisonMode='lowIsBetter' diff=currentView.Comparaison.AverageLocPerMethod round=2 %}
+            {% endif %}
+        </div>
+        <div class="stat-tile-target">average per method &middot; ideally under 20</div>
+        <div class="card-graph mt-3">
+            {{ currentView|barchartLocPerMethodRepartition}}
+        </div>
+    </div>
+</div>
+
+<p class="section-title mb-3">Every aggregate, in detail</p>
+
+<!-- Detailed aggregates -->
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+    <!-- Size & volume -->
+    <div class="soft-card animate-fade-in-up stagger-3">
+        <h2 class="card-title">Size &amp; volume</h2>
+        <p class="card-sub mb-2">How much code there is, and how it splits between files and methods.</p>
+        <div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Lines of code (LOC), total
+                    <span tabindex="0" data-tip="Physical lines, comments and blank lines included." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.Loc.Sum|stringifyNumber }}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Logical lines (LLOC), total
+                    <span tabindex="0" data-tip="Statement lines only, the real amount of executable code." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.Lloc.Sum|stringifyNumber }}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Comment lines (CLOC), total
+                    <span tabindex="0" data-tip="Lines of comments." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.Cloc.Sum|stringifyNumber }}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1">Average LOC per file</span>
+                <span class="row-value">{{ currentView.Loc.Avg|floatformat:0 }}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1">Average LOC per method</span>
+                <span class="row-value">{{ currentView.LocPerMethod.Avg|floatformat:1 }}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1">Average LLOC per method</span>
+                <span class="row-value">{{ currentView.LlocPerMethod.Avg|floatformat:1 }}</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Complexity + cohesion & coupling -->
+    <div class="soft-card animate-fade-in-up stagger-3">
+        <h2 class="card-title">Complexity</h2>
+        <p class="card-sub mb-2">How much branching the code asks a reader to follow.</p>
+        <div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Cyclomatic complexity per method
+                    <span tabindex="0" data-tip="Average number of independent execution paths per method. Below 5 methods stay easy to test." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.CyclomaticComplexityPerMethod.Avg|floatformat:2 }}
+                    {% if currentView.CyclomaticComplexityPerMethod.Max > 0 %}<span class="text-xs text-gray-400 font-sans font-normal">min {{ currentView.CyclomaticComplexityPerMethod.Min|floatformat:0 }} · max {{ currentView.CyclomaticComplexityPerMethod.Max|floatformat:0 }}</span>{% endif %}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Cyclomatic complexity per class
+                    <span tabindex="0" data-tip="Average of the summed complexity of each class's methods." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.CyclomaticComplexityPerClass.Avg|floatformat:1 }}</span>
+            </div>
+        </div>
+
+        <h2 class="card-title mt-6">Cohesion &amp; coupling</h2>
+        <p class="card-sub mb-2">Whether each class does one job, and how tied together they are.</p>
+        <div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">LCOM4 per class
+                    <span tabindex="0" data-tip="Number of unrelated responsibility groups per class. 1 means each class does one thing." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.Lcom4PerClass.Avg|floatformat:2 }}
+                    {% if currentView.Lcom4PerClass.Max > 0 %}<span class="text-xs text-gray-400 font-sans font-normal">min {{ currentView.Lcom4PerClass.Min|floatformat:0 }} · max {{ currentView.Lcom4PerClass.Max|floatformat:0 }}</span>{% endif %}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Afferent coupling (Ca)
+                    <span tabindex="0" data-tip="Average number of components that depend on a class. Shown as a dash when the language engine does not expose class-level dependencies." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{% if currentView.AfferentCoupling.Counter > 0 %}{{ currentView.AfferentCoupling.Avg|floatformat:2 }}{% else %}-{% endif %}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Efferent coupling (Ce)
+                    <span tabindex="0" data-tip="Average number of components a class depends on. Shown as a dash when the language engine does not expose class-level dependencies." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{% if currentView.EfferentCoupling.Counter > 0 %}{{ currentView.EfferentCoupling.Avg|floatformat:2 }}{% else %}-{% endif %}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Instability
+                    <span tabindex="0" data-tip="Ce / (Ce + Ca), from 0 (stable) to 1 (volatile), over the whole codebase." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{% if currentView.AfferentCoupling.Counter > 0 %}{{ currentView.Instability.Avg|floatformat:2 }}{% else %}-{% endif %}</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Maintainability -->
+    <div class="soft-card animate-fade-in-up stagger-4">
+        <h2 class="card-title">Maintainability</h2>
+        <p class="card-sub mb-2">How comfortable the code is to change, and how much comments help.</p>
+        <div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Maintainability Index
+                    <span tabindex="0" data-tip="Composite of size, complexity and Halstead volume (0-128). Above 85 the code is comfortable to work with." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.MaintainabilityIndex.Avg|floatformat:1 }}
+                    {% if currentView.MaintainabilityIndex.Max > 0 %}<span class="text-xs text-gray-400 font-sans font-normal">min {{ currentView.MaintainabilityIndex.Min|floatformat:0 }} · max {{ currentView.MaintainabilityIndex.Max|floatformat:0 }}</span>{% endif %}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Without comments
+                    <span tabindex="0" data-tip="Same index computed while ignoring comments. A large gap with the main index means readability relies heavily on comments." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.MaintainabilityIndexWithoutComments.Avg|floatformat:1 }}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Comment weight
+                    <span tabindex="0" data-tip="Contribution of comments to the Maintainability Index. Higher means comments help more." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.MaintainabilityCommentWeight.Avg|floatformat:1 }}</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Halstead -->
+    <div class="soft-card animate-fade-in-up stagger-4">
+        <h2 class="card-title">Halstead measures</h2>
+        <p class="card-sub mb-2">Average per class, derived from the count of operators and operands. Relative indicators.</p>
+        <div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Volume
+                    <span tabindex="0" data-tip="Size of the implementation in bits: length times log2(vocabulary)." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.HalsteadVolume.Avg|floatformat:0 }}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Difficulty
+                    <span tabindex="0" data-tip="How error-prone writing this code is, based on operator and operand reuse." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.HalsteadDifficulty.Avg|floatformat:1 }}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Effort
+                    <span tabindex="0" data-tip="Mental effort to implement or understand: difficulty times volume." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.HalsteadEffort.Avg|stringifyNumber }}</span>
+            </div>
+            <div class="data-row">
+                <span class="row-name flex-1 flex items-center gap-1.5">Time to program
+                    <span tabindex="0" data-tip="Theoretical implementation time per class: effort divided by 18 (Stroud number), in seconds." class="text-gray-300 text-xs">ⓘ</span></span>
+                <span class="row-value">{{ currentView.HalsteadTime.Avg|floatformat:0 }} s</span>
+            </div>
+        </div>
+        <p class="card-sub mt-4 pt-3 border-t border-gray-100">
+            Per-class Halstead details (vocabulary, length, bugs) are available on the <a href="classes{{ scopeSuffix }}.html" class="text-blue-600 hover:underline">Classes</a> page.
+        </p>
+    </div>
+</div>
+
+<!-- Help Modal -->
+<div x-data x-show="$store.helpModal.open" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4"
+    style="backdrop-filter: blur(4px);">
+    <div class="absolute inset-0 bg-black/40" @click="$store.helpModal.open = false"></div>
+    <div class="relative soft-card w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+        <div class="flex items-center justify-between mb-4 pb-3 border-b border-gray-200">
+            <h3 class="card-title" x-text="$store.helpModal.title"></h3>
+            <button @click="$store.helpModal.open = false" class="text-gray-400 hover:text-gray-600 transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+            </button>
+        </div>
+        <video x-ref="helpVideo" :src="$store.helpModal.video" autoplay loop controls playsinline class="w-full rounded-lg mb-4"
+            x-effect="if (!$store.helpModal.open) { $refs.helpVideo?.pause(); $refs.helpVideo?.removeAttribute('src'); }"></video>
+        <a :href="$store.helpModal.link" target="_blank" rel="noopener noreferrer"
+            class="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline">
+            Read full documentation
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+        </a>
+    </div>
+</div>
+
+{% endblock %}

--- a/internal/report/templates/html/partials/file_explorer_sidebar.html
+++ b/internal/report/templates/html/partials/file_explorer_sidebar.html
@@ -1,4 +1,5 @@
-<!-- File Explorer Sidebar -->
+<!-- File explorer sidebar: a real nested tree, flattened into one list so Alpine
+     can render any depth with a single loop. -->
 <div x-data="fileSidebar()" x-cloak
      @keydown.window="if ((e=$event).ctrlKey && e.key==='b') { e.preventDefault(); toggle(); }">
 
@@ -11,15 +12,12 @@
 
     <!-- Sidebar panel -->
     <div :class="open ? 'translate-x-0' : 'translate-x-full'" class="file-sidebar" id="file-sidebar-panel">
+
         <!-- Header -->
-        <div class="flex items-center justify-between px-4 py-3 border-b border-slate-200 bg-slate-50">
-            <h3 class="text-sm font-semibold text-slate-700 flex items-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
-                </svg>
-                Files
-            </h3>
-            <button @click="toggle()" aria-label="Close file explorer" class="p-1 rounded hover:bg-slate-200 text-slate-500">
+        <div class="flex items-center justify-between px-5 pt-5 pb-3">
+            <h2 class="card-title text-base">Files</h2>
+            <button @click="toggle()" aria-label="Close the file explorer"
+                    class="p-1.5 rounded-lg hover:bg-slate-100 text-slate-400 hover:text-slate-600 transition-colors">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                 </svg>
@@ -27,56 +25,86 @@
         </div>
 
         <!-- Search -->
-        <div class="px-3 py-2 border-b border-slate-100">
-            <input type="text" x-model.debounce.200ms="query" placeholder="Search files..."
-                   class="w-full px-3 py-1.5 text-xs border border-slate-200 rounded-md focus:outline-none focus:ring-1 focus:ring-slate-400 bg-white">
+        <div class="px-5 pb-3">
+            <div class="relative">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+                     class="w-4 h-4 text-slate-400 absolute left-3.5 top-1/2 -translate-y-1/2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+                </svg>
+                <input type="search" x-model.debounce.200ms="query" aria-label="Search a file"
+                       placeholder="Search a file"
+                       class="w-full bg-slate-50 border border-slate-200 rounded-full pl-10 pr-3 py-2 text-sm
+                              placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500
+                              focus:border-transparent focus:bg-white transition-colors">
+            </div>
         </div>
 
-        <!-- Min risks filter -->
-        <div class="px-3 py-2 border-b border-slate-100 flex items-center gap-2">
-            <label for="min-risks-input" class="text-xs text-slate-500 whitespace-nowrap">Min risks</label>
-            <input type="number" min="0" x-model.number="minRisks" id="min-risks-input"
-                   class="w-16 px-2 py-1 text-xs border border-slate-200 rounded-md focus:outline-none focus:ring-1 focus:ring-slate-400 bg-white">
+        <!-- Scope: everything, or only files carrying a risk -->
+        <div class="px-5 pb-3">
+            <div class="seg w-full" role="tablist" aria-label="Filter files">
+                <button role="tab" class="seg-item flex-1 text-center" :class="onlyAtRisk ? '' : 'seg-item--active'"
+                        :aria-selected="onlyAtRisk ? 'false' : 'true'" @click="onlyAtRisk = false">All</button>
+                <button role="tab" class="seg-item flex-1 text-center" :class="onlyAtRisk ? 'seg-item--active' : ''"
+                        :aria-selected="onlyAtRisk ? 'true' : 'false'" @click="onlyAtRisk = true">
+                    At risk <span class="text-slate-400 font-normal" x-text="atRiskCount"></span>
+                </button>
+            </div>
         </div>
 
         <!-- Tree -->
-        <div class="overflow-y-auto flex-1 px-2 py-2" style="max-height: calc(100vh - 150px);">
-            <template x-for="root in tree" :key="root.name">
-                <div class="mb-1">
-                    <template x-for="dir in root.dirs" :key="dir.path">
-                        <div class="mb-0.5">
-                            <button @click="dir.expanded = !dir.expanded"
-                                    class="flex items-center gap-1 w-full px-2 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100 rounded truncate">
-                                <svg :class="dir.expanded ? 'rotate-90' : ''" class="w-3 h-3 transition-transform flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                                </svg>
-                                <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-amber-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                                    <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" />
-                                </svg>
-                                <span class="truncate" x-text="dir.name"></span>
-                            </button>
-                            <div x-show="dir.expanded" class="ml-4">
-                                <template x-for="f in dir.files" :key="f.path">
-                                    <div @click="selectFile(f)"
-                                       class="flex items-center gap-1.5 px-2 py-0.5 text-xs text-slate-600 hover:bg-slate-100 rounded truncate group cursor-pointer"
-                                       :class="selectedPath === f.path ? 'bg-blue-50 text-blue-700 font-medium' : ''">
-                                        <span class="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                                              :class="riskDot(f)"></span>
-                                        <span class="truncate" x-text="fileName(f)"></span>
-                                    </div>
-                                </template>
-                            </div>
-                        </div>
-                    </template>
+        <div class="overflow-y-auto flex-1 px-3 pb-4">
+            <template x-for="n in visibleNodes" :key="n.id">
+                <div>
+                    <!-- Folder -->
+                    <button x-show="n.type === 'dir'" @click="toggleDir(n)"
+                            :style="`padding-left: ${0.5 + n.depth * 0.75}rem`"
+                            :aria-expanded="n.expanded ? 'true' : 'false'"
+                            class="w-full flex items-center gap-1.5 pr-2 py-1.5 rounded-lg text-left
+                                   text-slate-500 hover:bg-slate-50 transition-colors group">
+                        <svg :class="n.expanded ? 'rotate-90' : ''"
+                             class="w-3 h-3 shrink-0 text-slate-300 group-hover:text-slate-400 transition-transform"
+                             xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                        </svg>
+                        <span class="dot shrink-0" :class="n.sev"></span>
+                        <span class="font-mono text-xs truncate" x-text="n.name" :title="n.path"></span>
+                    </button>
+
+                    <!-- File -->
+                    <button x-show="n.type === 'file'" @click="selectFile(n.file)"
+                            :data-sb-path="n.path"
+                            :style="`padding-left: ${1.5 + n.depth * 0.75}rem`"
+                            :aria-current="n.file && selectedPath === n.file.path ? 'true' : 'false'"
+                            class="w-full flex items-center gap-1.5 pr-3 py-1.5 rounded-full text-left transition-colors"
+                            :class="n.file && selectedPath === n.file.path
+                                    ? 'bg-slate-900 text-white'
+                                    : 'text-slate-600 hover:bg-slate-50'">
+                        <span class="dot shrink-0" :class="n.sev"></span>
+                        <span class="font-mono text-xs truncate" x-text="n.name" :title="n.path"></span>
+                        <span x-show="n.file && n.file.isTest"
+                              class="shrink-0 px-1 py-px rounded text-[10px] font-medium leading-tight"
+                              :class="n.file && selectedPath === n.file.path ? 'bg-white/20 text-white' : 'bg-violet-50 text-violet-600'">test</span>
+                    </button>
                 </div>
             </template>
-            <div x-show="tree.length === 0" class="text-xs text-slate-400 text-center py-4">No files found</div>
+
+            <p x-show="!visibleNodes.length" class="text-xs text-slate-400 text-center py-8">
+                <span x-show="query">No file matches <span class="font-medium" x-text="query"></span>.</span>
+                <span x-show="!query && onlyAtRisk">No file carries a risk.</span>
+            </p>
+        </div>
+
+        <!-- Legend -->
+        <div class="px-5 py-3 border-t border-slate-100 flex items-center gap-4 text-[11px] text-slate-400">
+            <span class="flex items-center gap-1.5"><span class="dot sev-good"></span> clean</span>
+            <span class="flex items-center gap-1.5"><span class="dot sev-warn"></span> some risks</span>
+            <span class="flex items-center gap-1.5"><span class="dot sev-bad"></span> many risks</span>
         </div>
     </div>
 
     <!-- FAB toggle -->
     <button x-show="!open" x-transition @click="toggle()"
-            class="fixed bottom-6 right-6 z-50 w-12 h-12 bg-slate-700 hover:bg-slate-800 text-white rounded-full shadow-lg flex items-center justify-center transition-colors"
+            class="fixed bottom-6 right-6 z-50 w-12 h-12 bg-slate-800 hover:bg-slate-900 text-white rounded-full shadow-lg flex items-center justify-center transition-colors"
             title="Browse files (Ctrl+B)"
             aria-label="Browse files">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -89,17 +117,19 @@
 function fileSidebar() {
     const isDesktop = window.innerWidth >= 1024;
     const stored = localStorage.getItem('ast-sidebar-open');
-    const defaultOpen = isDesktop ? true : false;
-    const initialOpen = stored !== null ? stored === 'true' : defaultOpen;
     const isExplorerPage = {% if page == 'explorer.html' %}true{% else %}false{% endif %};
+    // The tree is the explorer's main navigation, so it is always open there.
+    // Everywhere else it is a side tool: closed until asked for (FAB or Ctrl+B).
+    const initialOpen = isExplorerPage ? true : (stored !== null ? stored === 'true' : false);
 
     return {
         open: initialOpen,
         query: '',
-        minRisks: 0,
+        onlyAtRisk: false,
         files: [],
         risksByPath: {},
-        tree: [],
+        nodes: [],
+        collapsed: {},
         selectedPath: '',
         isExplorerPage: isExplorerPage,
 
@@ -108,15 +138,18 @@ function fileSidebar() {
             this.files = d.files || [];
             this.risksByPath = d.risks || {};
             this.buildTree();
-            this.$watch('query', () => this.buildTree());
-            this.$watch('minRisks', () => this.buildTree());
             if (this.open && isDesktop) this.pushMain(true);
 
-            // On explorer page, listen for external selection (e.g. URL deep-link)
             if (this.isExplorerPage) {
                 window.addEventListener('explorer-file-selected', (e) => {
-                    if (e.detail && e.detail.path) this.selectedPath = e.detail.path;
+                    if (e.detail && e.detail.path) {
+                        this.selectedPath = e.detail.path;
+                        this.revealPath(e.detail.path);
+                    }
                 });
+                // The explorer may have selected a deep-linked file before this
+                // component was listening, so resolve ?file= here as well.
+                this.selectFromQuery();
             }
         },
 
@@ -124,11 +157,7 @@ function fileSidebar() {
             this.open = !this.open;
             localStorage.setItem('ast-sidebar-open', this.open);
             if (window.innerWidth >= 1024) this.pushMain(this.open);
-            if (this.open && window.innerWidth < 1024) {
-                document.body.style.overflow = 'hidden';
-            } else {
-                document.body.style.overflow = '';
-            }
+            document.body.style.overflow = (this.open && window.innerWidth < 1024) ? 'hidden' : '';
         },
 
         pushMain(push) {
@@ -139,39 +168,134 @@ function fileSidebar() {
             }
         },
 
-        buildTree() {
-            const q = (this.query || '').toLowerCase();
-            const mr = this.minRisks || 0;
-            const filtered = this.files.filter(f => {
-                if (q && !(f.path || '').toLowerCase().includes(q) && !(f.shortPath || '').toLowerCase().includes(q)) return false;
-                if (mr > 0 && (this.risksByPath[f.path] || []).length < mr) return false;
-                return true;
-            });
+        // Resolve ?file=<hash|shortPath|path> the same way the explorer does
+        selectFromQuery() {
+            let param = null;
+            try { param = new URLSearchParams(window.location.search).get('file'); } catch (e) { return; }
+            if (!param) return;
+            const f = this.files.find(x => (x.pathHash || '') === param)
+                || this.files.find(x => (x.shortPath || '') === param)
+                || this.files.find(x => (x.path || '') === param);
+            if (!f) return;
+            this.selectedPath = f.path;
+            this.revealPath(f.path);
+        },
 
-            const byDir = {};
-            for (const f of filtered) {
-                const parts = (f.shortPath || f.path).split('/');
-                const dir = parts.slice(0, -1).join('/') || '/';
-                if (!byDir[dir]) byDir[dir] = [];
-                byDir[dir].push(f);
+        // Risks are keyed by path hash, like everywhere else in the report data
+        risksFor(f) { return this.risksByPath[f.pathHash] || []; },
+
+        severityOf(count) {
+            if (count >= 3) return 'sev-bad';
+            if (count >= 1) return 'sev-warn';
+            return 'sev-good';
+        },
+
+        get atRiskCount() {
+            return this.files.filter(f => this.risksFor(f).length > 0).length;
+        },
+
+        // Build a nested tree, then flatten it into an ordered list of nodes that
+        // carry their own depth. One Alpine loop can then render any depth.
+        buildTree() {
+            const root = { children: new Map(), files: [] };
+            for (const f of this.files) {
+                const parts = (f.shortPath || f.path || '').split('/').filter(Boolean);
+                const fileName = parts.pop();
+                let node = root;
+                for (const part of parts) {
+                    if (!node.children.has(part)) node.children.set(part, { children: new Map(), files: [] });
+                    node = node.children.get(part);
+                }
+                node.files.push({ name: fileName, file: f });
             }
 
-            const rootsMap = {};
-            Object.keys(byDir).forEach(d => {
-                const root = (d.split('/')[0]) || '/';
-                if (!rootsMap[root]) rootsMap[root] = [];
-                rootsMap[root].push(d);
-            });
+            const out = [];
+            let seq = 0;
+            const walk = (node, depth, prefix) => {
+                for (const [name, child] of [...node.children.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+                    const path = prefix ? prefix + '/' + name : name;
+                    // A folder inherits the worst severity of what it contains
+                    const worst = this.worstSeverityIn(child);
+                    out.push({ id: 'd' + (seq++), type: 'dir', name, path, depth, sev: worst });
+                    walk(child, depth + 1, path);
+                }
+                for (const entry of node.files.sort((a, b) => a.name.localeCompare(b.name))) {
+                    const count = this.risksFor(entry.file).length;
+                    out.push({
+                        id: 'f' + (seq++), type: 'file', name: entry.name,
+                        path: entry.file.shortPath || entry.file.path,
+                        depth, file: entry.file, sev: this.severityOf(count),
+                    });
+                }
+            };
+            walk(root, 0, '');
+            this.nodes = out;
+        },
 
-            this.tree = Object.keys(rootsMap).sort().map(root => ({
-                name: root,
-                dirs: rootsMap[root].sort().map(d => ({
-                    name: d,
-                    path: d,
-                    expanded: !!q || !!mr || Object.keys(rootsMap).length <= 3,
-                    files: (byDir[d] || []).sort((a, b) => (a.path || '').localeCompare(b.path || ''))
-                }))
-            }));
+        worstSeverityIn(node) {
+            let max = 0;
+            const visit = (n) => {
+                for (const entry of n.files) max = Math.max(max, this.risksFor(entry.file).length);
+                for (const child of n.children.values()) visit(child);
+            };
+            visit(node);
+            return this.severityOf(max);
+        },
+
+        // Visibility is derived: a node shows when no ancestor is collapsed. A
+        // search or the "at risk" filter hides non-matching files and any folder
+        // left empty by the filter.
+        get visibleNodes() {
+            const q = this.query.trim().toLowerCase();
+            const keep = new Set();
+            if (q || this.onlyAtRisk) {
+                for (const n of this.nodes) {
+                    if (n.type !== 'file') continue;
+                    if (q && !(n.path || '').toLowerCase().includes(q)) continue;
+                    if (this.onlyAtRisk && this.risksFor(n.file).length === 0) continue;
+                    keep.add(n.path);
+                    const parts = (n.path || '').split('/');
+                    for (let i = 1; i < parts.length; i++) keep.add(parts.slice(0, i).join('/'));
+                }
+            }
+            const out = [];
+            for (const n of this.nodes) {
+                if ((q || this.onlyAtRisk) && !keep.has(n.path)) continue;
+                // While filtering, everything matching stays expanded
+                const collapsedAncestor = (q || this.onlyAtRisk) ? false : this.hasCollapsedAncestor(n.path);
+                if (collapsedAncestor) continue;
+                out.push(n.type === 'dir'
+                    ? { ...n, expanded: (q || this.onlyAtRisk) ? true : !this.collapsed[n.path] }
+                    : n);
+            }
+            return out;
+        },
+
+        hasCollapsedAncestor(path) {
+            const parts = (path || '').split('/');
+            for (let i = 1; i < parts.length; i++) {
+                if (this.collapsed[parts.slice(0, i).join('/')]) return true;
+            }
+            return false;
+        },
+
+        toggleDir(n) {
+            this.collapsed = { ...this.collapsed, [n.path]: !this.collapsed[n.path] };
+        },
+
+        // Make sure a deep-linked file is neither hidden inside a collapsed
+        // folder nor off-screen in a long tree
+        revealPath(fullPath) {
+            const f = this.files.find(x => x.path === fullPath);
+            const rel = (f && (f.shortPath || f.path)) || fullPath;
+            const parts = rel.split('/');
+            const next = { ...this.collapsed };
+            for (let i = 1; i < parts.length; i++) delete next[parts.slice(0, i).join('/')];
+            this.collapsed = next;
+            this.$nextTick(() => {
+                const el = document.querySelector(`[data-sb-path="${CSS.escape(rel)}"]`);
+                if (el) el.scrollIntoView({ block: 'center' });
+            });
         },
 
         selectFile(f) {
@@ -179,22 +303,9 @@ function fileSidebar() {
             if (this.isExplorerPage) {
                 this.$dispatch('sidebar-select-file', { path: f.path, pathHash: f.pathHash || f.shortPath || f.path });
             } else {
-                window.location.href = 'explorer.html?file=' + encodeURIComponent(f.pathHash || f.shortPath || f.path);
+                window.location.href = 'explorer{{ scopeSuffix }}.html?file=' + encodeURIComponent(f.pathHash || f.shortPath || f.path);
             }
         },
-
-        riskDot(f) {
-            const count = (this.risksByPath[f.path] || []).length;
-            if (count >= 5) return 'bg-red-500';
-            if (count >= 3) return 'bg-orange-500';
-            if (count >= 1) return 'bg-amber-400';
-            return 'bg-green-400';
-        },
-
-        fileName(f) {
-            const p = f.shortPath || f.path || '';
-            return p.split('/').pop() || p;
-        }
     };
 }
 </script>

--- a/internal/report/templates/html/partials/file_explorer_sidebar.html
+++ b/internal/report/templates/html/partials/file_explorer_sidebar.html
@@ -17,7 +17,7 @@
         <div class="flex items-center justify-between px-5 pt-5 pb-3">
             <h2 class="card-title text-base">Files</h2>
             <button @click="toggle()" aria-label="Close the file explorer"
-                    class="p-1.5 rounded-lg hover:bg-slate-100 text-slate-400 hover:text-slate-600 transition-colors">
+                    class="p-1.5 rounded-lg hover:bg-slate-100 text-slate-500 hover:text-slate-600 transition-colors">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                 </svg>
@@ -28,13 +28,13 @@
         <div class="px-5 pb-3">
             <div class="relative">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
-                     class="w-4 h-4 text-slate-400 absolute left-3.5 top-1/2 -translate-y-1/2">
+                     class="w-4 h-4 text-slate-500 absolute left-3.5 top-1/2 -translate-y-1/2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
                 </svg>
                 <input type="search" x-model.debounce.200ms="query" aria-label="Search a file"
                        placeholder="Search a file"
                        class="w-full bg-slate-50 border border-slate-200 rounded-full pl-10 pr-3 py-2 text-sm
-                              placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500
+                              placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500
                               focus:border-transparent focus:bg-white transition-colors">
             </div>
         </div>
@@ -46,7 +46,7 @@
                         :aria-selected="onlyAtRisk ? 'false' : 'true'" @click="onlyAtRisk = false">All</button>
                 <button role="tab" class="seg-item flex-1 text-center" :class="onlyAtRisk ? 'seg-item--active' : ''"
                         :aria-selected="onlyAtRisk ? 'true' : 'false'" @click="onlyAtRisk = true">
-                    At risk <span class="text-slate-400 font-normal" x-text="atRiskCount"></span>
+                    At risk <span class="text-slate-600 font-normal" x-text="atRiskCount"></span>
                 </button>
             </div>
         </div>
@@ -62,7 +62,7 @@
                             class="w-full flex items-center gap-1.5 pr-2 py-1.5 rounded-lg text-left
                                    text-slate-500 hover:bg-slate-50 transition-colors group">
                         <svg :class="n.expanded ? 'rotate-90' : ''"
-                             class="w-3 h-3 shrink-0 text-slate-300 group-hover:text-slate-400 transition-transform"
+                             class="w-3 h-3 shrink-0 text-slate-300 group-hover:text-slate-500 transition-transform"
                              xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
                         </svg>
@@ -88,14 +88,14 @@
                 </div>
             </template>
 
-            <p x-show="!visibleNodes.length" class="text-xs text-slate-400 text-center py-8">
+            <p x-show="!visibleNodes.length" class="text-xs text-slate-500 text-center py-8">
                 <span x-show="query">No file matches <span class="font-medium" x-text="query"></span>.</span>
                 <span x-show="!query && onlyAtRisk">No file carries a risk.</span>
             </p>
         </div>
 
         <!-- Legend -->
-        <div class="px-5 py-3 border-t border-slate-100 flex items-center gap-4 text-[11px] text-slate-400">
+        <div class="px-5 py-3 border-t border-slate-100 flex items-center gap-4 text-[11px] text-slate-500">
             <span class="flex items-center gap-1.5"><span class="dot sev-good"></span> clean</span>
             <span class="flex items-center gap-1.5"><span class="dot sev-warn"></span> some risks</span>
             <span class="flex items-center gap-1.5"><span class="dot sev-bad"></span> many risks</span>

--- a/internal/report/templates/html/partials/language_tabs.html
+++ b/internal/report/templates/html/partials/language_tabs.html
@@ -9,7 +9,7 @@
         {% for scope in scopes %}{% if scope.Kind != "directory" %}<a role="tab" href="{{ pageBase }}{{ scope.Suffix }}.html"
            class="seg-item {% if scope.IsActive %}seg-item--active{% endif %}"
            aria-selected="{% if scope.IsActive %}true{% else %}false{% endif %}"{% if scope.IsActive %} aria-current="page"{% endif %}>{{ scope.Label }}
-            <span class="text-slate-400 font-normal">{{ scope.FileCount }}</span></a>{% endif %}{% endfor %}
+            <span class="text-slate-600 font-normal">{{ scope.FileCount }}</span></a>{% endif %}{% endfor %}
     </div>
     {% if hasDirectoryScopes %}
     <div class="flex items-center gap-2">
@@ -18,7 +18,7 @@
             {% for scope in scopes %}{% if scope.Kind == "directory" %}<a role="tab" href="{{ pageBase }}{{ scope.Suffix }}.html"
                class="seg-item {% if scope.IsActive %}seg-item--active{% endif %}"
                aria-selected="{% if scope.IsActive %}true{% else %}false{% endif %}"{% if scope.IsActive %} aria-current="page"{% endif %}>{{ scope.Label }}
-                <span class="text-slate-400 font-normal">{{ scope.FileCount }}</span></a>{% endif %}{% endfor %}
+                <span class="text-slate-600 font-normal">{{ scope.FileCount }}</span></a>{% endif %}{% endfor %}
         </div>
     </div>
     {% endif %}

--- a/internal/report/templates/html/partials/language_tabs.html
+++ b/internal/report/templates/html/partials/language_tabs.html
@@ -1,0 +1,25 @@
+<!-- Scope switcher: include with pageBase="classes". The available scopes are
+     computed in Go (buildScopes in html_report_generator.go): the whole project,
+     then one per language, then one per analyzed folder (only when several
+     folders were given on the command line). The "All languages" view is always
+     offered, so a single-language project still shows the distinction between
+     the whole project and that language. -->
+<div class="flex flex-wrap items-center justify-end gap-x-5 gap-y-2 mb-6">
+    <div class="seg" role="tablist" aria-label="Filter by language">
+        {% for scope in scopes %}{% if scope.Kind != "directory" %}<a role="tab" href="{{ pageBase }}{{ scope.Suffix }}.html"
+           class="seg-item {% if scope.IsActive %}seg-item--active{% endif %}"
+           aria-selected="{% if scope.IsActive %}true{% else %}false{% endif %}"{% if scope.IsActive %} aria-current="page"{% endif %}>{{ scope.Label }}
+            <span class="text-slate-400 font-normal">{{ scope.FileCount }}</span></a>{% endif %}{% endfor %}
+    </div>
+    {% if hasDirectoryScopes %}
+    <div class="flex items-center gap-2">
+        <span class="section-title">Folder</span>
+        <div class="seg" role="tablist" aria-label="Filter by analyzed folder">
+            {% for scope in scopes %}{% if scope.Kind == "directory" %}<a role="tab" href="{{ pageBase }}{{ scope.Suffix }}.html"
+               class="seg-item {% if scope.IsActive %}seg-item--active{% endif %}"
+               aria-selected="{% if scope.IsActive %}true{% else %}false{% endif %}"{% if scope.IsActive %} aria-current="page"{% endif %}>{{ scope.Label }}
+                <span class="text-slate-400 font-normal">{{ scope.FileCount }}</span></a>{% endif %}{% endfor %}
+        </div>
+    </div>
+    {% endif %}
+</div>

--- a/internal/report/templates/html/partials/suggestions.html
+++ b/internal/report/templates/html/partials/suggestions.html
@@ -1,17 +1,11 @@
-
-<div class="dashboard-card p-6" id="suggestions-card">
-  <div class="mb-6">
-    <h2 class="text-xl font-bold text-gray-900 mb-3" style="letter-spacing: -0.02em;">Suggestions</h2>
-    <div class="text-sm text-gray-600 flex items-start gap-2 leading-relaxed">
-      <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mt-0.5 text-gray-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" />
-      </svg>
-      <span>
-        {% if subtitle %}{{ subtitle }}{% else %}
-          Automatically inferred from metrics (coupling, purity, boundary nodes, etc.). These highlight concrete actions to improve the architecture.
-        {% endif %}
-      </span>
-    </div>
+<div class="soft-card animate-fade-in-up" id="suggestions-card">
+  <div class="mb-4">
+    <h2 class="card-title">{% if title %}{{ title }}{% else %}What the measurements singled out{% endif %}</h2>
+    <p class="card-sub">
+      {% if subtitle %}{{ subtitle }}{% else %}
+        Places where a measured threshold was crossed, with the figure behind it.
+      {% endif %}
+    </p>
   </div>
 
   {% if not suggestions or suggestions|length == 0 %}
@@ -19,49 +13,40 @@
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 text-green-300 mx-auto mb-3">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-4.902Z" />
       </svg>
-      <p class="text-sm font-medium text-gray-500">{{ emptyText|default:"No suggestions at the moment." }}</p>
+      <p class="text-sm font-medium text-gray-500">{{ emptyText|default:"No measured threshold was crossed." }}</p>
     </div>
   {% else %}
     <div id="suggestions-empty" class="text-center py-8 hidden">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 text-green-300 mx-auto mb-3">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-4.902Z" />
       </svg>
-      <p class="text-sm font-medium text-gray-500">{{ emptyText|default:"No suggestions at the moment." }}</p>
+      <p class="text-sm font-medium text-gray-500">{{ emptyText|default:"No measured threshold was crossed." }}</p>
     </div>
-    <div id="suggestions-list" class="space-y-6">
+    <div id="suggestions-list" class="space-y-7">
 
       {# ── Coupling ── #}
       {% with suggestions|countCategory:"coupling" as couplingCount %}
       {% if couplingCount > 0 %}
       <div>
-        <div class="flex items-center gap-2 mb-2">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-amber-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m9.86-2.54 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"/></svg>
-          <span class="font-semibold text-gray-900">Coupling</span>
-          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 text-amber-700">{{ couplingCount }}</span>
+        <div class="flex items-center gap-2">
+          <span class="dot sev-warn"></span>
+          <span class="text-sm font-semibold text-gray-900">Coupling</span>
+          <span tabindex="0" data-tip="Efferent coupling ratio: the share of a group's dependencies that point outside the group." class="text-gray-300 text-xs">ⓘ</span>
+          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-slate-100 text-slate-600">{{ couplingCount }}</span>
         </div>
-        <p class="text-sm text-gray-600 mb-3">This community depends on many others. Introduce a facade or API boundary to reduce direct dependencies and stabilize interactions.</p>
-        {% if couplingCount <= 3 %}
-        <ul class="space-y-2">
+        <p class="text-sm text-gray-500 mt-1">Most of what these groups depend on lives outside them, so a change elsewhere reaches them.</p>
+        {% if couplingCount > 3 %}<details class="mt-2"><summary class="cursor-pointer text-sm text-blue-600 hover:underline">Show all {{ couplingCount }}</summary>{% endif %}
+        <div class="mt-1">
           {% for s in suggestions %}{% if s.Category == "coupling" %}
-          <li class="flex items-start gap-2 text-sm">
-            <span class="shrink-0 px-2 py-0.5 text-xs font-medium rounded-md bg-amber-50 border border-amber-200 text-amber-700">{{ s.Location }}</span>
-            <span class="text-gray-500">{{ s.Why }}</span>
-          </li>
+          <div class="data-row">
+            <div class="min-w-0 flex-1">
+              <div class="row-name truncate"><code class="ident">{{ s.Location }}</code></div>
+              <div class="row-meta">{{ s.Why }}</div>
+            </div>
+          </div>
           {% endif %}{% endfor %}
-        </ul>
-        {% else %}
-        <details class="group">
-          <summary class="cursor-pointer text-sm text-amber-700 hover:text-amber-900 font-medium">Show all {{ couplingCount }} items</summary>
-          <ul class="space-y-2 mt-2">
-            {% for s in suggestions %}{% if s.Category == "coupling" %}
-            <li class="flex items-start gap-2 text-sm">
-              <span class="shrink-0 px-2 py-0.5 text-xs font-medium rounded-md bg-amber-50 border border-amber-200 text-amber-700">{{ s.Location }}</span>
-              <span class="text-gray-500">{{ s.Why }}</span>
-            </li>
-            {% endif %}{% endfor %}
-          </ul>
-        </details>
-        {% endif %}
+        </div>
+        {% if couplingCount > 3 %}</details>{% endif %}
       </div>
       {% endif %}
       {% endwith %}
@@ -70,34 +55,25 @@
       {% with suggestions|countCategory:"purity" as purityCount %}
       {% if purityCount > 0 %}
       <div>
-        <div class="flex items-center gap-2 mb-2">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z"/></svg>
-          <span class="font-semibold text-gray-900">Purity</span>
-          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-blue-100 text-blue-700">{{ purityCount }}</span>
+        <div class="flex items-center gap-2">
+          <span class="dot sev-warn"></span>
+          <span class="text-sm font-semibold text-gray-900">Mixed concerns</span>
+          <span tabindex="0" data-tip="Purity: the share of files in a group that come from the same namespace." class="text-gray-300 text-xs">ⓘ</span>
+          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-slate-100 text-slate-600">{{ purityCount }}</span>
         </div>
-        <p class="text-sm text-gray-600 mb-3">This community aggregates several concerns. Consider splitting it into smaller, cohesive modules aligned by domain or namespace to improve purity and maintainability.</p>
-        {% if purityCount <= 3 %}
-        <ul class="space-y-2">
+        <p class="text-sm text-gray-500 mt-1">These groups gather files from several unrelated namespaces, so their content is not aligned with one concern.</p>
+        {% if purityCount > 3 %}<details class="mt-2"><summary class="cursor-pointer text-sm text-blue-600 hover:underline">Show all {{ purityCount }}</summary>{% endif %}
+        <div class="mt-1">
           {% for s in suggestions %}{% if s.Category == "purity" %}
-          <li class="flex items-start gap-2 text-sm">
-            <span class="shrink-0 px-2 py-0.5 text-xs font-medium rounded-md bg-blue-50 border border-blue-200 text-blue-700">{{ s.Location }}</span>
-            <span class="text-gray-500">{{ s.Why }}</span>
-          </li>
+          <div class="data-row">
+            <div class="min-w-0 flex-1">
+              <div class="row-name truncate"><code class="ident">{{ s.Location }}</code></div>
+              <div class="row-meta">{{ s.Why }}</div>
+            </div>
+          </div>
           {% endif %}{% endfor %}
-        </ul>
-        {% else %}
-        <details class="group">
-          <summary class="cursor-pointer text-sm text-blue-700 hover:text-blue-900 font-medium">Show all {{ purityCount }} items</summary>
-          <ul class="space-y-2 mt-2">
-            {% for s in suggestions %}{% if s.Category == "purity" %}
-            <li class="flex items-start gap-2 text-sm">
-              <span class="shrink-0 px-2 py-0.5 text-xs font-medium rounded-md bg-blue-50 border border-blue-200 text-blue-700">{{ s.Location }}</span>
-              <span class="text-gray-500">{{ s.Why }}</span>
-            </li>
-            {% endif %}{% endfor %}
-          </ul>
-        </details>
-        {% endif %}
+        </div>
+        {% if purityCount > 3 %}</details>{% endif %}
       </div>
       {% endif %}
       {% endwith %}
@@ -106,69 +82,51 @@
       {% with suggestions|countCategory:"boundary" as boundaryCount %}
       {% if boundaryCount > 0 %}
       <div>
-        <div class="flex items-center gap-2 mb-2">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-purple-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"/></svg>
-          <span class="font-semibold text-gray-900">Boundary</span>
-          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-purple-100 text-purple-700">{{ boundaryCount }}</span>
+        <div class="flex items-center gap-2">
+          <span class="dot sev-none"></span>
+          <span class="text-sm font-semibold text-gray-900">Boundary nodes</span>
+          <span tabindex="0" data-tip="A node is on a boundary when it takes part in dependencies that cross the frontier between two groups." class="text-gray-300 text-xs">ⓘ</span>
+          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-slate-100 text-slate-600">{{ boundaryCount }}</span>
         </div>
-        <p class="text-sm text-gray-600 mb-3">These nodes connect multiple communities and can create tight coupling. Consider introducing anti-corruption layers, moving responsibilities, or clarifying ownership to reduce boundary crossings.</p>
-        {% if boundaryCount <= 3 %}
-        <ul class="space-y-2">
+        <p class="text-sm text-gray-500 mt-1">These nodes sit on dependencies that cross group frontiers, so they carry traffic between otherwise separate parts of the code.</p>
+        {% if boundaryCount > 3 %}<details class="mt-2"><summary class="cursor-pointer text-sm text-blue-600 hover:underline">Show all {{ boundaryCount }}</summary>{% endif %}
+        <div class="mt-1">
           {% for s in suggestions %}{% if s.Category == "boundary" %}
-          <li class="flex items-start gap-2 text-sm">
-            <span class="shrink-0 px-2 py-0.5 text-xs font-medium rounded-md bg-purple-50 border border-purple-200 text-purple-700">{{ s.Location }}</span>
-            <span class="text-gray-500">{{ s.Why }}</span>
-          </li>
+          <div class="data-row">
+            <div class="min-w-0 flex-1">
+              <div class="row-name truncate"><code class="ident">{{ s.Location }}</code></div>
+              <div class="row-meta">{{ s.Why }}</div>
+            </div>
+          </div>
           {% endif %}{% endfor %}
-        </ul>
-        {% else %}
-        <details class="group">
-          <summary class="cursor-pointer text-sm text-purple-700 hover:text-purple-900 font-medium">Show all {{ boundaryCount }} items</summary>
-          <ul class="space-y-2 mt-2">
-            {% for s in suggestions %}{% if s.Category == "boundary" %}
-            <li class="flex items-start gap-2 text-sm">
-              <span class="shrink-0 px-2 py-0.5 text-xs font-medium rounded-md bg-purple-50 border border-purple-200 text-purple-700">{{ s.Location }}</span>
-              <span class="text-gray-500">{{ s.Why }}</span>
-            </li>
-            {% endif %}{% endfor %}
-          </ul>
-        </details>
-        {% endif %}
+        </div>
+        {% if boundaryCount > 3 %}</details>{% endif %}
       </div>
       {% endif %}
       {% endwith %}
 
-      {# ── Other (fallback for suggestions without category) ── #}
+      {# ── Anything without a category: per-file measurements ── #}
       {% with suggestions|countCategory:"other" as otherCount %}
       {% if otherCount > 0 %}
       <div>
-        <div class="flex items-center gap-2 mb-2">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.383a14.406 14.406 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"/></svg>
-          <span class="font-semibold text-gray-900">Other</span>
-          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-700">{{ otherCount }}</span>
+        <div class="flex items-center gap-2">
+          <span class="dot sev-warn"></span>
+          <span class="text-sm font-semibold text-gray-900">Single files</span>
+          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-slate-100 text-slate-600">{{ otherCount }}</span>
         </div>
-        {% if otherCount <= 3 %}
-        <ul class="space-y-2">
+        <p class="text-sm text-gray-500 mt-1">These come from measurements taken file by file, not from the dependency graph.</p>
+        {% if otherCount > 3 %}<details class="mt-2"><summary class="cursor-pointer text-sm text-blue-600 hover:underline">Show all {{ otherCount }}</summary>{% endif %}
+        <div class="mt-1">
           {% for s in suggestions %}{% if s.Category != "coupling" and s.Category != "purity" and s.Category != "boundary" %}
-          <li class="flex items-start gap-2 text-sm">
-            <span class="shrink-0 px-2 py-0.5 text-xs font-medium rounded-md bg-gray-50 border border-gray-200 text-gray-700">{{ s.Location }}</span>
-            <span class="text-gray-500">{% if s.Why %}{{ s.Why }}{% else %}{{ s.Summary }}{% endif %}</span>
-          </li>
+          <div class="data-row">
+            <div class="min-w-0 flex-1">
+              <div class="row-name truncate"><code class="ident">{{ s.Location }}</code></div>
+              <div class="row-meta">{% if s.Why %}{{ s.Why }}{% else %}{{ s.Summary }}{% endif %}</div>
+            </div>
+          </div>
           {% endif %}{% endfor %}
-        </ul>
-        {% else %}
-        <details class="group">
-          <summary class="cursor-pointer text-sm text-gray-700 hover:text-gray-900 font-medium">Show all {{ otherCount }} items</summary>
-          <ul class="space-y-2 mt-2">
-            {% for s in suggestions %}{% if s.Category != "coupling" and s.Category != "purity" and s.Category != "boundary" %}
-            <li class="flex items-start gap-2 text-sm">
-              <span class="shrink-0 px-2 py-0.5 text-xs font-medium rounded-md bg-gray-50 border border-gray-200 text-gray-700">{{ s.Location }}</span>
-              <span class="text-gray-500">{% if s.Why %}{{ s.Why }}{% else %}{{ s.Summary }}{% endif %}</span>
-            </li>
-            {% endif %}{% endfor %}
-          </ul>
-        </details>
-        {% endif %}
+        </div>
+        {% if otherCount > 3 %}</details>{% endif %}
       </div>
       {% endif %}
       {% endwith %}

--- a/internal/report/templates/html/risks.html
+++ b/internal/report/templates/html/risks.html
@@ -1,231 +1,115 @@
 {% extends "layout.html" %}
 
 {% block title %}
-    Risks
+    Suggestions
 {% endblock %}
 
 {% block pageTitle %}
-    AST Metrics - Overview
+    AST Metrics - Suggestions
 {% endblock %}
 
 {% block content %}
 
-<style>
-    .dashboard-card {
-        background: white;
-        border: 1px solid #e2e8f0;
-        border-radius: 16px;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        position: relative;
-        overflow: hidden;
-    }
+{% set riskEntries = currentView.ConcernedFiles|selectTopRiskEntries:100 %}
+{% set nbEntries = riskEntries|length %}
+{% set nbObservations = currentView.Suggestions|length %}
+{% set nbCoupling = currentView.Suggestions|countCategory:"coupling" %}
+{% set nbPurity = currentView.Suggestions|countCategory:"purity" %}
+{% set nbBoundary = currentView.Suggestions|countCategory:"boundary" %}
+{% set nbOther = currentView.Suggestions|countCategory:"other" %}
 
-    .dashboard-card:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-        border-color: #cbd5e1;
-    }
-
-    .dashboard-card::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, #3b82f6, #8b5cf6);
-        opacity: 0;
-        transition: opacity 0.3s ease;
-    }
-
-    .dashboard-card:hover::before {
-        opacity: 1;
-    }
-
-    @keyframes fadeIn {
-        from { opacity: 0; transform: translateY(10px); }
-        to { opacity: 1; transform: translateY(0); }
-    }
-
-    .animate-fade-in-up {
-        animation: fadeIn 0.5s ease-out backwards;
-    }
-
-    .stagger-1 { animation-delay: 0.1s; }
-    .stagger-2 { animation-delay: 0.2s; }
-    .stagger-3 { animation-delay: 0.3s; }
-
-    /* Language tabs styling - Primary navigation */
-    .lang-tab {
-        transition: all 0.2s ease;
-        border-bottom: 3px solid transparent;
-        position: relative;
-    }
-
-    .lang-tab:hover {
-        background-color: #f8fafc;
-        border-bottom-color: #cbd5e1;
-    }
-
-    .lang-tab.active {
-        border-bottom-color: #3b82f6;
-        color: #3b82f6;
-        font-weight: 600;
-    }
-
-    /* Section navigation - Secondary navigation as segmented control */
-    .section-nav {
-        display: inline-flex;
-        background: #f1f5f9;
-        border-radius: 12px;
-        padding: 4px;
-        gap: 4px;
-    }
-
-    .section-tab {
-        transition: all 0.2s ease;
-        position: relative;
-        border-radius: 8px;
-        white-space: nowrap;
-    }
-
-    .section-tab:hover:not(.active) {
-        background-color: rgba(255, 255, 255, 0.6);
-    }
-
-    .section-tab.active {
-        background: white;
-        color: #3b82f6;
-        font-weight: 600;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    }
-
-    .section-tab.active.amber {
-        background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
-        color: #92400e;
-    }
-
-    /* Table improvements */
-    .table-row {
-        transition: all 0.15s ease;
-    }
-
-    .table-row:hover {
-        background-color: #f8fafc;
-        transform: translateX(2px);
-    }
-
-    /* Smooth scroll */
-    html {
-        scroll-behavior: smooth;
-    }
-
-    /* Scroll indicator animation */
-    @keyframes pulse-subtle {
-        0%, 100% { opacity: 1; }
-        50% { opacity: 0.7; }
-    }
-
-    .scroll-indicator {
-        animation: pulse-subtle 2s ease-in-out infinite;
-    }
-</style>
-
-<!-- Hero Section -->
-<div class="mb-8 animate-fade-in-up">
-    <h1 class="text-4xl font-bold text-gray-900 mb-3" style="letter-spacing: -0.02em;">Risk Analysis</h1>
-    <p class="text-base text-gray-600 font-light">Identify components with low maintainability and high refactoring priority</p>
+<!-- Verdict: what the analysis noticed, in words -->
+<div class="page-hero animate-fade-in-up">
+    <div class="flex flex-wrap items-start justify-between gap-8">
+        <div class="min-w-0">
+            <p class="page-kicker mb-3">
+                {{ currentView.ConcernedFiles|length }} files
+                {% if scopeKind != "all" %} · {{ scopeLabel }}{% endif %}
+            </p>
+            {% if nbObservations > 0 %}
+            <h1 class="verdict-title">
+                {{ nbObservations }} observation{% if nbObservations > 1 %}s{% endif %} came out of the measurements.<br>
+                <span class="verdict-muted">{{ nbEntries }} components are listed below, densest files first.</span>
+            </h1>
+            <p class="verdict-lead mt-4">
+                Each observation names a place in the code and the measurement that singled it out:
+                a coupling ratio, a cohesion figure, a boundary crossing. Nothing here is a verdict on
+                the code, and the order is not a queue of work.
+            </p>
+            {% else %}
+            <h1 class="verdict-title">
+                Nothing crossed the measured thresholds.<br>
+                <span class="verdict-muted">{{ nbEntries }} components are still listed below, densest files first.</span>
+            </h1>
+            <p class="verdict-lead mt-4">
+                Coupling, cohesion and module boundaries all stayed within the thresholds the heuristics
+                look at. The table below still describes where the code is dense, so you can see the shape
+                of the project.
+            </p>
+            {% endif %}
+        </div>
+        <div class="kpi-strip kpi-strip--divided shrink-0">
+            <div>
+                <div class="kpi-value">{{ nbEntries }}</div>
+                <div class="kpi-label">components listed</div>
+            </div>
+            {% if nbCoupling > 0 %}
+            <div>
+                <div class="kpi-value">{{ nbCoupling }}</div>
+                <div class="kpi-label">on coupling</div>
+            </div>
+            {% endif %}
+            {% if nbPurity > 0 %}
+            <div>
+                <div class="kpi-value">{{ nbPurity }}</div>
+                <div class="kpi-label">on mixed concerns</div>
+            </div>
+            {% endif %}
+            {% if nbBoundary > 0 %}
+            <div>
+                <div class="kpi-value">{{ nbBoundary }}</div>
+                <div class="kpi-label">on boundaries</div>
+            </div>
+            {% endif %}
+            {% if nbOther > 0 %}
+            <div>
+                <div class="kpi-value">{{ nbOther }}</div>
+                <div class="kpi-label">on single files</div>
+            </div>
+            {% endif %}
+            {% if nbObservations == 0 %}
+            <div>
+                <div class="kpi-value">0</div>
+                <div class="kpi-label">observations</div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
 </div>
 
-    <!-- Navigation Container -->
-    <div class="mb-8">
-        <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
-            <!-- Primary Navigation: Language Filter -->
-            <div class="flex-1 min-w-0">
-                <div class="mb-2">
-                    <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Filter by Language</span>
-                </div>
-                <div class="flex overflow-x-auto overflow-y-hidden border-b-2 border-gray-200 whitespace-nowrap">
-                    <a 
-                        href="risks.html"
-                        class="lang-tab inline-flex items-center h-11 px-4 py-2 -mb-0.5 text-center {% if currentLanguage == "All" %}active{% else %}text-gray-600{% endif %} sm:px-6 focus:outline-none">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-                        </svg>
-                        <span class="text-sm font-medium">
-                            All languages <span class="text-xs text-gray-500 ml-1">({{ projectAggregated.Combined.ConcernedFiles|length }})</span>
-                        </span>
-                    </a>
-                    {% for languageName, lang in projectAggregated.ByProgrammingLanguage %}
-                    <a 
-                        href="risks_{{ languageName|langSlug }}.html"
-                        class="lang-tab inline-flex items-center h-11 px-4 py-2 -mb-0.5 text-center {% if currentLanguage == languageName %}active{% else %}text-gray-600{% endif %} sm:px-6">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-                        </svg>
-                        <span class="text-sm font-medium">
-                            {{ languageName }} <span class="text-xs text-gray-500 ml-1">({{ lang.ConcernedFiles|length }})</span>
-                        </span>
-                    </a>
-                    {% endfor %}
-                </div>
-            </div>
-            
-            <!-- Secondary Navigation: Section Jump -->
-            <div class="shrink-0">
-                <div class="mb-2">
-                    <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Jump to Section</span>
-                </div>
-                <div class="section-nav">
-                    <a href="#suggestions-section" class="section-tab inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-gray-700">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.383a14.406 14.406 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18" />
-                        </svg>
-                        Suggestions
-                    </a>
-                    <a href="#high-risk-section" class="section-tab active amber inline-flex items-center gap-2 px-5 py-2.5 text-sm font-semibold">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-                        </svg>
-                        High-Risk Components
-                    </a>
-                </div>
+<div class="mt-6">
+    {% include "partials/language_tabs.html" with pageBase="risks" %}
+</div>
+
+<div class="space-y-6">
+
+    <!-- What the measurements singled out -->
+    {% include "partials/suggestions.html" with suggestions=currentView.Suggestions title="What the measurements singled out" subtitle="Places where a measured threshold was crossed, with the figure behind it." emptyText="No measured threshold was crossed." %}
+
+    <!-- Where the code is dense -->
+    <div class="soft-card animate-fade-in-up stagger-2">
+        <div class="flex items-start justify-between gap-4 mb-4">
+            <div>
+                <h2 class="card-title">Where the code is dense</h2>
+                <p class="card-sub">
+                    Grouped by file, files that accumulate the most complexity and change history first.
+                    Click any column header to sort on it instead.
+                </p>
             </div>
         </div>
+        {% include "componentTableRisks.html" with detailled=true linesToDisplay=100 %}
     </div>
 
+</div>
 
-    <!-- Suggestions section -->
-    <div id="suggestions-section" class="scroll-mt-8 mb-12">
-        {% include "partials/suggestions.html" with suggestions=currentView.Suggestions subtitle="Automatically inferred from coupling, purity and boundary nodes" emptyText="No suggestions — looks healthy based on current heuristics." %}
-    </div>
-
-    <!-- High-Risk Components section -->
-    <div id="high-risk-section" class="scroll-mt-8">
-        <!-- start: line of 1 cards -->
-        <div class="grid grid-cols-1 gap-6">
-
-            <!-- start: card -->
-            <div class="w-full dashboard-card p-8 animate-fade-in-up stagger-1">
-                <div class="mb-6 pb-6 border-b border-gray-100">
-                    <div class="flex items-start justify-between gap-4">
-                        <div class="flex-1">
-                            <h2 class="text-2xl font-bold text-gray-900 mb-2" style="letter-spacing: -0.02em;">
-                                High-Risk Components
-                            </h2>
-                            <p class="text-sm text-gray-600 leading-relaxed">
-                                Components with low maintainability index and recent modifications. These are prime candidates for refactoring to improve code quality and reduce technical debt.
-                            </p>
-                        </div>
-                    </div>
-                </div>
-                <div class="mt-6">
-                    {% include "componentTableRisks.html" with detailled=true linesToDisplay=100 %}
-                </div>
-            </div>
-            <!-- end: card -->
-        </div>
-        <!-- end: line of 1 cards -->
-    </div>
-    
 {% endblock %}

--- a/internal/report/templates/html/testquality.html
+++ b/internal/report/templates/html/testquality.html
@@ -10,190 +10,225 @@ AST Metrics - Test Quality
 
 {% block content %}
 
-<style>
-    .dashboard-card {
-        background: white;
-        border: 1px solid #e2e8f0;
-        border-radius: 16px;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        position: relative;
-        overflow: hidden;
-    }
+{% include "partials/language_tabs.html" with pageBase="testquality" %}
 
-    .dashboard-card:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-        border-color: #cbd5e1;
-    }
-
-    .dashboard-card::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, #3b82f6, #8b5cf6);
-        opacity: 0;
-        transition: opacity 0.3s ease;
-    }
-
-    .dashboard-card:hover::before {
-        opacity: 1;
-    }
-
-    .metric-value {
-        font-family: var(--font-mono);
-        letter-spacing: -0.05em;
-    }
-
-    .score-isolated { color: #059669; }
-    .score-semi { color: #d97706; }
-    .score-coupled { color: #dc2626; }
-
-    .badge-isolated { background: #d1fae5; color: #065f46; }
-    .badge-semi { background: #fef3c7; color: #92400e; }
-    .badge-coupled { background: #fee2e2; color: #991b1b; }
-</style>
-
-<!-- Language tabs -->
-<div class="flex overflow-x-auto overflow-y-hidden border-b border-gray-200 whitespace-nowrap">
-    <a tabindex="-1" href="testquality.html"
-        class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center {% if currentLanguage == 'All'%}text-blue-600 border-blue-500{% endif %} bg-transparent border-b-2 sm:px-4 -px-1 focus:outline-none">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-        <span class="mx-1 text-sm sm:text-base">
-            All languages <span class="text-xs sm:text-sm">({{ projectAggregated.Combined.ConcernedFiles|length }}
-                files)</span>
-        </span>
-    </a>
-
-    {% for languageName, lang in projectAggregated.ByProgrammingLanguage %}
-    <a tabindex="0" href="testquality_{{ languageName|langSlug }}.html"
-        class="inline-flex items-center h-10 px-2 py-2 -mb-px text-center bg-transparent border-b-2 {% if currentLanguage == languageName %}text-blue-600 border-blue-500{% else %}text-gray-700 border-transparent{% endif %} sm:px-4 -px-1 hover:border-gray-400">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mx-1 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-        <span class="mx-1 text-sm sm:text-base">
-            {{ languageName }} <span class="text-xs sm:text-sm">({{ lang.ConcernedFiles|length }} files)</span>
-        </span>
-    </a>
-    {% endfor %}
-</div>
-
-{% if currentView.TestQuality %}
+{% if currentView.TestQuality and currentView.TestQuality.NbTestFiles > 0 %}
 {% set tq = currentView.TestQuality %}
+{% set matched = tq.NbTestedClasses %}
 
-<!-- Page intro -->
-<div class="mt-8 mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 mb-2">Test Quality</h1>
-    <p class="text-sm text-gray-600 leading-relaxed">
-        How effectively do your tests exercise your application code?
-        <br/>This page evaluates two dimensions: <strong>Isolation</strong> (does each test focus on a limited set of application structures?) and <strong>Traceability</strong>
-         (is every application structure covered by at least one test?).
-        Well-isolated tests are easier to maintain, faster to diagnose when they fail, and less likely to break due to unrelated changes.
-    </p>
+<!-- 1. Verdict -->
+<div class="page-hero animate-fade-in-up mt-8">
+    <div class="flex flex-wrap items-start justify-between gap-8">
+        <div class="min-w-0">
+            {% if matched == 0 %}
+            <span class="level-pill mb-5">
+                <span class="dot sev-none"></span> No test matched
+            </span>
+            {% elif tq.GlobalIsolationScore >= 80 %}
+            <span class="level-pill level-pill--good mb-5">
+                <span class="dot sev-good"></span> Focused tests
+            </span>
+            {% elif tq.GlobalIsolationScore >= 50 %}
+            <span class="level-pill level-pill--warn mb-5">
+                <span class="dot sev-warn"></span> Partly focused tests
+            </span>
+            {% else %}
+            <span class="level-pill level-pill--bad mb-5">
+                <span class="dot sev-bad"></span> Wide-reaching tests
+            </span>
+            {% endif %}
+
+            <p class="page-kicker mb-3">{{ tq.NbTestFiles }} test file{{ tq.NbTestFiles|pluralize }} ·
+                {{ tq.NbProdFiles }} application file{{ tq.NbProdFiles|pluralize }}</p>
+
+            <h1 class="verdict-title">
+                {% if matched == 0 %}
+                Your tests don't line up with the code.<br>
+                <span class="verdict-muted">Nothing could be matched, so nothing can be measured.</span>
+                {% elif tq.TraceabilityPct >= 70 %}
+                Your tests reach most of the code.<br>
+                {% if tq.GlobalIsolationScore >= 80 %}
+                <span class="verdict-muted">And each one stays on a small piece of it.</span>
+                {% elif tq.GlobalIsolationScore >= 50 %}
+                <span class="verdict-muted">But some of them touch a lot at once.</span>
+                {% else %}
+                <span class="verdict-muted">But each one touches a lot at once.</span>
+                {% endif %}
+                {% elif tq.TraceabilityPct >= 30 %}
+                Your tests reach part of the code.<br>
+                {% if tq.GlobalIsolationScore >= 80 %}
+                <span class="verdict-muted">What they do reach, they reach precisely.</span>
+                {% elif tq.GlobalIsolationScore >= 50 %}
+                <span class="verdict-muted">And a few of them touch far too much at once.</span>
+                {% else %}
+                <span class="verdict-muted">And they touch a lot at once when they do.</span>
+                {% endif %}
+                {% else %}
+                Your tests barely reach the code.<br>
+                <span class="verdict-muted">Most structures are never touched by a test.</span>
+                {% endif %}
+            </h1>
+
+            <p class="verdict-lead mt-4">
+                {% if matched == 0 %}
+                Among the <strong>{{ tq.NbProdClasses }} structures</strong> of this code, none could be matched to any
+                of your <strong>{{ tq.NbTestFiles }} test file{{ tq.NbTestFiles|pluralize }}</strong>
+                <span tabindex="0" data-tip="Traceability works by matching the names a test refers to with the structures it exercises. Depending on the project's conventions or the language, it can stay at zero even when tests do exist." class="text-gray-300 text-xs">ⓘ</span>.
+                Everything below only describes what could be linked, so read it as a floor, not as a measurement.
+                {% else %}
+                <strong>{{ matched }} of {{ tq.NbProdClasses }} structures</strong> are touched by at least one of your
+                <strong>{{ tq.NbTestFiles }} test file{{ tq.NbTestFiles|pluralize }}</strong>. The isolation score says
+                how few structures a single test touches: the fewer it touches, the more precisely a red test tells you
+                what actually broke.
+                {% endif %}
+            </p>
+        </div>
+
+        <div class="kpi-strip kpi-strip--divided shrink-0">
+            <div>
+                <div class="kpi-value">{{ tq.NbTestFiles }}</div>
+                <div class="kpi-label">test file{{ tq.NbTestFiles|pluralize }}</div>
+            </div>
+            <div>
+                <div class="kpi-value">{{ matched }}</div>
+                <div class="kpi-label">structures reached<br>of {{ tq.NbProdClasses }}</div>
+            </div>
+            <div>
+                <div class="kpi-value">{{ tq.TraceabilityPct|floatformat:0 }}%</div>
+                <div class="kpi-label">traceability</div>
+            </div>
+        </div>
+    </div>
 </div>
 
-<!-- Global Metrics Section -->
-<div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-    <!-- Global Isolation Score Card -->
-    <div class="dashboard-card p-6 animate-fade-in-up stagger-1">
-        <h5 class="text-5xl font-bold metric-value tracking-tight mb-2 {% if tq.GlobalIsolationScore >= 80 %}score-isolated{% elif tq.GlobalIsolationScore >= 50 %}score-semi{% else %}score-coupled{% endif %}">
-            {{ tq.GlobalIsolationScore|floatformat:1 }}
-        </h5>
-        <p class="text-sm font-medium text-gray-500 mb-1">Global Isolation Score</p>
-        <span class="text-xs px-2 py-0.5 rounded-full font-medium {% if tq.GlobalIsolationScore >= 80 %}badge-isolated{% elif tq.GlobalIsolationScore >= 50 %}badge-semi{% else %}badge-coupled{% endif %}">
-            {{ tq.IsolationLabel }}
-        </span>
-        <p class="text-xs text-gray-800 border-t border-gray-100 pt-3 mt-3">
-            Measures how concentrated your tests are on specific application components. A high score means most tests focus on a small number of components.
-        </p>
+<!-- 2. Metrics -->
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mt-6">
+    <div class="stat-tile animate-fade-in-up stagger-1">
+        <div class="stat-tile-label">
+            <span>Isolation
+                <span tabindex="0" data-tip="Average over all test files of a score that drops as a test touches more structures, and as those structures pull in more of the code behind them." class="text-gray-300 text-xs">ⓘ</span>
+            </span>
+            {% if matched == 0 %}<span class="dot sev-none"></span>
+            {% elif tq.GlobalIsolationScore >= 80 %}<span class="dot sev-good"></span>
+            {% elif tq.GlobalIsolationScore >= 50 %}<span class="dot sev-warn"></span>
+            {% else %}<span class="dot sev-bad"></span>{% endif %}
+        </div>
+        {% if matched == 0 %}
+        <div class="stat-tile-value text-none">n/a</div>
+        <div class="stat-tile-target">no test matched a structure, so there is nothing to score</div>
+        {% else %}
+        <div class="stat-tile-value">{{ tq.GlobalIsolationScore|floatformat:0 }}</div>
+        <div class="meter">
+            <div class="meter-fill {% if tq.GlobalIsolationScore >= 80 %}sev-good{% elif tq.GlobalIsolationScore >= 50 %}sev-warn{% else %}sev-bad{% endif %}"
+                style="width:{{ tq.GlobalIsolationScore|floatformat:0 }}%"></div>
+        </div>
+        <div class="stat-tile-target">target ≥ 80 · {{ tq.IsolationLabel }}</div>
+        {% endif %}
     </div>
 
-    <!-- Test Files Count -->
-    <div class="dashboard-card p-6 animate-fade-in-up stagger-2">
-        <h5 class="text-4xl font-bold text-gray-900 metric-value tracking-tight mb-2">
-            {{ tq.NbTestFiles }}
-        </h5>
-        <p class="text-sm font-medium text-gray-500 mb-3">Test Files</p>
-        <p class="text-xs text-gray-800 border-t border-gray-100 pt-3">
-            out of {{ tq.NbProdFiles }} application files
-        </p>
+    <div class="stat-tile animate-fade-in-up stagger-2">
+        <div class="stat-tile-label">
+            <span>Structures reached</span>
+            {% if tq.TraceabilityPct >= 70 %}<span class="dot sev-good"></span>
+            {% elif tq.TraceabilityPct >= 40 %}<span class="dot sev-warn"></span>
+            {% else %}<span class="dot sev-bad"></span>{% endif %}
+        </div>
+        <div class="stat-tile-value">{{ tq.TraceabilityPct|floatformat:0 }}%</div>
+        <div class="meter">
+            <div class="meter-fill {% if tq.TraceabilityPct >= 70 %}sev-good{% elif tq.TraceabilityPct >= 40 %}sev-warn{% else %}sev-bad{% endif %}"
+                style="width:{{ tq.TraceabilityPct|floatformat:0 }}%"></div>
+        </div>
+        <div class="stat-tile-target">target ≥ 70% · {{ matched }} of {{ tq.NbProdClasses }}</div>
     </div>
 
-    <!-- Traceability -->
-    <div class="dashboard-card p-6 animate-fade-in-up stagger-3">
-        <h5 class="text-4xl font-bold metric-value tracking-tight mb-2 {% if tq.TraceabilityPct >= 70 %}score-isolated{% elif tq.TraceabilityPct >= 40 %}score-semi{% else %}score-coupled{% endif %}">
-            {{ tq.TraceabilityPct|floatformat:1 }}%
-        </h5>
-        <p class="text-sm font-medium text-gray-500 mb-3">Traceability</p>
-        <p class="text-xs text-gray-800 border-t border-gray-100 pt-3">
-            {{ tq.NbTestedClasses }} of {{ tq.NbProdClasses }} structures tested
-        </p>
+    <div class="stat-tile animate-fade-in-up stagger-3">
+        <div class="stat-tile-label">
+            <span>Test files</span>
+            <span class="dot sev-none"></span>
+        </div>
+        <div class="stat-tile-value">{{ tq.NbTestFiles }}</div>
+        {% if tq.NbProdFiles > 0 %}
+        <div class="meter">
+            <div class="meter-fill sev-none" style="width:{{ tq.NbTestFiles * 100 / tq.NbProdFiles }}%"></div>
+        </div>
+        {% endif %}
+        <div class="stat-tile-target">alongside {{ tq.NbProdFiles }} application
+            file{{ tq.NbProdFiles|pluralize }}</div>
     </div>
 
-    <!-- Orphans Count -->
-    <div class="dashboard-card p-6 animate-fade-in-up stagger-4">
-        <h5 class="text-4xl font-bold text-gray-900 metric-value tracking-tight mb-2">
-            {{ tq.OrphanClasses|length }}
-        </h5>
-        <p class="text-sm font-medium text-gray-500 mb-3">Critical Orphans</p>
-        <p class="text-xs text-gray-800 border-t border-gray-100 pt-3">
-            Application structures with no tests, ranked by importance
-        </p>
+    {% if tq.GodTests %}
+    <div class="stat-tile animate-fade-in-up stagger-4">
+        <div class="stat-tile-label">
+            <span>Tests touching too much</span>
+            <span class="dot sev-bad"></span>
+        </div>
+        <div class="stat-tile-value">{{ tq.GodTests|length }}</div>
+        <div class="meter">
+            <div class="meter-fill sev-bad" style="width:{{ tq.GodTests|length * 100 / tq.NbTestFiles }}%"></div>
+        </div>
+        <div class="stat-tile-target">target 0 · each touches 5 structures or more</div>
     </div>
+    {% else %}
+    <div class="stat-tile animate-fade-in-up stagger-4">
+        <div class="stat-tile-label">
+            <span>Structures no test reaches</span>
+            {% if tq.NbProdClasses == matched %}<span class="dot sev-good"></span>{% else %}<span class="dot sev-bad"></span>{% endif %}
+        </div>
+        <div class="stat-tile-value">{{ tq.NbProdClasses - matched }}</div>
+        {% if tq.NbProdClasses > 0 %}
+        <div class="meter">
+            <div class="meter-fill {% if tq.NbProdClasses == matched %}sev-good{% else %}sev-bad{% endif %}"
+                style="width:{{ (tq.NbProdClasses - matched) * 100 / tq.NbProdClasses }}%"></div>
+        </div>
+        {% endif %}
+        <div class="stat-tile-target">target 0 · out of {{ tq.NbProdClasses }} structures</div>
+    </div>
+    {% endif %}
 </div>
 
-<!-- Charts Row -->
-<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
-    <!-- Isolation Distribution Histogram -->
-    <div class="dashboard-card p-6 animate-fade-in-up stagger-2">
-        <h3 class="text-lg font-bold text-gray-900 mb-2">Isolation Distribution</h3>
-        <p class="text-xs text-gray-500 mb-4">How many test files fall into each isolation tier. You want most tests on the right (high isolation = few application structures touched per test).</p>
-        <div id="isolation-histogram" style="height: 220px;"></div>
+<!-- 3. Content -->
+{% if matched > 0 %}
+<div class="soft-card mt-6 animate-fade-in-up stagger-2">
+    <div class="flex items-start justify-between gap-4 mb-4">
+        <div>
+            <h2 class="card-title">How focused your tests are</h2>
+            <p class="card-sub">Each bar counts test files by their isolation score. Bars on the right are tests that
+                stay on one or two structures; bars on the left touch a large part of the application at once.</p>
+        </div>
     </div>
-
-    <!-- Test Blast Radius Bubble Chart -->
-    <div class="dashboard-card p-6 animate-fade-in-up stagger-3">
-        <h3 class="text-lg font-bold text-gray-900 mb-2">Test Blast Radius</h3>
-        <p class="text-xs text-gray-500 mb-4">Aim for the top-left corner: tests that touch fewer application structures (low fan-out) and score high on isolation are more precise, stable, and easier to diagnose when they fail.</p>
-        <div id="blast-radius-chart" style="height: 220px;"></div>
-    </div>
+    <div id="isolation-histogram" style="height: 220px;"></div>
 </div>
+{% endif %}
 
-<!-- God Tests Leaderboard -->
 {% if tq.GodTests %}
-<div class="dashboard-card p-6 mt-6 animate-fade-in-up stagger-4">
-    <h3 class="text-xl font-bold text-gray-900 mb-2">God Tests</h3>
-    <p class="text-xs text-gray-500 mb-4">A "God Test" touches 5 or more application structures. When it fails, you can't tell which structure is broken. Consider splitting these into smaller, focused test files.</p>
+<div class="soft-card mt-6 animate-fade-in-up stagger-3">
+    <div class="flex items-start justify-between gap-4 mb-4">
+        <div>
+            <h2 class="card-title">Tests that touch too much</h2>
+            <p class="card-sub">These test files exercise five structures or more. They break for reasons that have
+                nothing to do with what they check, and when they go red you can't tell which structure is at fault.</p>
+        </div>
+    </div>
     <div class="overflow-x-auto">
         <table class="w-full text-left border-collapse sortable">
             <thead>
                 <tr class="text-xs text-gray-800 border-b border-gray-100">
-                    <th class="py-2 font-medium">Rank</th>
-                    <th class="py-2 font-medium">Test File</th>
-                    <th class="py-2 font-medium text-right" data-sort-method="number">Fan-Out</th>
+                    <th class="py-2 font-medium">Test file</th>
+                    <th class="py-2 font-medium text-right" data-sort-method="number">Structures touched</th>
                     <th class="py-2 font-medium text-right" data-sort-method="number">Isolation</th>
-                    <th class="py-2 font-medium text-right">Label</th>
+                    <th class="py-2 font-medium text-right">Verdict</th>
                 </tr>
             </thead>
             <tbody class="text-sm text-gray-600">
                 {% for test in tq.GodTests %}
                 <tr class="border-b border-gray-50 last:border-0 hover:bg-gray-50 transition-colors">
-                    <td class="py-2 font-medium text-gray-900">{{ forloop.Counter }}</td>
-                    <td class="py-2 font-medium text-gray-900 truncate max-w-[300px]" title="{{ test.FilePath }}">
+                    <td class="py-2 font-medium text-gray-900 truncate max-w-[320px]" title="{{ test.FilePath }}">
                         {{ test.ShortPath }}
                     </td>
                     <td class="py-2 text-right font-mono">{{ test.SUTFanOut }}</td>
                     <td class="py-2 text-right font-mono">{{ test.IsolationScore|floatformat:0 }}</td>
                     <td class="py-2 text-right">
-                        <span class="text-xs px-2 py-0.5 rounded-full font-medium {% if test.IsolationScore >= 80 %}badge-isolated{% elif test.IsolationScore >= 50 %}badge-semi{% else %}badge-coupled{% endif %}">
+                        <span class="text-xs px-2 py-0.5 rounded-full font-medium {% if test.IsolationScore >= 80 %}bg-green-100 text-green-700{% elif test.IsolationScore >= 50 %}bg-amber-100 text-amber-700{% else %}bg-red-100 text-red-700{% endif %}">
                             {{ test.IsolationLabel }}
                         </span>
                     </td>
@@ -205,38 +240,39 @@ AST Metrics - Test Quality
 </div>
 {% endif %}
 
-<!-- Orphan Critical Structures -->
 {% if tq.OrphanClasses %}
-<div class="dashboard-card p-6 mt-6 animate-fade-in-up stagger-5">
-    <h3 class="text-xl font-bold text-gray-900 mb-2">Orphan Critical Structures</h3>
-    <p class="text-xs text-gray-500 mb-4">These application structures have no test touching them. They are ranked by weight: the more complex and coupled a structure is, the riskier it is to leave it untested. Prioritize writing tests for the top entries.</p>
+<div class="soft-card mt-6 animate-fade-in-up stagger-4">
+    <div class="flex items-start justify-between gap-4 mb-4">
+        <div>
+            <h2 class="card-title">Code no test reaches</h2>
+            <p class="card-sub">No test touches these structures. The more complex and the more connected one is, the
+                more a change there can break something else without anything turning red. Sorted by untested surface:
+                complexity multiplied by the number of connections.</p>
+        </div>
+    </div>
     <div class="overflow-x-auto">
         <table class="w-full text-left border-collapse sortable">
             <thead>
                 <tr class="text-xs text-gray-800 border-b border-gray-100">
-                    <th class="py-2 font-medium">Rank</th>
                     <th class="py-2 font-medium">Structure</th>
                     <th class="py-2 font-medium">File</th>
                     <th class="py-2 font-medium text-right" data-sort-method="number">Complexity</th>
-                    <th class="py-2 font-medium text-right" data-sort-method="number">Efferent</th>
-                    <th class="py-2 font-medium text-right" data-sort-method="number">Afferent</th>
-                    <th class="py-2 font-medium text-right" data-sort-method="number">Weight</th>
+                    <th class="py-2 font-medium text-right" data-sort-method="number">Used by</th>
+                    <th class="py-2 font-medium text-right" data-sort-method="number">Untested surface</th>
                 </tr>
             </thead>
             <tbody class="text-sm text-gray-600">
                 {% for orphan in tq.OrphanClasses %}
                 <tr class="border-b border-gray-50 last:border-0 hover:bg-gray-50 transition-colors">
-                    <td class="py-2 font-medium text-gray-900">{{ forloop.Counter }}</td>
-                    <td class="py-2 font-medium text-gray-900 truncate max-w-[200px]" title="{{ orphan.ClassName }}">
+                    <td class="py-2 font-medium text-gray-900 truncate max-w-[220px]" title="{{ orphan.ClassName }}">
                         {{ orphan.ClassName }}
                     </td>
-                    <td class="py-2 text-gray-500 truncate max-w-[200px]" title="{{ orphan.FilePath }}">
-                        {{ orphan.FilePath }}
+                    <td class="py-2 text-gray-500 truncate max-w-[220px]" title="{{ orphan.FilePath }}">
+                        {{ orphan.FilePath|split:"/"|last }}
                     </td>
                     <td class="py-2 text-right font-mono">{{ orphan.Complexity }}</td>
-                    <td class="py-2 text-right font-mono">{{ orphan.Efferent }}</td>
                     <td class="py-2 text-right font-mono">{{ orphan.Afferent }}</td>
-                    <td class="py-2 text-right font-mono font-bold">{{ orphan.Weight|floatformat:0 }}</td>
+                    <td class="py-2 text-right font-mono font-semibold text-gray-900">{{ orphan.Weight|floatformat:0 }}</td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -246,8 +282,30 @@ AST Metrics - Test Quality
 {% endif %}
 
 {% else %}
-<div class="dashboard-card p-6 mt-8">
-    <p class="text-gray-600">No test quality data available. Ensure your project contains test files to see metrics.</p>
+<!-- No test file at all: say so plainly -->
+<div class="page-hero animate-fade-in-up mt-8">
+    <div class="flex flex-wrap items-start justify-between gap-8">
+        <div class="min-w-0">
+            <span class="level-pill mb-5">
+                <span class="dot sev-none"></span> Nothing to measure
+            </span>
+            <h1 class="verdict-title">
+                No test file detected.<br>
+                <span class="verdict-muted">Nothing here can tell you whether this code works.</span>
+            </h1>
+            <p class="verdict-lead mt-4">
+                {% if currentView.TestQuality %}
+                AST Metrics scanned <strong>{{ currentView.TestQuality.NbProdFiles }}
+                    file{{ currentView.TestQuality.NbProdFiles|pluralize }}</strong> and recognised no test among them.
+                {% else %}
+                AST Metrics recognised no test file in the analysed sources.
+                {% endif %}
+                Test files are identified from the usual naming conventions of each language, so a project that names
+                them differently will show up empty here
+                <span tabindex="0" data-tip="Files are treated as tests when their path or name follows the language's usual convention, such as _test.go, test_*.py or *Test.php." class="text-gray-300 text-xs">ⓘ</span>.
+            </p>
+        </div>
+    </div>
 </div>
 {% endif %}
 
@@ -259,166 +317,73 @@ document.addEventListener('DOMContentLoaded', function() {
     var data = (window.__AST_DATA__ || {}).testQuality;
     if (!data) return;
 
-    // Isolation Distribution Histogram
-    if (data.isolationHistogram && typeof d3 !== 'undefined') {
-        var histEl = document.getElementById('isolation-histogram');
-        if (histEl) {
-            var bins = data.isolationHistogram;
-            var labels = ['0-19', '20-39', '40-59', '60-79', '80-100'];
-            var colors = ['#dc2626', '#f97316', '#eab308', '#84cc16', '#059669'];
+    var histEl = document.getElementById('isolation-histogram');
+    if (!histEl || !data.isolationHistogram || typeof d3 === 'undefined') return;
 
-            var margin = {top: 10, right: 20, bottom: 30, left: 40};
-            var width = histEl.clientWidth - margin.left - margin.right;
-            var height = 200 - margin.top - margin.bottom;
+    var bins = data.isolationHistogram;
+    var labels = ['0-19', '20-39', '40-59', '60-79', '80-100'];
+    var colors = ['#ef4444', '#f59e0b', '#fbbf24', '#4ade80', '#22c55e'];
 
-            var svg = d3.select('#isolation-histogram')
-                .append('svg')
-                .attr('width', width + margin.left + margin.right)
-                .attr('height', height + margin.top + margin.bottom)
-                .append('g')
-                .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+    var margin = {top: 10, right: 20, bottom: 34, left: 40};
+    var width = histEl.clientWidth - margin.left - margin.right;
+    var height = 200 - margin.top - margin.bottom;
 
-            var x = d3.scaleBand()
-                .domain(labels)
-                .range([0, width])
-                .padding(0.2);
+    var svg = d3.select('#isolation-histogram')
+        .append('svg')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
-            var y = d3.scaleLinear()
-                .domain([0, d3.max(bins) || 1])
-                .nice()
-                .range([height, 0]);
+    var x = d3.scaleBand()
+        .domain(labels)
+        .range([0, width])
+        .padding(0.2);
 
-            svg.append('g')
-                .attr('transform', 'translate(0,' + height + ')')
-                .call(d3.axisBottom(x))
-                .selectAll('text')
-                .style('font-size', '11px');
+    var y = d3.scaleLinear()
+        .domain([0, d3.max(bins) || 1])
+        .nice()
+        .range([height, 0]);
 
-            svg.append('g')
-                .call(d3.axisLeft(y).ticks(5))
-                .selectAll('text')
-                .style('font-size', '11px');
+    svg.append('g')
+        .attr('transform', 'translate(0,' + height + ')')
+        .call(d3.axisBottom(x))
+        .selectAll('text')
+        .style('font-size', '11px');
 
-            svg.selectAll('.bar')
-                .data(bins)
-                .join('rect')
-                .attr('x', function(d, i) { return x(labels[i]); })
-                .attr('y', function(d) { return y(d); })
-                .attr('width', x.bandwidth())
-                .attr('height', function(d) { return height - y(d); })
-                .attr('fill', function(d, i) { return colors[i]; })
-                .attr('rx', 4);
+    svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', height + 30)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '10px')
+        .style('fill', '#94a3b8')
+        .text('isolation score');
 
-            svg.selectAll('.label')
-                .data(bins)
-                .join('text')
-                .attr('x', function(d, i) { return x(labels[i]) + x.bandwidth() / 2; })
-                .attr('y', function(d) { return y(d) - 4; })
-                .attr('text-anchor', 'middle')
-                .style('font-size', '11px')
-                .style('font-weight', '600')
-                .style('fill', '#374151')
-                .text(function(d) { return d > 0 ? d : ''; });
-        }
-    }
+    svg.append('g')
+        .call(d3.axisLeft(y).ticks(5))
+        .selectAll('text')
+        .style('font-size', '11px');
 
-    // Blast Radius Bubble Chart
-    if (data.testFiles && data.testFiles.length > 0 && typeof d3 !== 'undefined') {
-        var bubbleEl = document.getElementById('blast-radius-chart');
-        if (bubbleEl) {
-            var margin = {top: 10, right: 20, bottom: 30, left: 40};
-            var width = bubbleEl.clientWidth - margin.left - margin.right;
-            var height = 200 - margin.top - margin.bottom;
+    svg.selectAll('.bar')
+        .data(bins)
+        .join('rect')
+        .attr('x', function(d, i) { return x(labels[i]); })
+        .attr('y', function(d) { return y(d); })
+        .attr('width', x.bandwidth())
+        .attr('height', function(d) { return height - y(d); })
+        .attr('fill', function(d, i) { return colors[i]; })
+        .attr('rx', 4);
 
-            var svg = d3.select('#blast-radius-chart')
-                .append('svg')
-                .attr('width', width + margin.left + margin.right)
-                .attr('height', height + margin.top + margin.bottom)
-                .append('g')
-                .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
-
-            var tests = data.testFiles.filter(function(t) { return t.fanOut > 0; });
-
-            var x = d3.scaleLinear()
-                .domain([0, d3.max(tests, function(t) { return t.fanOut; }) || 1])
-                .nice()
-                .range([0, width]);
-
-            var y = d3.scaleLinear()
-                .domain([0, 100])
-                .range([height, 0]);
-
-            var r = d3.scaleSqrt()
-                .domain([0, d3.max(tests, function(t) { return t.fanOut; }) || 1])
-                .range([3, 20]);
-
-            var color = function(score) {
-                if (score >= 80) return '#059669';
-                if (score >= 50) return '#eab308';
-                return '#dc2626';
-            };
-
-            svg.append('g')
-                .attr('transform', 'translate(0,' + height + ')')
-                .call(d3.axisBottom(x).ticks(5))
-                .selectAll('text')
-                .style('font-size', '11px');
-
-            svg.append('text')
-                .attr('x', width / 2)
-                .attr('y', height + 28)
-                .attr('text-anchor', 'middle')
-                .style('font-size', '10px')
-                .style('fill', '#6b7280')
-                .text('Fan-Out (prod structures touched)');
-
-            svg.append('g')
-                .call(d3.axisLeft(y).ticks(5))
-                .selectAll('text')
-                .style('font-size', '11px');
-
-            svg.append('text')
-                .attr('transform', 'rotate(-90)')
-                .attr('y', -35)
-                .attr('x', -height / 2)
-                .attr('text-anchor', 'middle')
-                .style('font-size', '10px')
-                .style('fill', '#6b7280')
-                .text('Isolation Score');
-
-            // Tooltip
-            var tooltip = d3.select('#blast-radius-chart')
-                .append('div')
-                .attr('class', 'graph-tooltip')
-                .style('opacity', 0);
-
-            svg.selectAll('circle')
-                .data(tests)
-                .join('circle')
-                .attr('cx', function(t) { return x(t.fanOut); })
-                .attr('cy', function(t) { return y(t.isolationScore); })
-                .attr('r', function(t) { return r(t.fanOut); })
-                .attr('fill', function(t) { return color(t.isolationScore); })
-                .attr('opacity', 0.7)
-                .attr('stroke', '#fff')
-                .attr('stroke-width', 1)
-                .on('mouseover', function(event, t) {
-                    tooltip.transition().duration(200).style('opacity', 1);
-                    tooltip.html(
-                        '<strong>' + t.shortPath + '</strong><br/>' +
-                        'Fan-out: ' + t.fanOut + '<br/>' +
-                        'Isolation: ' + Math.round(t.isolationScore) + ' (' + t.isolationLabel + ')'
-                    )
-                    .style('left', (event.offsetX) + 'px')
-                    .style('top', (event.offsetY - 10) + 'px')
-                    .attr('class', 'graph-tooltip visible');
-                })
-                .on('mouseout', function() {
-                    tooltip.transition().duration(300).style('opacity', 0)
-                    .attr('class', 'graph-tooltip');
-                });
-        }
-    }
+    svg.selectAll('.label')
+        .data(bins)
+        .join('text')
+        .attr('x', function(d, i) { return x(labels[i]) + x.bandwidth() / 2; })
+        .attr('y', function(d) { return y(d) - 4; })
+        .attr('text-anchor', 'middle')
+        .style('font-size', '11px')
+        .style('font-weight', '600')
+        .style('fill', '#334155')
+        .text(function(d) { return d > 0 ? d : ''; });
 });
 </script>
 {% endblock %}

--- a/internal/scm/commit.go
+++ b/internal/scm/commit.go
@@ -1,8 +1,12 @@
 package scm
 
 type Commit struct {
-	Hash      string
-	Author    string
+	Hash string
+	// Author is the display name recorded by git (%an)
+	Author string
+	// Email is the author address (%ae). It is only used to resolve an avatar,
+	// and stays empty on repositories whose log does not expose it.
+	Email     string
 	Timestamp int
 	Files     []string
 }

--- a/internal/scm/git_repository.go
+++ b/internal/scm/git_repository.go
@@ -81,7 +81,7 @@ func getAbsolutePath(repoRoot string) (string, error) {
 }
 
 func (git *GitRepository) ListAllCommitsSince(since string) ([]Commit, error) {
-	cmd := exec.Command("git", "--no-pager", "log", "--pretty=format:# %h|%an|%ct", "--name-only", "--since="+since)
+	cmd := exec.Command("git", "--no-pager", "log", "--pretty=format:# %h|%an|%ct|%ae", "--name-only", "--since="+since)
 	cmd.Dir = git.Path
 
 	stdout, err := cmd.StdoutPipe()
@@ -117,9 +117,16 @@ func (git *GitRepository) ListAllCommitsSince(since string) ([]Commit, error) {
 				commits = append(commits, currentCommit)
 			}
 
+			// The email is appended last, so a log without it still parses
+			email := ""
+			if len(commitInfos) > 3 {
+				email = commitInfos[3]
+			}
+
 			currentCommit = Commit{
 				Hash:      commitInfos[0],
 				Author:    commitInfos[1],
+				Email:     email,
 				Timestamp: timestamp,
 			}
 			continue

--- a/internal/ui/component_barchart_cyclomatic_by_method_repartition.go
+++ b/internal/ui/component_barchart_cyclomatic_by_method_repartition.go
@@ -39,6 +39,11 @@ func (c *ComponentBarchartCyclomaticByMethodRepartition) GetData() *orderedmap.O
 	// repartition of classes by cyclomatic complexity
 	for _, file := range c.Files {
 
+		// test files are not production code: exclude them from the repartition
+		if file.GetIsTest() {
+			continue
+		}
+
 		functions := engine.GetFunctionsInFile(file)
 		for _, function := range functions {
 			if function.Stmts.Analyze == nil {

--- a/internal/ui/component_barchart_lcom_repartition.go
+++ b/internal/ui/component_barchart_lcom_repartition.go
@@ -46,6 +46,10 @@ func (c *ComponentBarchartLcomRepartition) GetData() *orderedmap.OrderedMap[stri
 	}
 
 	for _, file := range c.Files {
+		// test files are not production code: exclude them from the repartition
+		if file.GetIsTest() {
+			continue
+		}
 		classes := engine.GetClassesInFile(file)
 		for _, class := range classes {
 			if class.Stmts == nil || class.Stmts.Analyze == nil || class.Stmts.Analyze.ClassCohesion == nil || class.Stmts.Analyze.ClassCohesion.Lcom4 == nil {

--- a/internal/ui/component_barchart_loc_by_method_repartition.go
+++ b/internal/ui/component_barchart_loc_by_method_repartition.go
@@ -44,6 +44,10 @@ func (c *ComponentBarchartLocByMethodRepartition) GetData() *orderedmap.OrderedM
 
 	// repartition of files by LOC
 	for _, file := range c.Files {
+		// test files are not production code: exclude them from the repartition
+		if file.GetIsTest() {
+			continue
+		}
 		functions := engine.GetFunctionsInFile(file)
 		for _, funct := range functions {
 			if funct.Stmts.Analyze == nil {

--- a/internal/ui/component_barchart_maintainability_index_repartition.go
+++ b/internal/ui/component_barchart_maintainability_index_repartition.go
@@ -44,6 +44,10 @@ func (c *ComponentBarchartMaintainabilityIndexRepartition) GetData() *orderedmap
 
 	// repartition of files by LOC
 	for _, file := range c.Files {
+		// test files are not production code: exclude them from the repartition
+		if file.GetIsTest() {
+			continue
+		}
 		classes := engine.GetClassesInFile(file)
 
 		if classes == nil || len(classes) == 0 {


### PR DESCRIPTION
Reworks the HTML report so each page carries an explicit verdict, adds the classes and metrics pages plus language tabs, and replaces the share/footer links with a sponsor link.