### PR TITLE
feat(report): rework the dependencies page around a packed, explorable graph

### DIFF
--- a/internal/report/templates/html/dependencies.html
+++ b/internal/report/templates/html/dependencies.html
@@ -3,29 +3,49 @@
 {% block content %}
 
 <style>
-    /* Page-specific only: the graph surface, its tooltip and the view switch.
-       Everything else comes from the shared components in layout.html. */
+    /* Page-specific only: the graph surface, its HUD (search, zoom, panel),
+       the tooltip and the view switch. Everything else comes from the shared
+       components in layout.html. */
+
+    /* The drawing surface: a dotted canvas, like a design tool */
+    #dep-shell {
+        position: relative;
+        height: clamp(560px, 68vh, 860px);
+        border: 1px solid #e2e8f0;
+        border-radius: 16px;
+        overflow: hidden;
+        background-color: #fcfdff;
+        background-image: radial-gradient(circle, #e5eaf1 1px, transparent 1px);
+        background-size: 22px 22px;
+    }
+    #dep-shell:fullscreen {
+        height: 100vh;
+        border-radius: 0;
+    }
     #dep-graph-canvas {
-        width: 100%;
-        min-height: 600px;
+        position: absolute;
+        inset: 0;
         cursor: grab;
-        background: white;
     }
-    #dep-graph-canvas:active {
-        cursor: grabbing;
+    #dep-graph-canvas.dragging { cursor: grabbing; }
+    #dep-graph-canvas canvas {
+        opacity: 0;
+        transition: opacity 0.45s ease;
     }
+    #dep-shell.dep-ready #dep-graph-canvas canvas { opacity: 1; }
+
     .dep-tooltip {
         position: fixed;
         pointer-events: none;
         z-index: 50;
-        background: rgba(255,255,255,0.95);
-        backdrop-filter: blur(4px);
+        background: rgba(255,255,255,0.96);
+        backdrop-filter: blur(6px);
         color: #1e293b;
         font-size: 12px;
         line-height: 1.5;
         padding: 8px 12px;
-        border-radius: 8px;
-        box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
+        border-radius: 10px;
+        box-shadow: 0 8px 20px rgba(15,23,42,0.12);
         border: 1px solid #e2e8f0;
         opacity: 0;
         transition: opacity 150ms ease;
@@ -33,6 +53,7 @@
         word-break: break-all;
     }
     .dep-tooltip.visible { opacity: 1; }
+    .dep-tooltip .tip-hint { color: #64748b; font-size: 11px; }
 
     /* Discreet segmented control for "By file / By folder" */
     .dep-seg {
@@ -61,6 +82,193 @@
         box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
     }
     .dep-seg label:focus-within { outline: 2px solid #3b82f6; outline-offset: 1px; }
+
+    /* Floating search, top-left of the surface */
+    .dep-search {
+        position: absolute;
+        left: 14px;
+        top: 14px;
+        width: min(260px, 60%);
+        z-index: 30;
+    }
+    .dep-search > svg {
+        position: absolute;
+        left: 10px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 14px;
+        height: 14px;
+        color: #64748b;
+        pointer-events: none;
+    }
+    .dep-search input {
+        width: 100%;
+        font-size: 12.5px;
+        padding: 0.5rem 0.75rem 0.5rem 2rem;
+        border-radius: 10px;
+        border: 1px solid #e2e8f0;
+        background: rgba(255,255,255,0.94);
+        backdrop-filter: blur(6px);
+        color: #0f172a;
+        outline: none;
+        box-shadow: 0 4px 12px rgba(15,23,42,0.06);
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+    .dep-search input:focus {
+        border-color: #93c5fd;
+        box-shadow: 0 0 0 3px rgba(59,130,246,0.12);
+    }
+    .dep-search input::placeholder { color: #64748b; }
+    .dep-search-results {
+        position: absolute;
+        top: calc(100% + 6px);
+        left: 0;
+        right: 0;
+        background: white;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        box-shadow: 0 12px 28px rgba(15,23,42,0.14);
+        overflow: hidden;
+        display: none;
+    }
+    .dep-search-results.open { display: block; }
+    .dep-search-item {
+        padding: 0.5rem 0.75rem;
+        cursor: pointer;
+        border-bottom: 1px solid #f8fafc;
+    }
+    .dep-search-item:last-child { border-bottom: 0; }
+    .dep-search-item:hover, .dep-search-item.active { background: #f1f5f9; }
+    .dep-search-item .name { font-size: 12.5px; font-weight: 500; color: #0f172a; }
+    .dep-search-item .meta { font-size: 11px; color: #64748b; margin-top: 1px; }
+
+    /* Floating zoom / fit / fullscreen, bottom-right of the surface */
+    .dep-fab-group {
+        position: absolute;
+        right: 14px;
+        bottom: 14px;
+        display: flex;
+        flex-direction: column;
+        border-radius: 12px;
+        overflow: hidden;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 6px 16px rgba(15,23,42,0.10);
+        z-index: 20;
+    }
+    .dep-fab {
+        width: 34px;
+        height: 34px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(255,255,255,0.95);
+        backdrop-filter: blur(6px);
+        border: 0;
+        color: #475569;
+        cursor: pointer;
+        transition: background-color 0.15s ease, color 0.15s ease;
+    }
+    .dep-fab + .dep-fab { border-top: 1px solid #eef2f6; }
+    .dep-fab:hover { background: #f1f5f9; color: #0f172a; }
+    .dep-fab svg { width: 15px; height: 15px; }
+
+    /* Selection panel, top-right of the surface */
+    .dep-panel {
+        position: absolute;
+        top: 14px;
+        right: 14px;
+        width: 300px;
+        max-width: calc(100% - 28px);
+        max-height: calc(100% - 28px);
+        overflow: auto;
+        background: rgba(255,255,255,0.97);
+        backdrop-filter: blur(8px);
+        border: 1px solid #e2e8f0;
+        border-radius: 16px;
+        box-shadow: 0 16px 40px rgba(15,23,42,0.14);
+        display: none;
+        z-index: 25;
+    }
+    .dep-panel.open { display: block; }
+    .dep-panel-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.5rem;
+        padding: 0.875rem 1rem 0.625rem;
+        border-bottom: 1px solid #f1f5f9;
+    }
+    .dep-panel-close {
+        border: 0;
+        background: transparent;
+        color: #64748b;
+        cursor: pointer;
+        padding: 2px;
+        border-radius: 6px;
+        flex-shrink: 0;
+    }
+    .dep-panel-close:hover { background: #f1f5f9; color: #334155; }
+    .dep-panel-section { padding: 0.625rem 1rem; }
+    .dep-panel-section + .dep-panel-section { border-top: 1px solid #f8fafc; }
+    .dep-panel-section-title {
+        font-size: 10.5px;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: #64748b;
+        margin-bottom: 0.375rem;
+    }
+    .dep-panel-list { max-height: 150px; overflow: auto; }
+    .dep-panel-list a {
+        display: block;
+        font-size: 12.5px;
+        color: #334155;
+        padding: 0.25rem 0.375rem;
+        border-radius: 7px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        cursor: pointer;
+    }
+    .dep-panel-list a:hover { background: #f1f5f9; color: #0f172a; }
+    .dep-panel-foot { padding: 0.75rem 1rem 0.875rem; }
+    .dep-panel-open {
+        display: block;
+        width: 100%;
+        text-align: center;
+        font-size: 12.5px;
+        font-weight: 600;
+        color: #1d4ed8;
+        background: #eff6ff;
+        border: 1px solid #bfdbfe;
+        border-radius: 10px;
+        padding: 0.45rem 0.5rem;
+        transition: background-color 0.15s ease;
+    }
+    .dep-panel-open:hover { background: #dbeafe; }
+
+    /* Small monospace chips: cycle chains, isolated files */
+    .dep-chip {
+        font-family: var(--font-mono);
+        font-size: 11.5px;
+        background: #f1f5f9;
+        border: 1px solid #e2e8f0;
+        padding: 0.15rem 0.45rem;
+        border-radius: 7px;
+        color: #334155;
+        white-space: nowrap;
+    }
+    a.dep-chip:hover { background: #e2e8f0; color: #0f172a; }
+    .dep-cycle-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.3rem 0.4rem;
+        padding: 0.625rem 0;
+        border-bottom: 1px solid #f1f5f9;
+    }
+    .dep-cycle-row:last-child { border-bottom: 0; }
+    .dep-cycle-arrow { color: #cbd5e1; font-size: 11px; }
 
     @keyframes dep-spin { to { transform: rotate(360deg); } }
 </style>
@@ -102,6 +310,10 @@
                     <div class="kpi-value" id="kpi-avg">0</div>
                     <div class="kpi-label">links per file</div>
                 </div>
+                <div>
+                    <div class="kpi-value" id="kpi-cycles">0</div>
+                    <div class="kpi-label">circular chains</div>
+                </div>
             </div>
         </div>
     </div>
@@ -113,6 +325,7 @@
                 <span class="flex items-center gap-2"><span class="dot" style="background:#0d9488"></span> Mostly uses others</span>
                 <span class="flex items-center gap-2"><span class="dot" style="background:#7c3aed"></span> Mostly used</span>
                 <span class="flex items-center gap-2"><span class="dot" style="background:#3b82f6"></span> Balanced</span>
+                <span id="dep-legend-cycle" class="hidden flex items-center gap-2"><span class="dot" style="background:#d97706"></span> Part of a cycle</span>
                 <span class="text-gray-500">size = number of links</span>
             </div>
             <div id="dep-view-toggle" class="dep-seg">
@@ -128,12 +341,62 @@
             <span id="dep-breadcrumb-current" class="font-medium text-gray-800"></span>
         </div>
 
-        <!-- Graph container -->
-        <div id="dep-graph-wrapper" style="position:relative;background:white;border-radius:14px;overflow:hidden;">
-            <div id="dep-graph-canvas" style="width:100%;min-height:600px;"></div>
+        <!-- Drawing surface -->
+        <div id="dep-shell">
+            <div id="dep-graph-canvas"></div>
+
+            <!-- Search -->
+            <div class="dep-search">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-4.35-4.35M17 11a6 6 0 1 1-12 0 6 6 0 0 1 12 0Z" />
+                </svg>
+                <input type="text" id="dep-search-input" placeholder="Find a file&hellip;" autocomplete="off" spellcheck="false">
+                <div id="dep-search-results" class="dep-search-results"></div>
+            </div>
+
+            <!-- Zoom / fit / fullscreen -->
+            <div class="dep-fab-group">
+                <button type="button" class="dep-fab" id="dep-zoom-in" title="Zoom in">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14M5 12h14"/></svg>
+                </button>
+                <button type="button" class="dep-fab" id="dep-zoom-out" title="Zoom out">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14"/></svg>
+                </button>
+                <button type="button" class="dep-fab" id="dep-zoom-fit" title="Fit to view">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 8V6a3 3 0 0 1 3-3h2M16 3h2a3 3 0 0 1 3 3v2M21 16v2a3 3 0 0 1-3 3h-2M8 21H6a3 3 0 0 1-3-3v-2"/></svg>
+                </button>
+                <button type="button" class="dep-fab" id="dep-fullscreen" title="Fullscreen">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15m11.25 5.25-5.25-5.25m5.25 5.25v-4.5m0 4.5h-4.5"/></svg>
+                </button>
+            </div>
+
+            <!-- Selection panel -->
+            <div id="dep-panel" class="dep-panel">
+                <div class="dep-panel-head">
+                    <div class="min-w-0">
+                        <div class="row-name truncate" id="dep-panel-name"></div>
+                        <div class="row-meta truncate" id="dep-panel-meta"></div>
+                    </div>
+                    <button type="button" class="dep-panel-close" id="dep-panel-close" title="Close">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:14px;height:14px"><path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M18 6 6 18"/></svg>
+                    </button>
+                </div>
+                <div class="dep-panel-section">
+                    <div class="dep-panel-section-title" id="dep-panel-uses-title">Uses</div>
+                    <div class="dep-panel-list" id="dep-panel-uses"></div>
+                </div>
+                <div class="dep-panel-section">
+                    <div class="dep-panel-section-title" id="dep-panel-usedby-title">Used by</div>
+                    <div class="dep-panel-list" id="dep-panel-usedby"></div>
+                </div>
+                <div class="dep-panel-foot">
+                    <a href="#" class="dep-panel-open" id="dep-panel-open">Open in explorer</a>
+                </div>
+            </div>
+
             <!-- Loading skeleton -->
-            <div id="dep-graph-loading" class="absolute inset-0 flex flex-col items-center justify-center bg-white" style="z-index:10;">
-                <div class="relative" style="width:160px;height:160px;">
+            <div id="dep-graph-loading" class="absolute inset-0 flex flex-col items-center justify-center" style="z-index:15;background:rgba(252,253,255,0.92);">
+                <div class="relative" style="width:140px;height:140px;">
                     <div style="position:absolute;inset:0;border-radius:50%;border:3px solid #e2e8f0;"></div>
                     <div style="position:absolute;inset:0;border-radius:50%;border:3px solid transparent;border-top-color:#3b82f6;animation:dep-spin 0.8s linear infinite;"></div>
                     <svg viewBox="0 0 100 100" style="position:absolute;inset:15%;width:70%;height:70%;opacity:0.15;">
@@ -141,21 +404,36 @@
                         <line x1="30" y1="30" x2="70" y2="25" stroke="#cbd5e1" stroke-width="1.5"/><line x1="30" y1="30" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/><line x1="70" y1="25" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/><line x1="50" y1="65" x2="80" y2="60" stroke="#cbd5e1" stroke-width="1.5"/><line x1="20" y1="70" x2="50" y2="65" stroke="#cbd5e1" stroke-width="1.5"/>
                     </svg>
                 </div>
-                <p class="mt-4 text-sm text-gray-500 font-medium">Building dependency graph...</p>
+                <p class="mt-4 text-sm text-gray-500 font-medium">Laying out the dependency graph&hellip;</p>
             </div>
         </div>
+
+        <!-- Files with no link at all, kept out of the drawing -->
+        <details id="dep-isolated" class="hidden mt-3">
+            <summary class="text-xs text-gray-500 cursor-pointer select-none hover:text-gray-700" id="dep-isolated-summary"></summary>
+            <div class="mt-2 flex flex-wrap gap-1.5" id="dep-isolated-chips"></div>
+        </details>
+    </div>
+
+    <!-- Circular dependencies -->
+    <div class="soft-card mt-6 animate-fade-in-up stagger-2">
+        <div class="mb-3">
+            <h2 class="card-title">Circular dependencies</h2>
+            <p class="card-sub">Files that end up depending on themselves through others.</p>
+        </div>
+        <div id="dep-cycles-body"></div>
     </div>
 
     <!-- Where the coupling sits -->
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
-        <div class="soft-card animate-fade-in-up stagger-2">
+        <div class="soft-card animate-fade-in-up stagger-3">
             <div class="mb-3">
                 <h2 class="card-title">Handle with care</h2>
-                <p class="card-sub">Many files depend on these. A change here propagates.</p>
+                <p class="card-sub">Many files depend on these. A change here propagates. Hover a row to spot it in the graph.</p>
             </div>
             <div id="dep-afferent-list"></div>
         </div>
-        <div class="soft-card animate-fade-in-up stagger-3">
+        <div class="soft-card animate-fade-in-up stagger-4">
             <div class="mb-3">
                 <h2 class="card-title">Heavily wired</h2>
                 <p class="card-sub">These files need many others to work.</p>
@@ -184,7 +462,6 @@ document.addEventListener('DOMContentLoaded', function() {
         var _d = window.__AST_DATA__ || {};
         var deps = _d.fileDeps || {};
         var folderDeps = _d.folderDeps || null;
-        var depFileCount = _d.depFileCount || 0;
         var dict = _d.dictionary || {};
         function resolve(h) { return dict[h] || h; }
 
@@ -195,9 +472,10 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         document.getElementById('dep-content').classList.remove('hidden');
 
-        // Compute KPIs from file-level deps
+        // ---- File-level graph model -----------------------------------------
         var totalEdgesFile = 0;
         var nodeMapFile = {};
+        var outAdjFile = {};
         fileKeys.forEach(function(fp) {
             if (!nodeMapFile[fp]) nodeMapFile[fp] = { id: fp, eff: 0, aff: 0 };
             var entry = deps[fp];
@@ -206,19 +484,23 @@ document.addEventListener('DOMContentLoaded', function() {
                     if (!nodeMapFile[d.path]) nodeMapFile[d.path] = { id: d.path, eff: 0, aff: 0 };
                     nodeMapFile[fp].eff++;
                     nodeMapFile[d.path].aff++;
+                    if (!outAdjFile[fp]) outAdjFile[fp] = [];
+                    outAdjFile[fp].push(d.path);
                     totalEdgesFile++;
                 });
             }
         });
         var nodesFile = Object.values(nodeMapFile);
-        var totalFilesKPI = nodesFile.length;
-        var avgCoupling = totalFilesKPI > 0 ? ((nodesFile.reduce(function(s,n) { return s + n.eff + n.aff; }, 0)) / totalFilesKPI).toFixed(1) : '0.0';
+        var linkedFiles = nodesFile.filter(function(n) { return n.eff + n.aff > 0; });
+        var isolatedFiles = nodesFile.filter(function(n) { return n.eff + n.aff === 0; });
+        var totalFilesKPI = linkedFiles.length;
+        var avgCoupling = totalFilesKPI > 0 ? ((2 * totalEdgesFile) / totalFilesKPI).toFixed(1) : '0.0';
 
         document.getElementById('kpi-files').textContent = totalFilesKPI;
         document.getElementById('kpi-edges').textContent = totalEdgesFile;
         document.getElementById('kpi-avg').textContent = avgCoupling;
 
-        // ---- Verdict + coupling lists -------------------------------------
+        // ---- Small helpers ---------------------------------------------------
         function esc(s) {
             return String(s).replace(/[&<>"]/g, function(c) {
                 return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
@@ -241,6 +523,9 @@ document.addEventListener('DOMContentLoaded', function() {
         function plural(n, word) {
             return n + ' ' + word + (n === 1 ? '' : 's');
         }
+        function explorerUrl(id) {
+            return 'explorer{{ scopeSuffix }}.html?file=' + encodeURIComponent(id);
+        }
         // Human fraction of the project touched by a change in one file.
         function fractionPhrase(ratio) {
             if (!(ratio > 0)) return '';
@@ -256,8 +541,85 @@ document.addEventListener('DOMContentLoaded', function() {
             return 'less than a tenth of the project';
         }
 
-        var byAff = nodesFile.slice().sort(function(a, b) { return b.aff - a.aff || a.id.localeCompare(b.id); });
-        var byEff = nodesFile.slice().sort(function(a, b) { return b.eff - a.eff || a.id.localeCompare(b.id); });
+        // ---- Circular dependencies (Tarjan, iterative) -----------------------
+        function tarjanSCC(ids, outAdj) {
+            var index = 0, S = [], onStack = {}, idx = {}, low = {}, sccs = [];
+            ids.forEach(function(v0) {
+                if (idx[v0] !== undefined) return;
+                var stack = [{ v: v0, i: 0 }];
+                idx[v0] = low[v0] = index++; S.push(v0); onStack[v0] = true;
+                while (stack.length) {
+                    var fr = stack[stack.length - 1];
+                    var nbrs = outAdj[fr.v] || [];
+                    if (fr.i < nbrs.length) {
+                        var w = nbrs[fr.i++];
+                        if (idx[w] === undefined) {
+                            idx[w] = low[w] = index++; S.push(w); onStack[w] = true;
+                            stack.push({ v: w, i: 0 });
+                        } else if (onStack[w] && idx[w] < low[fr.v]) {
+                            low[fr.v] = idx[w];
+                        }
+                    } else {
+                        stack.pop();
+                        if (stack.length) {
+                            var p = stack[stack.length - 1].v;
+                            if (low[fr.v] < low[p]) low[p] = low[fr.v];
+                        }
+                        if (low[fr.v] === idx[fr.v]) {
+                            var comp = [], w2;
+                            do { w2 = S.pop(); onStack[w2] = false; comp.push(w2); } while (w2 !== fr.v);
+                            if (comp.length > 1) sccs.push(comp);
+                        }
+                    }
+                }
+            });
+            return sccs;
+        }
+
+        // Shortest loop through the first file of the group, for display
+        function representativeCycle(scc, outAdj) {
+            var start = scc[0];
+            var inScc = new Set(scc);
+            var prev = {};
+            var seen = new Set([start]);
+            var queue = [start];
+            while (queue.length) {
+                var v = queue.shift();
+                var nbrs = outAdj[v] || [];
+                for (var k = 0; k < nbrs.length; k++) {
+                    var w = nbrs[k];
+                    if (!inScc.has(w)) continue;
+                    if (w === start) {
+                        var path = [v], cur = v;
+                        while (cur !== start) { cur = prev[cur]; path.push(cur); }
+                        path.reverse();
+                        path.push(start);
+                        return path;
+                    }
+                    if (!seen.has(w)) { seen.add(w); prev[w] = v; queue.push(w); }
+                }
+            }
+            return scc.concat([scc[0]]);
+        }
+
+        var sccs = tarjanSCC(Object.keys(nodeMapFile), outAdjFile);
+        var sccIdByNode = {};
+        sccs.forEach(function(scc, i) {
+            scc.forEach(function(id) { sccIdByNode[id] = i; });
+        });
+        var cycles = sccs
+            .map(function(scc) { return { files: scc, path: representativeCycle(scc, outAdjFile) }; })
+            .sort(function(a, b) { return a.files.length - b.files.length; });
+        var filesInCycles = Object.keys(sccIdByNode).length;
+
+        document.getElementById('kpi-cycles').textContent = cycles.length;
+        if (cycles.length > 0) {
+            document.getElementById('dep-legend-cycle').classList.remove('hidden');
+        }
+
+        // ---- Verdict ---------------------------------------------------------
+        var byAff = linkedFiles.slice().sort(function(a, b) { return b.aff - a.aff || a.id.localeCompare(b.id); });
+        var byEff = linkedFiles.slice().sort(function(a, b) { return b.eff - a.eff || a.id.localeCompare(b.id); });
         var maxAff = byAff.length ? byAff[0].aff : 0;
         var maxEff = byEff.length ? byEff[0].eff : 0;
 
@@ -267,6 +629,7 @@ document.addEventListener('DOMContentLoaded', function() {
         var hotspots = byAff.filter(function(n) {
             return n.aff >= hotspotFloor && n.aff >= maxAff * 0.5;
         });
+        var hotspotIds = new Set(hotspots.map(function(n) { return n.id; }));
 
         var titleEl = document.getElementById('dep-verdict-title');
         var leadEl = document.getElementById('dep-verdict-lead');
@@ -275,8 +638,8 @@ document.addEventListener('DOMContentLoaded', function() {
         if (totalEdgesFile === 0) {
             titleHtml = 'Nothing links these files together.'
                 + '<br><span class="verdict-muted">No dependency to untangle.</span>';
-            leadHtml = totalFilesKPI > 0
-                ? 'AST Metrics found <strong>' + plural(totalFilesKPI, 'file') + '</strong> but no reference from one to another. Imports may be dynamic, or these files simply stand alone.'
+            leadHtml = nodesFile.length > 0
+                ? 'AST Metrics found <strong>' + plural(nodesFile.length, 'file') + '</strong> but no reference from one to another. Imports may be dynamic, or these files simply stand alone.'
                 : 'No dependency could be resolved from imports or class references.';
         } else if (totalFilesKPI <= 2) {
             titleHtml = 'Only ' + plural(totalFilesKPI, 'file') + ' take part in the graph.'
@@ -310,10 +673,46 @@ document.addEventListener('DOMContentLoaded', function() {
                 + (fracTop ? ': touching it moves ' + fracTop + '.' : '.');
         }
 
+        if (cycles.length > 0 && totalEdgesFile > 0) {
+            leadHtml += ' AST Metrics also found <strong>' + plural(cycles.length, 'circular chain')
+                + '</strong>, listed further down.';
+        }
+
         titleEl.innerHTML = titleHtml;
         leadEl.innerHTML = leadHtml;
 
-        // Severity by volume of coupling
+        // ---- Circular dependencies card --------------------------------------
+        (function renderCycles() {
+            var body = document.getElementById('dep-cycles-body');
+            if (!body) return;
+            if (cycles.length === 0) {
+                body.innerHTML = '<div class="insight insight--good"><span class="dot sev-good"></span>'
+                    + '<span>No file ends up depending on itself through others. Dependencies flow one way.</span></div>';
+                return;
+            }
+            var sev = (cycles.length >= 3 || filesInCycles >= 6) ? 'bad' : 'warn';
+            var html = '<div class="insight insight--' + sev + '"><span class="dot sev-' + sev + '"></span>'
+                + '<span><strong>' + plural(filesInCycles, 'file') + '</strong> are caught in '
+                + plural(cycles.length, 'circular chain')
+                + '. Breaking a single link in each chain frees the files it holds together.</span></div>';
+            var shown = cycles.slice(0, 8);
+            html += shown.map(function(c) {
+                var chips = c.path.map(function(id) {
+                    return '<a class="dep-chip" href="' + explorerUrl(id) + '" title="' + esc(resolve(id)) + '">'
+                        + esc(baseName(resolve(id))) + '</a>';
+                }).join('<span class="dep-cycle-arrow">&rarr;</span>');
+                var meta = c.files.length > 2
+                    ? '<span class="row-meta shrink-0 ml-auto">' + plural(c.files.length, 'file') + ' entangled</span>'
+                    : '';
+                return '<div class="dep-cycle-row">' + chips + meta + '</div>';
+            }).join('');
+            if (cycles.length > shown.length) {
+                html += '<p class="text-xs text-gray-500 mt-2">and ' + (cycles.length - shown.length) + ' more circular chains.</p>';
+            }
+            body.innerHTML = html;
+        })();
+
+        // ---- Coupling lists ---------------------------------------------------
         function sevOf(count) {
             if (count >= 15) return 'sev-bad';
             if (count >= 6) return 'sev-warn';
@@ -334,7 +733,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 var width = maxValue > 0 ? Math.max(4, Math.round(value / maxValue * 100)) : 0;
                 var sev = sevOf(value);
                 var folder = dirOf(full);
-                return '<a href="explorer{{ scopeSuffix }}.html?file=' + encodeURIComponent(n.id) + '" class="data-row" title="' + esc(full) + '">'
+                return '<a href="' + explorerUrl(n.id) + '" class="data-row" data-dep-node="' + esc(n.id) + '" title="' + esc(full) + '">'
                     + (withDot ? '<span class="dot ' + sev + '"></span>' : '')
                     + '<div class="min-w-0 flex-1">'
                     + '<div class="row-name truncate">' + esc(baseName(full)) + '</div>'
@@ -349,35 +748,72 @@ document.addEventListener('DOMContentLoaded', function() {
 
         renderCouplingList('dep-afferent-list', byAff, 'aff', maxAff, false);
         renderCouplingList('dep-efferent-list', byEff, 'eff', maxEff, true);
-        // ------------------------------------------------------------------
 
-        // State machine
-        var state = { mode: 'files', expandedFolder: null };
-        var useFolderView = (depFileCount > 1500 && folderDeps && folderDeps.folders && Object.keys(folderDeps.folders).length > 0);
-        if (useFolderView) state.mode = 'folders';
+        // ---- Isolated files strip ---------------------------------------------
+        (function renderIsolated() {
+            if (!isolatedFiles.length) return;
+            var det = document.getElementById('dep-isolated');
+            var summary = document.getElementById('dep-isolated-summary');
+            var chips = document.getElementById('dep-isolated-chips');
+            det.classList.remove('hidden');
+            summary.innerHTML = plural(isolatedFiles.length, 'file') + ' with no link at all, kept out of the drawing';
+            chips.innerHTML = isolatedFiles
+                .slice()
+                .sort(function(a, b) { return resolve(a.id).localeCompare(resolve(b.id)); })
+                .map(function(n) {
+                    return '<a class="dep-chip" href="' + explorerUrl(n.id) + '" title="' + esc(resolve(n.id)) + '">'
+                        + esc(baseName(resolve(n.id))) + '</a>';
+                }).join('');
+        })();
 
+        // =======================================================================
+        //  The graph itself
+        // =======================================================================
+        var shellEl = document.getElementById('dep-shell');
         var canvasEl = document.getElementById('dep-graph-canvas');
-        var wrapperEl = document.getElementById('dep-graph-wrapper');
+        var loadingEl = document.getElementById('dep-graph-loading');
         var tooltip = document.getElementById('dep-tooltip');
         var breadcrumb = document.getElementById('dep-breadcrumb');
         var breadcrumbRoot = document.getElementById('dep-breadcrumb-root');
         var breadcrumbCurrent = document.getElementById('dep-breadcrumb-current');
+        var searchInput = document.getElementById('dep-search-input');
+        var searchResults = document.getElementById('dep-search-results');
+        var panelEl = document.getElementById('dep-panel');
+
+        var hasFolderData = (folderDeps && folderDeps.folders && Object.keys(folderDeps.folders).length > 0);
+
+        // Reverse map: file hash -> folder hash, for cross-highlighting
+        var fileToFolder = {};
+        if (hasFolderData && folderDeps.filesByFolder) {
+            Object.keys(folderDeps.filesByFolder).forEach(function(dir) {
+                folderDeps.filesByFolder[dir].forEach(function(f) { fileToFolder[f] = dir; });
+            });
+        }
+
+        // Folders read better as soon as the file graph gets busy
+        var state = { mode: 'files', expandedFolder: null };
+        if (hasFolderData && totalFilesKPI > 60) state.mode = 'folders';
 
         var app = null;
         var worldContainer = null;
         var edgesGfx = null;
-        var activeSimulation = null;
+        var ringGfx = null;
         var scale = 1, panX = 0, panY = 0;
-        var isPanning = false, panStartX = 0, panStartY = 0, panStartPX = 0, panStartPY = 0;
+        var isPanning = false, panMoved = false, panStartX = 0, panStartY = 0, panStartPX = 0, panStartPY = 0;
         var currentNodes = null;
         var currentLinks = null;
+        var currentKind = 'files';
         var currentW = 0, currentH = 0;
+        var layoutGen = 0;
+        var selectedNode = null;
+        var focusState = null;
+        var viewAnimRAF = null;
+        var labelRAF = null;
 
         function hexToPixi(hex) {
             if (typeof hex === 'string' && hex.charAt(0) === '#') {
                 return parseInt(hex.substring(1), 16);
             }
-            // Fallback for rgb(...) or other formats via d3
             if (window.d3) {
                 var c = d3.color(hex);
                 if (c) return ((Math.round(c.r) & 0xff) << 16) | ((Math.round(c.g) & 0xff) << 8) | (Math.round(c.b) & 0xff);
@@ -396,7 +832,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         function shortLabel(p, max) {
-            max = max || 20;
+            max = max || 22;
             var parts = p.split('/');
             var name = parts[parts.length - 1];
             if (!name) name = parts[parts.length - 2] || p;
@@ -405,41 +841,49 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         function shortFolderLabel(p, max) {
-            max = max || 25;
+            max = max || 28;
             var parts = p.split('/').filter(Boolean);
             var name = parts.length > 2 ? '…/' + parts.slice(-2).join('/') : p;
             if (name.length > max) name = name.substring(0, max - 1) + '…';
             return name;
         }
 
+        function applyTransform() {
+            if (!worldContainer) return;
+            worldContainer.scale.set(scale);
+            worldContainer.position.set(panX, panY);
+        }
+
+        function scheduleLabels() {
+            if (labelRAF) return;
+            labelRAF = requestAnimationFrame(function() {
+                labelRAF = null;
+                updateLabels();
+            });
+        }
+
+        // ---- Pixi lifecycle ---------------------------------------------------
         function initPixiApp() {
-            if (activeSimulation) {
-                activeSimulation.stop();
-                activeSimulation = null;
-            }
             if (app) {
                 app.destroy(true, { children: true, texture: true, baseTexture: true });
+                app = null;
+                worldContainer = null;
+                edgesGfx = null;
+                ringGfx = null;
             }
-            var w = canvasEl.clientWidth || 800;
-            var h = Math.max(600, Math.min(Object.keys(deps).length * 8, 1200));
-            canvasEl.style.height = h + 'px';
+            var w = shellEl.clientWidth || 800;
+            var h = shellEl.clientHeight || 600;
 
             app = new PIXI.Application({
                 width: w,
                 height: h,
-                backgroundColor: 0xffffff,
+                backgroundAlpha: 0,
                 antialias: true,
                 resolution: window.devicePixelRatio || 1,
                 autoDensity: true,
             });
             canvasEl.innerHTML = '';
             canvasEl.appendChild(app.view);
-            app.view.style.width = '100%';
-            app.view.style.height = '100%';
-
-            // Hide loading skeleton
-            var loadingEl = document.getElementById('dep-graph-loading');
-            if (loadingEl) loadingEl.style.display = 'none';
 
             worldContainer = new PIXI.Container();
             app.stage.addChild(worldContainer);
@@ -447,54 +891,90 @@ document.addEventListener('DOMContentLoaded', function() {
             edgesGfx = new PIXI.Graphics();
             worldContainer.addChild(edgesGfx);
 
+            ringGfx = new PIXI.Graphics();
+
             scale = 1; panX = 0; panY = 0;
             currentW = w; currentH = h;
-
-            // Zoom
-            canvasEl.addEventListener('wheel', function(e) {
-                e.preventDefault();
-                var rect = canvasEl.getBoundingClientRect();
-                var mouseX = e.clientX - rect.left;
-                var mouseY = e.clientY - rect.top;
-                var zoomFactor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
-                var newScale = Math.min(8, Math.max(0.1, scale * zoomFactor));
-                panX = mouseX - (mouseX - panX) * (newScale / scale);
-                panY = mouseY - (mouseY - panY) * (newScale / scale);
-                scale = newScale;
-                worldContainer.scale.set(scale);
-                worldContainer.position.set(panX, panY);
-            }, { passive: false });
-
-            canvasEl.addEventListener('pointerdown', function(e) {
-                if (e.target === app.view || e.target === canvasEl) {
-                    isPanning = true;
-                    panStartX = e.clientX;
-                    panStartY = e.clientY;
-                    panStartPX = panX;
-                    panStartPY = panY;
-                    canvasEl.style.cursor = 'grabbing';
-                }
-            });
-            window.addEventListener('pointermove', function(e) {
-                if (!isPanning) return;
-                panX = panStartPX + (e.clientX - panStartX);
-                panY = panStartPY + (e.clientY - panStartY);
-                worldContainer.position.set(panX, panY);
-            });
-            window.addEventListener('pointerup', function() {
-                isPanning = false;
-                canvasEl.style.cursor = 'grab';
-            });
-
             return { w: w, h: h };
         }
 
-        function fitToView(nodes, W, H) {
-            if (!nodes.length) return;
+        // Pan and zoom listeners live on the shell, attached once: the canvas
+        // element inside is destroyed and recreated on every render.
+        shellEl.addEventListener('wheel', function(e) {
+            if (!worldContainer) return;
+            if (e.target.tagName !== 'CANVAS') return;
+            e.preventDefault();
+            var rect = canvasEl.getBoundingClientRect();
+            var mouseX = e.clientX - rect.left;
+            var mouseY = e.clientY - rect.top;
+            var zoomFactor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
+            var newScale = Math.min(8, Math.max(0.1, scale * zoomFactor));
+            panX = mouseX - (mouseX - panX) * (newScale / scale);
+            panY = mouseY - (mouseY - panY) * (newScale / scale);
+            scale = newScale;
+            applyTransform();
+            scheduleLabels();
+        }, { passive: false });
+
+        shellEl.addEventListener('pointerdown', function(e) {
+            if (!worldContainer) return;
+            if (e.target.tagName !== 'CANVAS') return;
+            isPanning = true;
+            panMoved = false;
+            panStartX = e.clientX;
+            panStartY = e.clientY;
+            panStartPX = panX;
+            panStartPY = panY;
+            canvasEl.classList.add('dragging');
+        });
+        window.addEventListener('pointermove', function(e) {
+            if (!isPanning) return;
+            var dx = e.clientX - panStartX;
+            var dy = e.clientY - panStartY;
+            if (Math.abs(dx) + Math.abs(dy) > 4) panMoved = true;
+            panX = panStartPX + dx;
+            panY = panStartPY + dy;
+            applyTransform();
+        });
+        window.addEventListener('pointerup', function(e) {
+            if (!isPanning) return;
+            isPanning = false;
+            canvasEl.classList.remove('dragging');
+            scheduleLabels();
+            // A motionless click on the background clears the selection
+            if (!panMoved && e.target.tagName === 'CANVAS') deselectNode();
+        });
+
+        // ---- View animation (zoom buttons, fit, focus on search) --------------
+        function animateView(targetScale, targetX, targetY, duration) {
+            if (viewAnimRAF) cancelAnimationFrame(viewAnimRAF);
+            var s0 = scale, x0 = panX, y0 = panY;
+            var start = null;
+            duration = duration || 260;
+            function step(ts) {
+                if (start === null) start = ts;
+                var t = Math.min(1, (ts - start) / duration);
+                var ease = 1 - Math.pow(1 - t, 3);
+                scale = s0 + (targetScale - s0) * ease;
+                panX = x0 + (targetX - x0) * ease;
+                panY = y0 + (targetY - y0) * ease;
+                applyTransform();
+                if (t < 1) {
+                    viewAnimRAF = requestAnimationFrame(step);
+                } else {
+                    viewAnimRAF = null;
+                    scheduleLabels();
+                }
+            }
+            viewAnimRAF = requestAnimationFrame(step);
+        }
+
+        function fitTransform(nodes, W, H) {
+            if (!nodes || !nodes.length) return null;
             var pad = 40;
             var x0 = Infinity, y0 = Infinity, x1 = -Infinity, y1 = -Infinity;
             nodes.forEach(function(d) {
-                var rr = (d._radius || 8) + 15;
+                var rr = (d._radius || 8) + 18;
                 if (d.x - rr < x0) x0 = d.x - rr;
                 if (d.y - rr < y0) y0 = d.y - rr;
                 if (d.x + rr > x1) x1 = d.x + rr;
@@ -502,92 +982,365 @@ document.addEventListener('DOMContentLoaded', function() {
             });
             x0 -= pad; y0 -= pad; x1 += pad; y1 += pad;
             var bw = x1 - x0, bh = y1 - y0;
-            if (bw <= 0 || bh <= 0) return;
-            var newScale = Math.min(W / bw, H / bh, 1.5);
-            var tx = W / 2 - newScale * (x0 + bw / 2);
-            var ty = H / 2 - newScale * (y0 + bh / 2);
-            scale = newScale;
-            panX = tx;
-            panY = ty;
-            worldContainer.scale.set(scale);
-            worldContainer.position.set(panX, panY);
+            if (bw <= 0 || bh <= 0) return null;
+            var s = Math.min(W / bw, H / bh, 1.6);
+            return {
+                scale: s,
+                x: W / 2 - s * (x0 + bw / 2),
+                y: H / 2 - s * (y0 + bh / 2)
+            };
         }
 
-        function drawEdges(links) {
+        function fitToView(animated) {
+            var t = fitTransform(currentNodes, currentW, currentH);
+            if (!t) return;
+            if (animated) {
+                animateView(t.scale, t.x, t.y);
+            } else {
+                scale = t.scale; panX = t.x; panY = t.y;
+                applyTransform();
+                scheduleLabels();
+            }
+        }
+
+        function zoomBy(factor) {
+            var newScale = Math.min(8, Math.max(0.1, scale * factor));
+            var cx = currentW / 2, cy = currentH / 2;
+            animateView(newScale, cx - (cx - panX) * (newScale / scale), cy - (cy - panY) * (newScale / scale), 180);
+        }
+
+        function focusOnNode(d) {
+            var target = Math.max(scale, 1.6);
+            animateView(target, currentW / 2 - target * d.x, currentH / 2 - target * d.y, 320);
+        }
+
+        // ---- Edges: gentle curves with arrowheads ------------------------------
+        function drawCurvedEdge(l, width, color, alpha) {
+            var sx = l.source.x, sy = l.source.y;
+            var tx = l.target.x, ty = l.target.y;
+            var dx = tx - sx, dy = ty - sy;
+            var len = Math.sqrt(dx * dx + dy * dy);
+            if (len < 1) return;
+            var ux = dx / len, uy = dy / len;
+            // Trim at node borders
+            var sr = (l.source._radius || 8) + 1;
+            var tr = (l.target._radius || 8) + 3;
+            var ax = sx + ux * sr, ay = sy + uy * sr;
+            var bx = tx - ux * tr, by = ty - uy * tr;
+            // Control point: midpoint pushed perpendicularly, for a soft bow
+            var bow = Math.min(26, len * 0.12);
+            var cx = (ax + bx) / 2 - uy * bow;
+            var cy = (ay + by) / 2 + ux * bow;
+
+            edgesGfx.lineStyle(width, color, alpha);
+            edgesGfx.moveTo(ax, ay);
+            edgesGfx.quadraticCurveTo(cx, cy, bx, by);
+
+            // Arrowhead along the curve tangent at the target
+            var tdx = bx - cx, tdy = by - cy;
+            var tlen = Math.sqrt(tdx * tdx + tdy * tdy) || 1;
+            tdx /= tlen; tdy /= tlen;
+            var arrow = Math.max(4, Math.min(7, width * 3.2));
+            var px = -tdy * arrow * 0.6, py = tdx * arrow * 0.6;
+            edgesGfx.lineStyle(0);
+            edgesGfx.beginFill(color, Math.min(1, alpha + 0.15));
+            edgesGfx.moveTo(bx, by);
+            edgesGfx.lineTo(bx - tdx * arrow + px, by - tdy * arrow + py);
+            edgesGfx.lineTo(bx - tdx * arrow - px, by - tdy * arrow - py);
+            edgesGfx.closePath();
+            edgesGfx.endFill();
+        }
+
+        var COLOR_EDGE = 0x94a3b8;
+        var COLOR_CYCLE = 0xd97706;
+        var COLOR_OUT = 0x0d9488;
+        var COLOR_IN = 0x7c3aed;
+
+        function drawEdges() {
+            if (!edgesGfx || !currentLinks) return;
             edgesGfx.clear();
-            links.forEach(function(l) {
-                var sx = l.source.x || 0, sy = l.source.y || 0;
-                var tx = l.target.x || 0, ty = l.target.y || 0;
-                edgesGfx.lineStyle(1.2, 0x94a3b8, 0.5);
-                edgesGfx.moveTo(sx, sy);
-                edgesGfx.lineTo(tx, ty);
-
-                // Arrow
-                var dx = tx - sx, dy = ty - sy;
-                var len = Math.sqrt(dx*dx + dy*dy);
-                if (len < 1) return;
-                var targetR = (l.target._radius || 8) + 2;
-                var ux = dx / len, uy = dy / len;
-                var ax = tx - ux * targetR, ay = ty - uy * targetR;
-                var arrowSize = 5;
-                var px = -uy * arrowSize, py = ux * arrowSize;
-                edgesGfx.beginFill(0x94a3b8, 0.6);
-                edgesGfx.moveTo(ax, ay);
-                edgesGfx.lineTo(ax - ux * arrowSize + px, ay - uy * arrowSize + py);
-                edgesGfx.lineTo(ax - ux * arrowSize - px, ay - uy * arrowSize - py);
-                edgesGfx.closePath();
-                edgesGfx.endFill();
+            var baseAlpha = currentKind === 'folders' ? 0.4 : 0.3;
+            currentLinks.forEach(function(l) {
+                var w = l._w || 1;
+                if (focusState) {
+                    var sid = l.source.id, tid = l.target.id;
+                    if (sid === focusState.id) {
+                        drawCurvedEdge(l, Math.max(w, 1.8), COLOR_OUT, 0.9);
+                    } else if (tid === focusState.id) {
+                        drawCurvedEdge(l, Math.max(w, 1.8), COLOR_IN, 0.9);
+                    } else if (focusState.set.has(sid) && focusState.set.has(tid)) {
+                        drawCurvedEdge(l, w, COLOR_EDGE, 0.12);
+                    } else {
+                        drawCurvedEdge(l, w, COLOR_EDGE, 0.03);
+                    }
+                } else if (l.inCycle) {
+                    drawCurvedEdge(l, Math.max(w, 1.5), COLOR_CYCLE, 0.6);
+                } else {
+                    drawCurvedEdge(l, w, COLOR_EDGE, baseAlpha);
+                }
             });
         }
 
-        // Build adjacency for chain highlight
-        function buildAdjacency(links) {
-            var outgoing = {}, incoming = {};
-            links.forEach(function(l) {
-                var sid = l.source.id || l.source;
-                var tid = l.target.id || l.target;
-                if (!outgoing[sid]) outgoing[sid] = new Set();
-                outgoing[sid].add(tid);
-                if (!incoming[tid]) incoming[tid] = new Set();
-                incoming[tid].add(sid);
+        // ---- Labels: hubs always, the rest appears as you zoom in --------------
+        var MAX_LABELS = 250;
+        var LABEL_SCALE = 1.25;
+
+        function markHubs(nodes) {
+            var showAll = nodes.length <= 45;
+            var sorted = nodes.slice().sort(function(a, b) { return (b.eff + b.aff) - (a.eff + a.aff); });
+            var cut = new Set(sorted.slice(0, 14).map(function(n) { return n.id; }));
+            nodes.forEach(function(n) {
+                n._isHub = showAll || cut.has(n.id) || hotspotIds.has(n.id);
             });
-            return { outgoing: outgoing, incoming: incoming };
         }
 
-        function getChain(startId, adj) {
-            var visited = new Set([startId]);
-            var queue = [startId];
-            while (queue.length > 0) {
-                var cur = queue.shift();
-                if (adj.outgoing[cur]) {
-                    for (var nb of adj.outgoing[cur]) {
-                        if (!visited.has(nb)) { visited.add(nb); queue.push(nb); }
-                    }
-                }
-            }
-            queue = [startId];
-            while (queue.length > 0) {
-                var cur = queue.shift();
-                if (adj.incoming[cur]) {
-                    for (var nb of adj.incoming[cur]) {
-                        if (!visited.has(nb)) { visited.add(nb); queue.push(nb); }
-                    }
-                }
-            }
-            return visited;
+        function ensureLabel(d) {
+            if (d._label) return d._label;
+            var text = d._kind === 'folders' ? shortFolderLabel(resolve(d.id)) : shortLabel(resolve(d.id));
+            var lbl = new PIXI.Text(text, {
+                fontSize: 11,
+                fill: '#334155',
+                fontFamily: 'system-ui, -apple-system, sans-serif',
+                stroke: '#ffffff',
+                strokeThickness: 3,
+            });
+            lbl.anchor.set(0.5, 0);
+            lbl.y = d._radius + 4;
+            lbl.visible = false;
+            d._sprite.addChild(lbl);
+            d._label = lbl;
+            return lbl;
         }
 
-        // ---- Render file view ----
-        function renderFileView(filterFolder) {
-            var dim = initPixiApp();
-            var W = dim.w, H = dim.h;
+        function updateLabels() {
+            if (!currentNodes) return;
+            var count = 0;
+            var zoomedIn = scale >= LABEL_SCALE;
+            currentNodes.forEach(function(d) {
+                if (!d._sprite) return;
+                var show = false;
+                if (focusState) {
+                    show = focusState.set.has(d.id);
+                } else if (d._isHub) {
+                    show = true;
+                } else if (zoomedIn) {
+                    var sx = d.x * scale + panX, sy = d.y * scale + panY;
+                    show = sx > -60 && sy > -60 && sx < currentW + 60 && sy < currentH + 60;
+                }
+                if (show && count < MAX_LABELS) {
+                    ensureLabel(d).visible = true;
+                    count++;
+                } else if (d._label) {
+                    d._label.visible = false;
+                }
+            });
+        }
 
-            var nodes = [];
-            var links = [];
-            var nodeMap = {};
+        // ---- Focus, selection, panel -------------------------------------------
+        function neighborsOf(d) {
+            var set = new Set([d.id]);
+            currentLinks.forEach(function(l) {
+                if (l.source.id === d.id) set.add(l.target.id);
+                if (l.target.id === d.id) set.add(l.source.id);
+            });
+            return set;
+        }
+
+        function applyFocus(d) {
+            if (!currentNodes || !currentLinks) return;
+            focusState = { id: d.id, set: neighborsOf(d) };
+            currentNodes.forEach(function(n) {
+                if (n._sprite) n._sprite.alpha = focusState.set.has(n.id) ? 1 : 0.12;
+            });
+            drawEdges();
+            updateLabels();
+        }
+
+        function clearFocus() {
+            if (selectedNode) { applyFocus(selectedNode); return; }
+            focusState = null;
+            if (currentNodes) currentNodes.forEach(function(n) { if (n._sprite) n._sprite.alpha = 1; });
+            drawEdges();
+            scheduleLabels();
+        }
+
+        function drawSelectionRing() {
+            if (!ringGfx) return;
+            ringGfx.clear();
+            if (!selectedNode) return;
+            ringGfx.lineStyle(2, 0x3b82f6, 0.9);
+            ringGfx.drawCircle(selectedNode.x, selectedNode.y, (selectedNode._radius || 8) + 5);
+        }
+
+        function panelList(containerId, titleId, titleText, ids) {
+            document.getElementById(titleId).textContent = titleText + ' (' + ids.length + ')';
+            var el = document.getElementById(containerId);
+            if (!ids.length) {
+                el.innerHTML = '<p class="text-xs text-gray-500 py-1">None.</p>';
+                return;
+            }
+            el.innerHTML = ids.map(function(id) {
+                return '<a data-dep-goto="' + esc(id) + '" title="' + esc(resolve(id)) + '">' + esc(baseName(resolve(id))) + '</a>';
+            }).join('');
+        }
+
+        function openPanel(d) {
+            var full = resolve(d.id);
+            document.getElementById('dep-panel-name').textContent = baseName(full);
+            document.getElementById('dep-panel-meta').textContent = dirOf(full) || ' ';
+            var entry = deps[d.id] || {};
+            var uses = (entry.efferent || []).map(function(x) { return x.path; });
+            var usedBy = (entry.afferent || []).map(function(x) { return x.path; });
+            panelList('dep-panel-uses', 'dep-panel-uses-title', 'Uses', uses);
+            panelList('dep-panel-usedby', 'dep-panel-usedby-title', 'Used by', usedBy);
+            document.getElementById('dep-panel-open').setAttribute('href', explorerUrl(d.id));
+            panelEl.classList.add('open');
+        }
+
+        function closePanel() {
+            panelEl.classList.remove('open');
+        }
+
+        function selectNode(d) {
+            selectedNode = d;
+            applyFocus(d);
+            drawSelectionRing();
+            openPanel(d);
+        }
+
+        function deselectNode() {
+            if (!selectedNode && !focusState) return;
+            selectedNode = null;
+            if (ringGfx) ringGfx.clear();
+            closePanel();
+            focusState = null;
+            if (currentNodes) currentNodes.forEach(function(n) { if (n._sprite) n._sprite.alpha = 1; });
+            drawEdges();
+            scheduleLabels();
+        }
+
+        // Clicking a name inside the panel moves the selection there
+        panelEl.addEventListener('click', function(e) {
+            var a = e.target.closest('a[data-dep-goto]');
+            if (!a) return;
+            e.preventDefault();
+            var id = a.getAttribute('data-dep-goto');
+            var node = currentNodes && currentNodes.find(function(n) { return n.id === id; });
+            if (node) {
+                selectNode(node);
+                focusOnNode(node);
+            } else {
+                window.location.href = explorerUrl(id);
+            }
+        });
+        document.getElementById('dep-panel-close').addEventListener('click', deselectNode);
+
+        document.addEventListener('keydown', function(e) {
+            if (e.key !== 'Escape') return;
+            searchResults.classList.remove('open');
+            deselectNode();
+        });
+
+        // ---- Tooltip ------------------------------------------------------------
+        function moveTooltip(ev) {
+            var gp = ev.global || (ev.data && ev.data.global);
+            if (!gp || !app) return;
+            var rect = app.view.getBoundingClientRect();
+            tooltip.style.left = (rect.left + gp.x + 14) + 'px';
+            tooltip.style.top = (rect.top + gp.y - 10) + 'px';
+        }
+
+        // ---- Layout: simulate off-screen, then pack the islands ------------------
+        function runLayout(nodes, links, kind, onDone) {
+            var gen = ++layoutGen;
+            var sim = d3.forceSimulation(nodes)
+                .force('link', d3.forceLink(links).id(function(d) { return d.id; })
+                    .distance(kind === 'folders' ? 110 : 60))
+                .force('charge', d3.forceManyBody().strength(kind === 'folders' ? -350 : -180))
+                .force('x', d3.forceX(0).strength(0.06))
+                .force('y', d3.forceY(0).strength(0.08))
+                .force('collision', d3.forceCollide().radius(function(d) { return d._radius + (kind === 'folders' ? 14 : 7); }))
+                .stop();
+
+            var maxTicks = Math.min(400, 120 + nodes.length);
+            var done = 0;
+            function chunk() {
+                if (gen !== layoutGen) return; // a newer render started
+                var start = performance.now();
+                while (done < maxTicks && sim.alpha() > 0.005 && performance.now() - start < 12) {
+                    sim.tick();
+                    done++;
+                }
+                if (done < maxTicks && sim.alpha() > 0.005) {
+                    requestAnimationFrame(chunk);
+                } else {
+                    packComponents(nodes, links);
+                    onDone();
+                }
+            }
+            requestAnimationFrame(chunk);
+        }
+
+        // Disconnected islands drift apart under repulsion; re-arrange their
+        // bounding boxes on shelves so the drawing has no dead space.
+        function packComponents(nodes, links) {
+            var parent = {};
+            function find(x) {
+                while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; }
+                return x;
+            }
+            nodes.forEach(function(n) { parent[n.id] = n.id; });
+            links.forEach(function(l) {
+                var a = find(l.source.id), b = find(l.target.id);
+                if (a !== b) parent[a] = b;
+            });
+
+            var comps = {};
+            nodes.forEach(function(n) {
+                var root = find(n.id);
+                if (!comps[root]) comps[root] = { nodes: [], x0: Infinity, y0: Infinity, x1: -Infinity, y1: -Infinity };
+                var c = comps[root];
+                c.nodes.push(n);
+                var pad = n._radius + 20;
+                if (n.x - pad < c.x0) c.x0 = n.x - pad;
+                if (n.y - pad < c.y0) c.y0 = n.y - pad;
+                if (n.x + pad > c.x1) c.x1 = n.x + pad;
+                if (n.y + pad > c.y1) c.y1 = n.y + pad;
+            });
+
+            var list = Object.values(comps);
+            if (list.length <= 1) return;
+            list.forEach(function(c) {
+                c.w = c.x1 - c.x0;
+                c.h = c.y1 - c.y0;
+            });
+            list.sort(function(a, b) { return b.w * b.h - a.w * a.h; });
+
+            var totalArea = list.reduce(function(s, c) { return s + c.w * c.h; }, 0);
+            var aspect = currentW > 0 && currentH > 0 ? currentW / currentH : 1.6;
+            var rowLimit = Math.max(list[0].w, Math.sqrt(totalArea * aspect) * 1.15);
+            var gap = 48;
+            var cx = 0, cy = 0, rowH = 0;
+
+            list.forEach(function(c) {
+                if (cx > 0 && cx + c.w > rowLimit) {
+                    cx = 0;
+                    cy += rowH + gap;
+                    rowH = 0;
+                }
+                var dx = cx - c.x0, dy = cy - c.y0;
+                c.nodes.forEach(function(n) { n.x += dx; n.y += dy; });
+                cx += c.w + gap;
+                if (c.h > rowH) rowH = c.h;
+            });
+        }
+
+        // ---- Building the two views ----------------------------------------------
+        function prepareFileGraph(filterFolder) {
+            var nodes = [], links = [], nodeMap = {};
 
             if (filterFolder && folderDeps && folderDeps.filesByFolder) {
-                // Drill-down: show files in this folder + connected files
+                // Drill-down: files of this folder plus their direct neighbours
                 var folderFiles = new Set(folderDeps.filesByFolder[filterFolder] || []);
                 var connectedFiles = new Set();
                 folderFiles.forEach(function(fp) {
@@ -596,18 +1349,16 @@ document.addEventListener('DOMContentLoaded', function() {
                     if (entry.efferent) entry.efferent.forEach(function(d) { connectedFiles.add(d.path); });
                     if (entry.afferent) entry.afferent.forEach(function(d) { connectedFiles.add(d.path); });
                 });
-
-                var relevantFiles = new Set([...folderFiles, ...connectedFiles]);
-                relevantFiles.forEach(function(fp) {
+                var relevant = new Set([...folderFiles, ...connectedFiles]);
+                relevant.forEach(function(fp) {
                     nodeMap[fp] = { id: fp, eff: 0, aff: 0, inFolder: folderFiles.has(fp) };
                 });
-
                 fileKeys.forEach(function(fp) {
-                    if (!relevantFiles.has(fp)) return;
+                    if (!relevant.has(fp)) return;
                     var entry = deps[fp];
                     if (entry.efferent) {
                         entry.efferent.forEach(function(d) {
-                            if (relevantFiles.has(d.path)) {
+                            if (relevant.has(d.path)) {
                                 nodeMap[fp].eff++;
                                 if (nodeMap[d.path]) nodeMap[d.path].aff++;
                                 links.push({ source: fp, target: d.path });
@@ -617,314 +1368,307 @@ document.addEventListener('DOMContentLoaded', function() {
                 });
                 nodes = Object.values(nodeMap);
             } else {
-                // Full file view
+                // Full view: files that stand alone are listed below the graph instead
+                linkedFiles.forEach(function(n) {
+                    nodeMap[n.id] = { id: n.id, eff: n.eff, aff: n.aff, inFolder: true };
+                });
                 fileKeys.forEach(function(fp) {
-                    if (!nodeMap[fp]) nodeMap[fp] = { id: fp, eff: 0, aff: 0, inFolder: true };
+                    if (!nodeMap[fp]) return;
                     var entry = deps[fp];
                     if (entry.efferent) {
                         entry.efferent.forEach(function(d) {
-                            if (!nodeMap[d.path]) nodeMap[d.path] = { id: d.path, eff: 0, aff: 0, inFolder: true };
-                            nodeMap[fp].eff++;
-                            nodeMap[d.path].aff++;
-                            links.push({ source: fp, target: d.path });
+                            if (nodeMap[d.path]) links.push({ source: fp, target: d.path });
                         });
                     }
                 });
                 nodes = Object.values(nodeMap);
             }
 
-            if (!nodes.length) return;
-
-            var adj = buildAdjacency(links);
-
-            // Node radius
+            links.forEach(function(l) {
+                var sid = typeof l.source === 'string' ? l.source : l.source.id;
+                var tid = typeof l.target === 'string' ? l.target : l.target.id;
+                l.inCycle = sccIdByNode[sid] !== undefined && sccIdByNode[sid] === sccIdByNode[tid];
+                l._w = 1;
+            });
             nodes.forEach(function(n) {
                 n._radius = Math.min(4 + Math.sqrt(n.eff + n.aff) * 3, 24);
+                n._kind = 'files';
             });
-
-            // Create sprites
-            var nodesContainer = new PIXI.Container();
-            worldContainer.addChild(nodesContainer);
-
-            nodes.forEach(function(d) {
-                var nc = new PIXI.Container();
-                nc.eventMode = 'static';
-                nc.cursor = 'pointer';
-
-                var color = nodeColor(d.eff, d.aff);
-                var gfx = new PIXI.Graphics();
-                gfx.beginFill(hexToPixi(color), d.inFolder !== false ? 0.85 : 0.4);
-                gfx.drawCircle(0, 0, d._radius);
-                gfx.endFill();
-                gfx.lineStyle(1.5, 0xffffff, 1);
-                gfx.drawCircle(0, 0, d._radius);
-                nc.addChild(gfx);
-
-                // Label
-                var lbl = new PIXI.Text(shortLabel(resolve(d.id)), {
-                    fontSize: 10,
-                    fill: '#334155',
-                    fontFamily: 'system-ui, -apple-system, sans-serif',
-                });
-                lbl.anchor.set(0.5, 0);
-                lbl.y = d._radius + 3;
-                nc.addChild(lbl);
-
-                nc.hitArea = new PIXI.Circle(0, 0, d._radius + 4);
-                d._sprite = nc;
-                d._gfx = gfx;
-                d._label = lbl;
-                d._color = color;
-
-                nc.on('pointerover', function(ev) {
-                    tooltip.innerHTML = '<strong>' + resolve(d.id) + '</strong><br>Uses ' + d.eff + ' &middot; Used by ' + d.aff;
-                    tooltip.classList.add('visible');
-                    var gp = ev.global || ev.data.global;
-                    tooltip.style.left = gp.x + 'px';
-                    tooltip.style.top = (gp.y - 12) + 'px';
-
-                    // Chain highlight
-                    var chain = getChain(d.id, adj);
-                    nodes.forEach(function(n) {
-                        n._sprite.alpha = chain.has(n.id) ? 1 : 0.08;
-                    });
-                    // Redraw edges with highlight
-                    edgesGfx.clear();
-                    links.forEach(function(l) {
-                        var sid = l.source.id || l.source;
-                        var tid = l.target.id || l.target;
-                        var inChain = chain.has(sid) && chain.has(tid);
-                        var sx = l.source.x || 0, sy = l.source.y || 0;
-                        var tx = l.target.x || 0, ty = l.target.y || 0;
-                        edgesGfx.lineStyle(inChain ? 2 : 0.5, inChain ? 0x3b82f6 : 0x94a3b8, inChain ? 0.85 : 0.02);
-                        edgesGfx.moveTo(sx, sy);
-                        edgesGfx.lineTo(tx, ty);
-                    });
-                });
-
-                nc.on('pointermove', function(ev) {
-                    var gp = ev.global || ev.data.global;
-                    tooltip.style.left = gp.x + 'px';
-                    tooltip.style.top = (gp.y - 12) + 'px';
-                });
-
-                nc.on('pointerout', function() {
-                    tooltip.classList.remove('visible');
-                    nodes.forEach(function(n) { n._sprite.alpha = 1; });
-                    drawEdges(links);
-                });
-
-                nc.on('pointertap', function() {
-                    window.location.href = 'explorer{{ scopeSuffix }}.html?file=' + encodeURIComponent(d.id);
-                });
-
-                nodesContainer.addChild(nc);
-            });
-
-            // Force simulation
-            activeSimulation = d3.forceSimulation(nodes)
-                .force('link', d3.forceLink(links).id(function(d) { return d.id; }).distance(80))
-                .force('charge', d3.forceManyBody().strength(-200))
-                .force('center', d3.forceCenter(W / 2, H / 2))
-                .force('collision', d3.forceCollide().radius(function(d) { return d._radius + 8; }))
-                .on('tick', function() {
-                    nodes.forEach(function(d) {
-                        d._sprite.x = d.x;
-                        d._sprite.y = d.y;
-                    });
-                    drawEdges(links);
-                })
-                .on('end', function() {
-                    currentNodes = nodes;
-                    currentLinks = links;
-                    fitToView(nodes, W, H);
-                });
+            return { nodes: nodes, links: links };
         }
 
-        // ---- Render folder view ----
-        function renderFolderView() {
-            if (!folderDeps || !folderDeps.folders) return;
-
-            var dim = initPixiApp();
-            var W = dim.w, H = dim.h;
-
+        function prepareFolderGraph() {
             var folders = folderDeps.folders;
-            var folderKeys = Object.keys(folders);
-            var nodes = [];
-            var links = [];
-            var nodeMap = {};
-
-            folderKeys.forEach(function(dir) {
+            var nodes = [], links = [], nodeMap = {};
+            Object.keys(folders).forEach(function(dir) {
                 var f = folders[dir];
                 var effCount = 0, affCount = 0;
                 if (f.efferent) f.efferent.forEach(function(e) { effCount += e.count; });
                 if (f.afferent) f.afferent.forEach(function(e) { affCount += e.count; });
                 nodeMap[dir] = { id: dir, eff: effCount, aff: affCount, fileCount: f.fileCount || 1 };
             });
-
-            // Build links
-            folderKeys.forEach(function(dir) {
+            Object.keys(folders).forEach(function(dir) {
                 var f = folders[dir];
                 if (f.efferent) {
                     f.efferent.forEach(function(e) {
-                        if (nodeMap[e.path]) {
-                            links.push({ source: dir, target: e.path, count: e.count });
-                        }
+                        if (nodeMap[e.path]) links.push({ source: dir, target: e.path, count: e.count });
                     });
                 }
             });
-
             nodes = Object.values(nodeMap);
-            if (!nodes.length) { renderFileView(null); return; }
-
-            var adj = buildAdjacency(links);
-
-            // Radius proportional to fileCount
             var maxFC = d3.max(nodes, function(d) { return d.fileCount; }) || 1;
             nodes.forEach(function(d) {
-                d._radius = Math.max(6, Math.min(4 + Math.sqrt(d.fileCount / maxFC) * 30, 40));
+                d._radius = Math.max(8, Math.min(6 + Math.sqrt(d.fileCount / maxFC) * 30, 40));
+                d._kind = 'folders';
             });
-
-            var nodesContainer = new PIXI.Container();
-            worldContainer.addChild(nodesContainer);
-
-            nodes.forEach(function(d) {
-                var nc = new PIXI.Container();
-                nc.eventMode = 'static';
-                nc.cursor = 'pointer';
-
-                var color = nodeColor(d.eff, d.aff);
-                var gfx = new PIXI.Graphics();
-                gfx.beginFill(hexToPixi(color), 0.8);
-                gfx.drawCircle(0, 0, d._radius);
-                gfx.endFill();
-                gfx.lineStyle(1.5, 0xffffff, 1);
-                gfx.drawCircle(0, 0, d._radius);
-                nc.addChild(gfx);
-
-                var lbl = new PIXI.Text(shortFolderLabel(resolve(d.id)), {
-                    fontSize: 10,
-                    fill: '#334155',
-                    fontFamily: 'system-ui, -apple-system, sans-serif',
-                });
-                lbl.anchor.set(0.5, 0);
-                lbl.y = d._radius + 3;
-                nc.addChild(lbl);
-
-                nc.hitArea = new PIXI.Circle(0, 0, d._radius + 4);
-                d._sprite = nc;
-                d._gfx = gfx;
-                d._label = lbl;
-                d._color = color;
-
-                nc.on('pointerover', function(ev) {
-                    tooltip.innerHTML = '<strong>' + resolve(d.id) + '</strong><br>Files: ' + d.fileCount + '<br>Uses ' + d.eff + ' &middot; Used by ' + d.aff;
-                    tooltip.classList.add('visible');
-                    var gp = ev.global || ev.data.global;
-                    tooltip.style.left = gp.x + 'px';
-                    tooltip.style.top = (gp.y - 12) + 'px';
-
-                    var chain = getChain(d.id, adj);
-                    nodes.forEach(function(n) {
-                        n._sprite.alpha = chain.has(n.id) ? 1 : 0.08;
-                    });
-                    edgesGfx.clear();
-                    links.forEach(function(l) {
-                        var sid = l.source.id || l.source;
-                        var tid = l.target.id || l.target;
-                        var inChain = chain.has(sid) && chain.has(tid);
-                        var sx = l.source.x || 0, sy = l.source.y || 0;
-                        var tx = l.target.x || 0, ty = l.target.y || 0;
-                        edgesGfx.lineStyle(inChain ? 2 : 0.5, inChain ? 0x3b82f6 : 0x94a3b8, inChain ? 0.85 : 0.02);
-                        edgesGfx.moveTo(sx, sy);
-                        edgesGfx.lineTo(tx, ty);
-                    });
-                });
-
-                nc.on('pointermove', function(ev) {
-                    var gp = ev.global || ev.data.global;
-                    tooltip.style.left = gp.x + 'px';
-                    tooltip.style.top = (gp.y - 12) + 'px';
-                });
-
-                nc.on('pointerout', function() {
-                    tooltip.classList.remove('visible');
-                    nodes.forEach(function(n) { n._sprite.alpha = 1; });
-                    drawEdges(links);
-                });
-
-                nc.on('pointertap', function() {
-                    // Drill down into this folder
-                    state.mode = 'files';
-                    state.expandedFolder = d.id;
-                    breadcrumb.classList.remove('hidden');
-                    breadcrumbCurrent.textContent = resolve(d.id);
-                    // Sync radio to files
-                    document.querySelectorAll('input[name="dep-view"]').forEach(function(r) { if (r.value === 'files') r.checked = true; });
-                    renderFileView(d.id);
-                });
-
-                nodesContainer.addChild(nc);
+            links.forEach(function(l) {
+                l._w = Math.min(1 + Math.sqrt(l.count || 1) * 0.6, 4.5);
+                l.inCycle = false;
             });
-
-            // Force simulation
-            activeSimulation = d3.forceSimulation(nodes)
-                .force('link', d3.forceLink(links).id(function(d) { return d.id; }).distance(100))
-                .force('charge', d3.forceManyBody().strength(-300))
-                .force('center', d3.forceCenter(W / 2, H / 2))
-                .force('collision', d3.forceCollide().radius(function(d) { return d._radius + 12; }))
-                .on('tick', function() {
-                    nodes.forEach(function(d) {
-                        d._sprite.x = d.x;
-                        d._sprite.y = d.y;
-                    });
-                    drawEdges(links);
-                })
-                .on('end', function() {
-                    currentNodes = nodes;
-                    currentLinks = links;
-                    fitToView(nodes, W, H);
-                });
+            return { nodes: nodes, links: links };
         }
 
-        // Resize observer for sidebar toggle / window resize
+        // ---- Render ---------------------------------------------------------------
+        function renderGraph(kind, filterFolder) {
+            selectedNode = null;
+            focusState = null;
+            closePanel();
+            tooltip.classList.remove('visible');
+            searchInput.value = '';
+            searchResults.classList.remove('open');
+            shellEl.classList.remove('dep-ready');
+            loadingEl.style.display = 'flex';
+
+            var dim = initPixiApp();
+            currentKind = kind;
+            searchInput.placeholder = kind === 'folders' ? 'Find a folder…' : 'Find a file…';
+
+            var graph = kind === 'folders' ? prepareFolderGraph() : prepareFileGraph(filterFolder);
+            var nodes = graph.nodes, links = graph.links;
+            // Not published as currentNodes/currentLinks yet: sprites do not
+            // exist until the layout is done, and hover/label handlers may
+            // fire in between.
+            currentNodes = null;
+            currentLinks = null;
+
+            if (!nodes.length) {
+                loadingEl.style.display = 'none';
+                shellEl.classList.add('dep-ready');
+                return;
+            }
+
+            markHubs(nodes);
+
+            runLayout(nodes, links, kind, function() {
+                if (!app) return;
+
+                var nodesContainer = new PIXI.Container();
+                worldContainer.addChild(nodesContainer);
+                worldContainer.addChild(ringGfx);
+
+                nodes.forEach(function(d) {
+                    var nc = new PIXI.Container();
+                    nc.eventMode = 'static';
+                    nc.cursor = 'pointer';
+                    nc.x = d.x;
+                    nc.y = d.y;
+
+                    var color = nodeColor(d.eff, d.aff);
+                    var gfx = new PIXI.Graphics();
+                    // A hotspot named in the verdict wears a soft halo
+                    if (hotspotIds.has(d.id) && kind === 'files') {
+                        gfx.lineStyle(2, hexToPixi(color), 0.3);
+                        gfx.drawCircle(0, 0, d._radius + 4.5);
+                        gfx.lineStyle(0);
+                    }
+                    gfx.beginFill(hexToPixi(color), d.inFolder !== false ? 0.88 : 0.35);
+                    gfx.drawCircle(0, 0, d._radius);
+                    gfx.endFill();
+                    gfx.lineStyle(1.5, 0xffffff, 1);
+                    gfx.drawCircle(0, 0, d._radius);
+                    nc.addChild(gfx);
+
+                    nc.hitArea = new PIXI.Circle(0, 0, d._radius + 4);
+                    d._sprite = nc;
+                    d._label = null;
+
+                    nc.on('pointerover', function(ev) {
+                        if (kind === 'folders') {
+                            tooltip.innerHTML = '<strong>' + esc(resolve(d.id)) + '</strong><br>'
+                                + plural(d.fileCount, 'file') + ' &middot; uses ' + d.eff + ' &middot; used by ' + d.aff
+                                + '<br><span class="tip-hint">Click to open the folder</span>';
+                        } else {
+                            tooltip.innerHTML = '<strong>' + esc(resolve(d.id)) + '</strong><br>'
+                                + 'Uses ' + d.eff + ' &middot; used by ' + d.aff
+                                + '<br><span class="tip-hint">Click to inspect</span>';
+                        }
+                        tooltip.classList.add('visible');
+                        moveTooltip(ev);
+                        applyFocus(d);
+                    });
+                    nc.on('pointermove', moveTooltip);
+                    nc.on('pointerout', function() {
+                        tooltip.classList.remove('visible');
+                        clearFocus();
+                    });
+
+                    nc.on('pointertap', function() {
+                        if (kind === 'folders') {
+                            state.mode = 'files';
+                            state.expandedFolder = d.id;
+                            breadcrumb.classList.remove('hidden');
+                            breadcrumbCurrent.textContent = resolve(d.id);
+                            document.querySelectorAll('input[name="dep-view"]').forEach(function(r) {
+                                if (r.value === 'files') r.checked = true;
+                            });
+                            renderGraph('files', d.id);
+                        } else {
+                            selectNode(d);
+                        }
+                    });
+
+                    nodesContainer.addChild(nc);
+                });
+
+                currentNodes = nodes;
+                currentLinks = links;
+                drawEdges();
+                fitToView(false);
+                updateLabels();
+                loadingEl.style.display = 'none';
+                shellEl.classList.add('dep-ready');
+            });
+        }
+
+        // ---- Search -----------------------------------------------------------
+        function searchMatches(q) {
+            if (!currentNodes) return [];
+            q = q.toLowerCase();
+            var out = [];
+            for (var i = 0; i < currentNodes.length && out.length < 8; i++) {
+                var n = currentNodes[i];
+                if (resolve(n.id).toLowerCase().indexOf(q) !== -1) out.push(n);
+            }
+            return out;
+        }
+
+        function pickSearchResult(node) {
+            searchResults.classList.remove('open');
+            searchInput.blur();
+            if (currentKind === 'files') {
+                selectNode(node);
+            } else {
+                applyFocus(node);
+            }
+            focusOnNode(node);
+        }
+
+        searchInput.addEventListener('input', function() {
+            var q = this.value.trim();
+            if (q.length < 2) { searchResults.classList.remove('open'); return; }
+            var matches = searchMatches(q);
+            if (!matches.length) {
+                searchResults.innerHTML = '<div class="dep-search-item"><span class="meta">No match in this view.</span></div>';
+                searchResults.classList.add('open');
+                return;
+            }
+            searchResults.innerHTML = matches.map(function(n, i) {
+                var full = resolve(n.id);
+                return '<div class="dep-search-item' + (i === 0 ? ' active' : '') + '" data-idx="' + i + '">'
+                    + '<div class="name">' + esc(baseName(full)) + '</div>'
+                    + '<div class="meta">' + esc(dirOf(full) || full) + '</div>'
+                    + '</div>';
+            }).join('');
+            searchResults.classList.add('open');
+            var items = searchResults.querySelectorAll('.dep-search-item');
+            items.forEach(function(item, i) {
+                item.addEventListener('mousedown', function(e) {
+                    e.preventDefault();
+                    pickSearchResult(matches[i]);
+                });
+            });
+        });
+        searchInput.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter') {
+                var matches = searchMatches(this.value.trim());
+                if (matches.length) pickSearchResult(matches[0]);
+            }
+        });
+        searchInput.addEventListener('blur', function() {
+            setTimeout(function() { searchResults.classList.remove('open'); }, 150);
+        });
+
+        // ---- HUD buttons --------------------------------------------------------
+        document.getElementById('dep-zoom-in').addEventListener('click', function() { zoomBy(1.4); });
+        document.getElementById('dep-zoom-out').addEventListener('click', function() { zoomBy(1 / 1.4); });
+        document.getElementById('dep-zoom-fit').addEventListener('click', function() { fitToView(true); });
+        document.getElementById('dep-fullscreen').addEventListener('click', function() {
+            if (document.fullscreenElement) {
+                document.exitFullscreen();
+            } else if (shellEl.requestFullscreen) {
+                shellEl.requestFullscreen();
+            }
+        });
+        document.addEventListener('fullscreenchange', function() {
+            setTimeout(function() {
+                if (!app) return;
+                currentW = shellEl.clientWidth;
+                currentH = shellEl.clientHeight;
+                app.renderer.resize(currentW, currentH);
+                fitToView(false);
+            }, 80);
+        });
+
+        // ---- Coupling lists highlight the graph ----------------------------------
+        ['dep-afferent-list', 'dep-efferent-list'].forEach(function(listId) {
+            var el = document.getElementById(listId);
+            if (!el) return;
+            el.addEventListener('mouseover', function(e) {
+                var row = e.target.closest('a[data-dep-node]');
+                if (!row || !currentNodes) return;
+                var id = row.getAttribute('data-dep-node');
+                if (currentKind === 'folders') id = fileToFolder[id];
+                if (!id) return;
+                var node = currentNodes.find(function(n) { return n.id === id; });
+                if (node) applyFocus(node);
+            });
+            el.addEventListener('mouseout', function(e) {
+                if (e.relatedTarget && el.contains(e.relatedTarget)) return;
+                clearFocus();
+            });
+        });
+
+        // ---- Resize ---------------------------------------------------------------
         var depResizeRAF = null;
         var depResizeObserver = new ResizeObserver(function(entries) {
             if (!app || !worldContainer) return;
             var entry = entries[0];
             var newW = entry.contentRect.width;
-            if (newW > 0 && newW !== currentW) {
-                var newH = Math.max(600, parseInt(canvasEl.style.height) || 600);
+            var newH = entry.contentRect.height;
+            if (newW > 0 && (newW !== currentW || newH !== currentH)) {
                 if (depResizeRAF) cancelAnimationFrame(depResizeRAF);
                 depResizeRAF = requestAnimationFrame(function() {
                     depResizeRAF = null;
                     currentW = newW;
                     currentH = newH;
                     app.renderer.resize(newW, newH);
-                    if (currentNodes && currentLinks) {
-                        drawEdges(currentLinks);
-                        fitToView(currentNodes, newW, newH);
-                    }
+                    fitToView(false);
                 });
             }
         });
-        depResizeObserver.observe(wrapperEl);
+        depResizeObserver.observe(shellEl);
 
-        // Radio buttons for view mode
-        var hasFolderData = (folderDeps && folderDeps.folders && Object.keys(folderDeps.folders).length > 0);
+        // ---- View switching ---------------------------------------------------------
         var folderLabel = document.getElementById('dep-view-folder-label');
         if (!hasFolderData && folderLabel) {
             folderLabel.style.display = 'none';
             state.mode = 'files';
         }
 
-        // Check the correct radio based on initial state
         var radios = document.querySelectorAll('input[name="dep-view"]');
         radios.forEach(function(r) {
             if (r.value === state.mode) r.checked = true;
         });
-
-        // Radio change handler
         radios.forEach(function(radio) {
             radio.addEventListener('change', function() {
                 var mode = this.value;
@@ -932,31 +1676,25 @@ document.addEventListener('DOMContentLoaded', function() {
                 breadcrumb.classList.add('hidden');
                 if (mode === 'folders' && hasFolderData) {
                     state.mode = 'folders';
-                    renderFolderView();
+                    renderGraph('folders', null);
                 } else {
                     state.mode = 'files';
-                    renderFileView(null);
+                    renderGraph('files', null);
                 }
             });
         });
 
-        // Breadcrumb back navigation
         breadcrumbRoot.addEventListener('click', function(e) {
             e.preventDefault();
             state.mode = 'folders';
             state.expandedFolder = null;
             breadcrumb.classList.add('hidden');
-            // Sync radio
             radios.forEach(function(r) { if (r.value === 'folders') r.checked = true; });
-            renderFolderView();
+            renderGraph('folders', null);
         });
 
         // Initial render
-        if (state.mode === 'folders') {
-            renderFolderView();
-        } else {
-            renderFileView(null);
-        }
+        renderGraph(state.mode, null);
     });
 });
 </script>

--- a/internal/report/templates/html/dependencies.html
+++ b/internal/report/templates/html/dependencies.html
@@ -800,6 +800,10 @@ document.addEventListener('DOMContentLoaded', function() {
         var ringGfx = null;
         var scale = 1, panX = 0, panY = 0;
         var isPanning = false, panMoved = false, panStartX = 0, panStartY = 0, panStartPX = 0, panStartPY = 0;
+        // Raised when a node consumed the click: the background handler below
+        // sees the canvas as the event target either way, and would otherwise
+        // clear the selection the node just made.
+        var tapOnNode = false;
         var currentNodes = null;
         var currentLinks = null;
         var currentKind = 'files';
@@ -921,6 +925,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (e.target.tagName !== 'CANVAS') return;
             isPanning = true;
             panMoved = false;
+            tapOnNode = false;
             panStartX = e.clientX;
             panStartY = e.clientY;
             panStartPX = panX;
@@ -941,8 +946,11 @@ document.addEventListener('DOMContentLoaded', function() {
             isPanning = false;
             canvasEl.classList.remove('dragging');
             scheduleLabels();
-            // A motionless click on the background clears the selection
-            if (!panMoved && e.target.tagName === 'CANVAS') deselectNode();
+            // A motionless click on the background clears the selection.
+            // PIXI dispatches its taps during the capture phase of this same
+            // pointerup, so tapOnNode is already set when a node was hit.
+            if (!panMoved && !tapOnNode && e.target.tagName === 'CANVAS') deselectNode();
+            tapOnNode = false;
         });
 
         // ---- View animation (zoom buttons, fit, focus on search) --------------
@@ -1513,6 +1521,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     });
 
                     nc.on('pointertap', function() {
+                        tapOnNode = true;
                         if (kind === 'folders') {
                             state.mode = 'files';
                             state.expandedFolder = d.id;


### PR DESCRIPTION
Rebuilds the dependencies page as a packed, explorable graph (search, drill-down by folder, cycle highlighting, side panel) and keeps the node selection alive when clicking a dependency node.