### PR TITLE
docs(readme): point the GitHub Action to the ast-metrics organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ jobs:
   ast-metrics:
     runs-on: ubuntu-latest
     steps:
-        - uses: halleck45/action-ast-metrics@v2
+        - uses: ast-metrics/action-ast-metrics@v2
 ```
 
-On each pull request, the action runs `ast-metrics review` and publishes the result in the check summary and, when permissions allow it, as a single updated comment. On `push` events it runs a full analysis instead. See [action-ast-metrics](https://github.com/Halleck45/action-ast-metrics) for all options (`fail-on`, `sarif`, `html-artifact`...).
+On each pull request, the action runs `ast-metrics review` and publishes the result in the check summary and, when permissions allow it, as a single updated comment. On `push` events it runs a full analysis instead. See [action-ast-metrics](https://github.com/ast-metrics/action-ast-metrics) for all options (`fail-on`, `sarif`, `html-artifact`...).
 
 
 ## MCP Server for AI agents


### PR DESCRIPTION
The GitHub Action repository moved to https://github.com/ast-metrics/action-ast-metrics. This updates the README accordingly:

- `uses: halleck45/action-ast-metrics@v2` becomes `uses: ast-metrics/action-ast-metrics@v2`
- the documentation link now points to the new repository

Note: `uses:` does not follow repository redirects, so existing workflows referencing the old path must be updated to keep working.