### PR TITLE
fix(release): inject the version at build time and polish distribution

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -180,7 +180,7 @@ jobs:
             end
 
             test do
-              system "#{bin}/ast-metrics", "--version"
+              system "#{bin}/ast-metrics", "version"
             end
           end
           EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
               env: ["CGO_ENABLED=1"]
               goos: [${{ matrix.goos }}]
               goarch: [${{ matrix.goarch }}]
-              ldflags: ["-s", "-w"]
+              ldflags: ["-s", "-w", "-X main.version={{ .Version }}", "-X main.commit={{ .Commit }}", "-X main.date={{ .Date }}"]
               mod_timestamp: "{{ .CommitTimestamp }}"
           archives:
             - id: bin

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -7,6 +7,10 @@ FROM debian:stable-slim
 ARG TARGETARCH
 ARG VERSION
 
+LABEL org.opencontainers.image.source="https://github.com/ast-metrics/ast-metrics" \
+      org.opencontainers.image.description="Multi-language static code analyzer: complexity, coupling and maintainability metrics" \
+      org.opencontainers.image.licenses="MIT"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Follow-ups discovered while validating the new distribution channels on v0.40.0.

- **Version injection**: released binaries currently report `dev` in `ast-metrics version` (verified on the v0.40.0 .deb). The code expects goreleaser's standard `-X main.version` injection, but the custom `ldflags: ["-s", "-w"]` in `release.yml` replaced the goreleaser defaults and disabled it. The flags are now passed explicitly (version, commit, date).
- **Homebrew formula test**: the CLI exposes a `version` subcommand, not a `--version` flag, so `brew test` would have failed. The generated formula now calls the subcommand.
- **OCI labels** on `Dockerfile.release` (`org.opencontainers.image.source`, description, licenses) so ghcr links the package to this repository and shows a description.
