### PR TITLE
feat(sarif): cap the level of the results with --sarif-max-level

### DIFF
--- a/cmd/ast-metrics/main.go
+++ b/cmd/ast-metrics/main.go
@@ -178,6 +178,11 @@ func main() {
 						Usage:    "Generate a report in SARIF format (2.1.0)",
 						Category: "Report",
 					},
+					&cliV2.StringFlag{
+						Name:     "sarif-max-level",
+						Usage:    "Cap the level of the SARIF results: error, warning or note. GitHub code scanning fails its own pull request check on new error level alerts, whatever the quality gate decided",
+						Category: "Report",
+					},
 					// Watch mode
 					&cliV2.BoolFlag{
 						Name:     "watch",
@@ -363,6 +368,9 @@ func main() {
 					if cCtx.String("report-sarif") != "" {
 						config.Reports.Sarif = cCtx.String("report-sarif")
 					}
+					if cCtx.String("sarif-max-level") != "" {
+						config.Reports.SarifMaxLevel = cCtx.String("sarif-max-level")
+					}
 					if cCtx.Bool("open-html") {
 						config.Reports.OpenHtml = true
 					}
@@ -509,6 +517,7 @@ func main() {
 					&cliV2.StringSliceFlag{Name: "exclude", Usage: "Regular expression to exclude files from analysis", Category: "File selection"},
 					&cliV2.StringFlag{Name: "config", Usage: "Load configuration from file", Category: "Configuration"},
 					&cliV2.StringFlag{Name: "report-sarif", Usage: "Write lint violations as SARIF 2.1.0 to the given file", Category: "Report"},
+					&cliV2.StringFlag{Name: "sarif-max-level", Usage: "Cap the level of the SARIF results: error, warning or note", Category: "Report"},
 					&cliV2.StringFlag{Name: "php-extensions", Usage: "Extra file extensions for PHP (comma-separated, e.g. .inc,.module)", Category: "File selection"},
 					&cliV2.StringFlag{Name: "go-extensions", Usage: "Extra file extensions for Go (comma-separated)", Category: "File selection"},
 					&cliV2.StringFlag{Name: "python-extensions", Usage: "Extra file extensions for Python (comma-separated)", Category: "File selection"},
@@ -534,6 +543,9 @@ func main() {
 					// report sarif flag
 					if cCtx.String("report-sarif") != "" {
 						cfg.Reports.Sarif = cCtx.String("report-sarif")
+					}
+					if cCtx.String("sarif-max-level") != "" {
+						cfg.Reports.SarifMaxLevel = cCtx.String("sarif-max-level")
 					}
 
 					// paths from args
@@ -690,6 +702,7 @@ func main() {
 					&cliV2.StringFlag{Name: "report-markdown", Usage: "Write the Markdown report to the given file", Category: "Report"},
 					&cliV2.StringFlag{Name: "report-json", Usage: "Write the full JSON report to the given file", Category: "Report"},
 					&cliV2.StringFlag{Name: "report-sarif", Usage: "Write regressions as SARIF 2.1.0 to the given file", Category: "Report"},
+					&cliV2.StringFlag{Name: "sarif-max-level", Usage: "Cap the level of the SARIF results: error, warning or note. GitHub code scanning fails its own pull request check on new error level alerts, whatever --fail-on decided", Category: "Report"},
 					&cliV2.StringSliceFlag{Name: "exclude", Usage: "Regular expression to exclude files from analysis", Category: "File selection"},
 					&cliV2.StringFlag{Name: "config", Usage: "Load configuration from file", Category: "Configuration"},
 					&cliV2.StringFlag{Name: "php-extensions", Usage: "Extra file extensions for PHP (comma-separated, e.g. .inc,.module)", Category: "File selection"},
@@ -745,6 +758,7 @@ func main() {
 					cmd.ReportMarkdown = cCtx.String("report-markdown")
 					cmd.ReportJson = cCtx.String("report-json")
 					cmd.ReportSarif = cCtx.String("report-sarif")
+					cmd.ReportSarifMaxLevel = cCtx.String("sarif-max-level")
 					return cmd.Execute()
 				},
 			},

--- a/internal/command/lint_command.go
+++ b/internal/command/lint_command.go
@@ -111,7 +111,7 @@ func (c *LintCommand) Execute() error {
 
 	// If SARIF path provided, write SARIF report from violations
 	if c.Configuration.Reports.Sarif != "" {
-		_, err := report.GenerateSarifFromOutcomes(c.Configuration.Reports.Sarif, evaluation.Errors)
+		_, err := report.GenerateSarifFromOutcomes(c.Configuration.Reports.Sarif, evaluation.Errors, c.Configuration.Reports.SarifMaxLevel)
 		if err != nil {
 			return err
 		}

--- a/internal/command/review_command.go
+++ b/internal/command/review_command.go
@@ -39,6 +39,9 @@ type ReviewCommand struct {
 	ReportMarkdown string
 	ReportJson     string
 	ReportSarif    string
+	// ReportSarifMaxLevel caps the level of the SARIF results: error, warning or
+	// note. Empty keeps the level derived from the severity of the regression.
+	ReportSarifMaxLevel string
 }
 
 func NewReviewCommand(configuration *configuration.Configuration, out io.Writer, runners []engine.Engine) *ReviewCommand {
@@ -228,7 +231,7 @@ func (c *ReviewCommand) render(result *review.Result) error {
 		}
 	}
 	if c.ReportSarif != "" {
-		if _, err := report.GenerateSarifFromOutcomes(c.ReportSarif, result.ToRuleOutcomes()); err != nil {
+		if _, err := report.GenerateSarifFromOutcomes(c.ReportSarif, result.ToRuleOutcomes(), c.ReportSarifMaxLevel); err != nil {
 			return err
 		}
 	}

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -51,7 +51,10 @@ type ConfigurationReport struct {
 	Json        string `yaml:"json,omitempty"`
 	OpenMetrics string `yaml:"openmetrics,omitempty"`
 	Sarif       string `yaml:"sarif,omitempty"`
-	OpenHtml    bool   `yaml:"open_html,omitempty"`
+	// SarifMaxLevel caps the level of the SARIF results (error, warning or note).
+	// Empty keeps the level derived from the severity of the finding.
+	SarifMaxLevel string `yaml:"sarif_max_level,omitempty"`
+	OpenHtml      bool   `yaml:"open_html,omitempty"`
 }
 
 // function HasReports() bool {

--- a/internal/report/reporters_factory.go
+++ b/internal/report/reporters_factory.go
@@ -24,7 +24,7 @@ func (v *ReportersFactory) Factory(configuration *configuration.Configuration) [
 			reporters = append(reporters, NewOpenMetricsReportGenerator(v.Configuration.Reports.OpenMetrics))
 		}
 		if v.Configuration.Reports.Sarif != "" {
-			reporters = append(reporters, NewSarifReportGenerator(v.Configuration.Reports.Sarif))
+			reporters = append(reporters, NewSarifReportGenerator(v.Configuration.Reports.Sarif, v.Configuration.Reports.SarifMaxLevel))
 		}
 	}
 

--- a/internal/report/sarif_report_generator.go
+++ b/internal/report/sarif_report_generator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/halleck45/ast-metrics/internal/analyzer"
 	requirement "github.com/halleck45/ast-metrics/internal/analyzer/requirement"
@@ -86,10 +87,12 @@ type sarifRegion struct {
 
 type SarifReportGenerator struct {
 	ReportPath string
+	// MaxLevel caps the SARIF level of every result and rule. Empty means no cap.
+	MaxLevel string
 }
 
-func NewSarifReportGenerator(reportPath string) Reporter {
-	return &SarifReportGenerator{ReportPath: reportPath}
+func NewSarifReportGenerator(reportPath string, maxLevel string) Reporter {
+	return &SarifReportGenerator{ReportPath: reportPath, MaxLevel: maxLevel}
 }
 
 func (g *SarifReportGenerator) Generate(files []*pb.File, projectAggregated analyzer.ProjectAggregated) ([]GeneratedReport, error) {
@@ -103,7 +106,7 @@ func (g *SarifReportGenerator) Generate(files []*pb.File, projectAggregated anal
 		outcomes = projectAggregated.Evaluation.Errors
 	}
 
-	if err := writeSarifFile(g.ReportPath, outcomes); err != nil {
+	if err := writeSarifFile(g.ReportPath, outcomes, g.MaxLevel); err != nil {
 		return nil, err
 	}
 
@@ -119,17 +122,21 @@ func (g *SarifReportGenerator) Generate(files []*pb.File, projectAggregated anal
 }
 
 // Export function to build SARIF directly from outcomes (to be used by lint command)
-func GenerateSarifFromOutcomes(reportPath string, outcomes []requirement.RuleOutcome) (GeneratedReport, error) {
+func GenerateSarifFromOutcomes(reportPath string, outcomes []requirement.RuleOutcome, maxLevel string) (GeneratedReport, error) {
 	if reportPath == "" {
 		return GeneratedReport{}, fmt.Errorf("report path is empty")
 	}
-	if err := writeSarifFile(reportPath, outcomes); err != nil {
+	if err := writeSarifFile(reportPath, outcomes, maxLevel); err != nil {
 		return GeneratedReport{}, err
 	}
 	return GeneratedReport{Path: reportPath, Type: "file", Description: "SARIF report of requirement violations", Icon: "📄"}, nil
 }
 
-func writeSarifFile(reportPath string, outcomes []requirement.RuleOutcome) error {
+func writeSarifFile(reportPath string, outcomes []requirement.RuleOutcome, maxLevel string) error {
+	if err := validateSarifLevel(maxLevel); err != nil {
+		return err
+	}
+
 	log := sarifLog{
 		Schema:  "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
 		Version: "2.1.0",
@@ -158,19 +165,19 @@ func writeSarifFile(reportPath string, outcomes []requirement.RuleOutcome) error
 			ID:                   out.Rule,
 			Name:                 out.Rule,
 			ShortDescription:     &sarifMessage{Text: out.Rule},
-			DefaultConfiguration: &sarifRuleConfig{Level: mapSeverity(out.Severity)},
+			DefaultConfiguration: &sarifRuleConfig{Level: capSarifLevel(mapSeverity(out.Severity), maxLevel)},
 			// Quality tags (and no security-severity): GitHub code scanning
 			// then renders the alert with a plain error/warning/note severity
 			// instead of a security severity.
 			Properties: map[string]interface{}{
 				"tags":             []string{"quality", "maintainability"},
-				"problem.severity": mapSeverity(out.Severity),
+				"problem.severity": capSarifLevel(mapSeverity(out.Severity), maxLevel),
 			},
 		})
 	}
 
 	for _, out := range outcomes {
-		level := mapSeverity(out.Severity)
+		level := capSarifLevel(mapSeverity(out.Severity), maxLevel)
 		res := sarifResult{
 			RuleID:  out.Rule,
 			Level:   level,
@@ -226,6 +233,42 @@ func writeSarifFile(reportPath string, outcomes []requirement.RuleOutcome) error
 func fingerprint(rule, file string, line int) string {
 	h := sha256.Sum256([]byte(rule + "\x00" + file + "\x00" + strconv.Itoa(line)))
 	return hex.EncodeToString(h[:])
+}
+
+// sarifLevelRank orders the SARIF levels ast-metrics emits, from the quietest
+// to the loudest.
+var sarifLevelRank = map[string]int{"note": 1, "warning": 2, "error": 3}
+
+// SarifLevels lists the accepted values for the SARIF level ceiling.
+var SarifLevels = []string{"error", "warning", "note"}
+
+func validateSarifLevel(maxLevel string) error {
+	if maxLevel == "" {
+		return nil
+	}
+	if _, ok := sarifLevelRank[maxLevel]; !ok {
+		return fmt.Errorf("invalid SARIF level %q: expected one of %s", maxLevel, strings.Join(SarifLevels, ", "))
+	}
+	return nil
+}
+
+// capSarifLevel lowers a level to the given ceiling, leaving it untouched when
+// no ceiling is set. GitHub code scanning fails its own pull request check as
+// soon as a new error level alert appears in the diff, whatever the quality gate
+// decided; capping the level keeps code scanning purely informative without
+// downgrading the severity of the finding itself.
+func capSarifLevel(level string, maxLevel string) string {
+	if maxLevel == "" {
+		return level
+	}
+	ceiling, ok := sarifLevelRank[maxLevel]
+	if !ok {
+		return level
+	}
+	if sarifLevelRank[level] > ceiling {
+		return maxLevel
+	}
+	return level
 }
 
 func mapSeverity(sev requirement.Severity) string {

--- a/internal/report/sarif_report_generator_test.go
+++ b/internal/report/sarif_report_generator_test.go
@@ -84,9 +84,54 @@ func TestGenerateSarifFromOutcomes_Helper(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "lint.sarif.json")
 	out := []requirement.RuleOutcome{{Rule: "foo", Severity: requirement.SeverityLow, Message: "Something", File: "a.go"}}
-	report, err := GenerateSarifFromOutcomes(path, out)
+	report, err := GenerateSarifFromOutcomes(path, out, "")
 	assert.NoError(t, err)
 	assert.Equal(t, path, report.Path)
 	_, statErr := os.Stat(path)
 	assert.NoError(t, statErr)
+}
+
+func TestSarifGenerator_MaxLevelCapsTheLevel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.sarif.json")
+	gen := &SarifReportGenerator{ReportPath: path, MaxLevel: "warning"}
+
+	pa := analyzer.ProjectAggregated{
+		Evaluation: &requirement.EvaluationResult{
+			Errors: []requirement.RuleOutcome{
+				{Rule: "max_cyclomatic", Severity: requirement.SeverityHigh, Message: "Cyclomatic complexity too high", File: "/tmp/file.go", Line: 42},
+				{Rule: "max_loc", Severity: requirement.SeverityLow, Message: "Too many Lines of code", File: "/tmp/file.go", Line: 1},
+			},
+		},
+	}
+
+	_, err := gen.Generate(nil, pa)
+	assert.NoError(t, err)
+	b, readErr := os.ReadFile(path)
+	assert.NoError(t, readErr)
+	content := string(b)
+	// The high severity finding is lowered to the ceiling, so GitHub code
+	// scanning stops failing its own pull request check.
+	assert.NotContains(t, content, "\"level\": \"error\"")
+	assert.Contains(t, content, "\"level\": \"warning\"")
+	// A level already below the ceiling is left untouched.
+	assert.Contains(t, content, "\"level\": \"note\"")
+}
+
+func TestSarifGenerator_MaxLevelRejectsUnknownValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.sarif.json")
+	out := []requirement.RuleOutcome{{Rule: "foo", Severity: requirement.SeverityHigh, Message: "Something", File: "a.go"}}
+
+	_, err := GenerateSarifFromOutcomes(path, out, "critical")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid SARIF level")
+}
+
+func TestCapSarifLevel(t *testing.T) {
+	assert.Equal(t, "error", capSarifLevel("error", ""))
+	assert.Equal(t, "warning", capSarifLevel("error", "warning"))
+	assert.Equal(t, "note", capSarifLevel("error", "note"))
+	assert.Equal(t, "note", capSarifLevel("note", "warning"))
+	assert.Equal(t, "error", capSarifLevel("error", "unknown"))
 }


### PR DESCRIPTION
GitHub code scanning publishes a check of its own on a pull request, and fails it as soon as a new `error` level alert appears in the diff, whatever the quality gate decided. Uploading a SARIF report therefore turned an informative `review --fail-on never` into a blocking gate, with no way to opt out: `SeverityHigh` maps to `level: "error"`.

Observed on a test pull request: the `review` job exits 0 and reports "quality gate passed", while the Advanced Security check next to it fails with "1 new alert including 1 error".